### PR TITLE
feat: added random-derives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1240,6 +1240,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "random-derives"
+version = "0.1.0-pre2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1882,6 +1891,7 @@ version = "0.1.0-pre2"
 dependencies = [
  "rand",
  "rand_chacha",
+ "random-derives",
  "thiserror",
  "vitaminc-protected",
  "zeroize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,18 @@
 [workspace]
 resolver = "2"
 members = [
+    "packages/aead",
     "packages/async-traits",
+    "packages/encrypt",
     "packages/kms",
     "packages/protected",
+    "packages/protected-derive",
     "packages/password",
     "packages/permutation",
     "packages/random",
+    "packages/random-derives",
     "packages/traits",
     "packages/vitaminc",
-    "packages/encrypt", "packages/aead", "packages/protected-derive",
 ]
 
 [workspace.package]

--- a/packages/random-derives/Cargo.toml
+++ b/packages/random-derives/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "random-derives"
+documentation.workspace = true
+version.workspace = true
+repository.workspace = true
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "2", features = ["full"] }
+quote = "1"
+proc-macro2 = "1"

--- a/packages/random-derives/src/lib.rs
+++ b/packages/random-derives/src/lib.rs
@@ -1,0 +1,68 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, Data, DeriveInput, Fields};
+
+#[proc_macro_derive(Generatable)]
+pub fn derive_generatable(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = input.ident;
+
+    let result_expr = match &input.data {
+        Data::Struct(data_struct) => match &data_struct.fields {
+            Fields::Named(fields_named) => {
+                let field_inits = fields_named.named.iter().map(|f| {
+                    let field_name = f.ident.as_ref().unwrap();
+                    quote! {
+                        #field_name: Generatable::random(rng)?
+                    }
+                });
+                quote! {
+                    Ok(Self {
+                        #(#field_inits),*
+                    })
+                }
+            }
+            Fields::Unnamed(fields_unnamed) => {
+                let field_inits = fields_unnamed.unnamed.iter().map(|_| {
+                    quote! {
+                        Generatable::random(rng)?
+                    }
+                });
+                quote! {
+                    Ok(Self(
+                        #(#field_inits),*
+                    ))
+                }
+            }
+            Fields::Unit => {
+                quote! { Ok(Self) }
+            }
+        },
+        Data::Enum(_) => {
+            return syn::Error::new_spanned(
+                name,
+                "#[derive(Generatable)] is not supported for enums — implement Generatable manually for cryptographic safety."
+            )
+            .to_compile_error()
+            .into();
+        }
+        Data::Union(_) => {
+            return syn::Error::new_spanned(
+                name,
+                "#[derive(Generatable)] cannot be used on unions.",
+            )
+            .to_compile_error()
+            .into();
+        }
+    };
+
+    let expanded = quote! {
+        impl Generatable for #name {
+            fn random(rng: &mut vitaminc_random::SafeRand) -> Result<Self, vitaminc_random::RandomError> {
+                #result_expr
+            }
+        };
+    };
+
+    TokenStream::from(expanded)
+}

--- a/packages/random/Cargo.toml
+++ b/packages/random/Cargo.toml
@@ -19,4 +19,5 @@ rand = { workspace = true }
 thiserror = { workspace = true }
 zeroize = { workspace = true }
 
+random-derives = { path = "../random-derives" }
 vitaminc-protected = { version = "0.1.0-pre", path = "../protected" }

--- a/packages/random/README.md
+++ b/packages/random/README.md
@@ -7,6 +7,34 @@ A carefully designed random number generator that is safe to use for cryptograph
 
 This crate is part of the [Vitamin C](https://github.com/cipherstash/vitaminc) framework to make cryptography code healthy.
 
+## Generatable
+
+Types implementing the [`Generatable`] trait can be generated randomly using [`SafeRand`].
+
+```rust
+use vitaminc_random::{Generatable, SafeRand, SeedableRng};
+
+let mut rng = SafeRand::from_entropy();
+let x: [u8; 32] = Generatable::random(&mut rng).unwrap();
+```
+
+You can implement `Generatable` for your own types using the derive macro:
+
+```rust
+use vitaminc_random::{Generatable, SafeRand, SeedableRng};
+
+#[derive(Generatable)]
+struct MyStruct {
+    id: u32,
+    key: [u8; 16],
+}
+
+// Create a random number generator and generate an instance of MyStruct.
+let mut rng = vitaminc_random::SafeRand::from_entropy();
+let instance: MyStruct = Generatable::random(&mut rng).unwrap();
+println!("Generated id: {}", instance.id);
+```
+
 ## Bounded Random Numbers
 
 The `BoundedRng` trait provides a way to generate random numbers within a specific range.

--- a/packages/random/src/generatable.rs
+++ b/packages/random/src/generatable.rs
@@ -107,11 +107,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use zeroize::Zeroize;
-
-    use crate::{SafeRand, SeedableRng};
-
     use super::Generatable;
+    use crate::{SafeRand, SeedableRng};
+    use zeroize::Zeroize;
 
     fn assert_generatable<T>(rng: &mut SafeRand) -> T
     where

--- a/packages/random/src/lib.rs
+++ b/packages/random/src/lib.rs
@@ -5,11 +5,15 @@ mod generatable;
 mod safe_rand;
 
 pub use bounded::BoundedRng;
+#[doc(inline)]
 pub use generatable::Generatable;
 pub use safe_rand::SafeRand;
 
 // Re-exports
 pub use rand::{Fill, RngCore, SeedableRng};
+
+/// Derive macro for `Generatable`
+pub use random_derives::Generatable;
 
 #[derive(Error, Debug)]
 pub enum RandomError {


### PR DESCRIPTION
Adds a derive macro for the `Generatable` trait in the random crate.

```rust
#[derive(Generatable)]
struct MyStruct {
    id: u32,
    key: [u8; 16],
}

let mut rng = SafeRand::from_entropy();
let x: MyStruct = Generatable::random(&mut rng).unwrap();
```