### PR TITLE
feat: add protected-derive crate and opaque Debug implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1164,6 +1164,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "protected-derive"
+version = "0.1.0-pre2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "quickcheck"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1855,6 +1864,7 @@ dependencies = [
  "bitvec",
  "digest",
  "opaque-debug",
+ "protected-derive",
  "quickcheck",
  "serde",
  "serde_bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
     "packages/random",
     "packages/traits",
     "packages/vitaminc",
-    "packages/encrypt", "packages/aead",
+    "packages/encrypt", "packages/aead", "packages/protected-derive",
 ]
 
 [workspace.package]

--- a/packages/protected-derive/Cargo.toml
+++ b/packages/protected-derive/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "protected-derive"
+documentation.workspace = true
+version.workspace = true
+repository.workspace = true
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["full", "extra-traits"] }

--- a/packages/protected-derive/src/lib.rs
+++ b/packages/protected-derive/src/lib.rs
@@ -1,0 +1,201 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, Data, DataEnum, DataStruct, DeriveInput, Fields};
+
+#[proc_macro_derive(OpaqueDebug, attributes(opaque_debug))]
+pub fn derive_opaque_debug(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    let ident = input.ident.clone();
+    let generics = input.generics.clone();
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    // Only config is the mask string (default "***")
+    let mask = parse_mask_attr(&input);
+
+    let marker_impl = quote! {
+        impl #impl_generics ::vitaminc_protected::debug::OpaqueDebug for #ident #ty_generics #where_clause {}
+    };
+
+    let dbg_impl = match &input.data {
+        Data::Struct(ds) => debug_impl_for_struct(
+            &ident,
+            ds,
+            &impl_generics,
+            &ty_generics,
+            where_clause,
+            &mask,
+        ),
+        Data::Enum(de) => debug_impl_for_enum(
+            &ident,
+            de,
+            &impl_generics,
+            &ty_generics,
+            where_clause,
+            &mask,
+        ),
+        Data::Union(_) => {
+            // For unions: just print the type name
+            quote! {
+                impl #impl_generics ::core::fmt::Debug for #ident #ty_generics #where_clause {
+                    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                        let tn = ::core::any::type_name::<#ident #ty_generics>();
+                        f.write_str(tn)
+                    }
+                }
+            }
+        }
+    };
+
+    quote!(#marker_impl #dbg_impl).into()
+}
+
+/// Parse `#[opaque_debug(mask = "...")]` using syn v2 `parse_nested_meta`.
+fn parse_mask_attr(input: &DeriveInput) -> String {
+    let mut mask = "***".to_string();
+
+    for attr in &input.attrs {
+        if !attr.path().is_ident("opaque_debug") {
+            continue;
+        }
+        // Accept: #[opaque_debug(mask = "...")]
+        let _ = attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("mask") {
+                let lit: syn::LitStr = meta.value()?.parse()?;
+                mask = lit.value();
+                return Ok(());
+            }
+            // Unknown keys produce a nice error tied to the attribute span
+            Err(meta.error("unsupported attribute; expected `mask = \"...\"`"))
+        });
+    }
+
+    mask
+}
+
+fn debug_impl_for_struct(
+    ident: &syn::Ident,
+    ds: &DataStruct,
+    impl_generics: &impl quote::ToTokens,
+    ty_generics: &impl quote::ToTokens,
+    where_clause: Option<&syn::WhereClause>,
+    mask: &str,
+) -> proc_macro2::TokenStream {
+    match &ds.fields {
+        Fields::Named(named) => {
+            // Type { a: ***, b: *** }
+            let mut parts = Vec::new();
+            for (i, f) in named.named.iter().enumerate() {
+                let name = f.ident.as_ref().unwrap();
+                let comma = if i == 0 { "" } else { ", " };
+                parts.push(format!("{}{}: {}", comma, name, mask));
+            }
+            let fmt_body = format!("{{ {} }}", parts.concat());
+
+            quote! {
+                impl #impl_generics ::core::fmt::Debug for #ident #ty_generics #where_clause {
+                    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                        let tn = ::core::any::type_name::<#ident #ty_generics>();
+                        write!(f, "{} {}", tn, #fmt_body)
+                    }
+                }
+            }
+        }
+        Fields::Unnamed(unnamed) => {
+            // Type(***, ***, ...)
+            let mut parts = Vec::new();
+            for i in 0..unnamed.unnamed.len() {
+                let comma = if i == 0 { "" } else { ", " };
+                parts.push(format!("{}{}", comma, mask));
+            }
+            let fmt_body = format!("({})", parts.concat());
+
+            quote! {
+                impl #impl_generics ::core::fmt::Debug for #ident #ty_generics #where_clause {
+                    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                        let tn = ::core::any::type_name::<#ident #ty_generics>();
+                        write!(f, "{} {}", tn, #fmt_body)
+                    }
+                }
+            }
+        }
+        Fields::Unit => {
+            // Type
+            quote! {
+                impl #impl_generics ::core::fmt::Debug for #ident #ty_generics #where_clause {
+                    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                        let tn = ::core::any::type_name::<#ident #ty_generics>();
+                        f.write_str(tn)
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn debug_impl_for_enum(
+    ident: &syn::Ident,
+    de: &DataEnum,
+    impl_generics: &impl quote::ToTokens,
+    ty_generics: &impl quote::ToTokens,
+    where_clause: Option<&syn::WhereClause>,
+    mask: &str,
+) -> proc_macro2::TokenStream {
+    let mut arms = Vec::new();
+
+    for v in &de.variants {
+        let v_ident = &v.ident;
+        match &v.fields {
+            Fields::Named(named) => {
+                // Type::Variant { a: ***, b: *** }
+                let mut parts = Vec::new();
+                for (i, f) in named.named.iter().enumerate() {
+                    let fname = f.ident.as_ref().unwrap();
+                    let comma = if i == 0 { "" } else { ", " };
+                    parts.push(format!("{}{}: {}", comma, fname, mask));
+                }
+                let body = format!("{{ {} }}", parts.concat());
+                arms.push(quote! {
+                    Self::#v_ident { .. } => {
+                        let tn = ::core::any::type_name::<#ident #ty_generics>();
+                        write!(f, "{}::{} {}", tn, stringify!(#v_ident), #body)
+                    }
+                });
+            }
+            Fields::Unnamed(unnamed) => {
+                // Type::Variant(***, ***)
+                let mut parts = Vec::new();
+                for i in 0..unnamed.unnamed.len() {
+                    let comma = if i == 0 { "" } else { ", " };
+                    parts.push(format!("{}{}", comma, mask));
+                }
+                let body = format!("({})", parts.concat());
+                arms.push(quote! {
+                    Self::#v_ident(..) => {
+                        let tn = ::core::any::type_name::<#ident #ty_generics>();
+                        write!(f, "{}::{} {}", tn, stringify!(#v_ident), #body)
+                    }
+                });
+            }
+            Fields::Unit => {
+                // Type::Variant
+                arms.push(quote! {
+                    Self::#v_ident => {
+                        let tn = ::core::any::type_name::<#ident #ty_generics>();
+                        write!(f, "{}::{}", tn, stringify!(#v_ident))
+                    }
+                });
+            }
+        }
+    }
+
+    quote! {
+        impl #impl_generics ::core::fmt::Debug for #ident #ty_generics #where_clause {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                match self {
+                    #(#arms),*
+                }
+            }
+        }
+    }
+}

--- a/packages/protected/Cargo.toml
+++ b/packages/protected/Cargo.toml
@@ -23,6 +23,7 @@ opaque-debug = "0.3.1"
 subtle = "2.6.1"
 
 quickcheck = { version = "1.0.3", optional = true }
+protected-derive = { path = "../protected-derive" }
 
 [dev-dependencies]
 bincode = "1.3.3"

--- a/packages/protected/src/debug/mod.rs
+++ b/packages/protected/src/debug/mod.rs
@@ -1,0 +1,144 @@
+//! Opaque `Debug` for secret-bearing types.
+//!
+//! This module provides the [`OpaqueDebug`] marker trait and a `#[derive(OpaqueDebug)]`
+//! macro that **also** implements [`core::fmt::Debug`] for your type in a way that
+//! **never** reveals internal data.
+//!
+//! By default, the generated `Debug` implementation prints a placeholder that includes
+//! the type’s fully-qualified name via [`core::any::type_name`]:
+//!
+//! ```text
+//! Secret<your_crate::module::Type>
+//! ```
+//!
+//! You can override this placeholder with an attribute on the type.
+//!
+//! ## Why use this?
+//!
+//! - Prevents accidental leakage of secrets (keys, tokens, passwords) via `Debug`
+//!   in logs or error messages.
+//! - Keeps a meaningful breadcrumb (the type name) for diagnostics without exposing data.
+//! - Plays nicely with other wrappers (e.g., a [`crate::Protected<T>`] that zeroizes on drop).
+//!
+//! ## What it generates
+//!
+//! `#[derive(OpaqueDebug)]` generates:
+//!
+//! 1. An impl of the marker trait:
+//!    ```ignore
+//!    impl OpaqueDebug for YourType {}
+//!    ```
+//! 2. An impl of `core::fmt::Debug` that **never** formats internal fields.
+//!
+//! ## Usage
+//!
+//! ### Basic: default placeholder uses the fully-qualified type name
+//!
+//! ```rust
+//! use vitaminc_protected::OpaqueDebug;
+//!
+//! #[derive(OpaqueDebug)]
+//! struct ApiToken([u8; 32]);
+//!
+//! let t = ApiToken([0; 32]);
+//! let out = format!("{t:?}");
+//! assert!(out.contains("ApiToken (***)"));
+//! ```
+//!
+//! ### Works with generics
+//!
+//! The `Debug` impl includes the instantiated type parameters in the placeholder.
+//!
+//! ```rust
+//! use vitaminc_protected::OpaqueDebug;
+//!
+//! #[derive(OpaqueDebug)]
+//! struct Key<const N: usize>([u8; N]);
+//!
+//! let env = Key::<32>([0u8; 32]);
+//! let out = format!("{env:?}");
+//! assert!(out.contains("Key<32> (***)"));
+//! ```
+//!
+//! ### Enums and unit-like types are supported
+//!
+//! The internal representation is still hidden.
+//!
+//! ```rust
+//! use vitaminc_protected::OpaqueDebug;
+//!
+//! #[derive(OpaqueDebug)]
+//! enum SecretThing {
+//!     A(u32),
+//!     B { x: u8, y: u8 },
+//!     C,
+//! }
+//!
+//! let s = SecretThing::B { x: 7, y: 9 };
+//! let out = format!("{s:?}");
+//! assert!(out.contains("SecretThing::B { x: ***, y: *** }"));
+//! ```
+//!
+//! ### Using with Redacted wrapper (optional)
+//!
+//! This is useful to manage external types.
+//!
+//! ```rust
+//! use core::fmt;
+//! use vitaminc_protected::{OpaqueDebug, Redacted};
+//!
+//! let safe = Redacted::new([0u8; 32]);
+//! assert_eq!(format!("{:?}", safe), "Redacted<[u8; 32] ***>");
+//! ```
+//!
+//! ## Notes
+//!
+//! - The derive intentionally **replaces** any `Debug` you might otherwise derive or write.
+//! - The default placeholder is computed with `core::any::type_name::<T>()` at runtime.
+//! - The marker trait has no methods; it exists to make trait bounds and wrapper impls
+//!   straightforward (e.g., a wrapper can `impl<T: OpaqueDebug> Debug for Redacted<T>`).
+//!
+//! ### Feature compatibility
+//!
+//! This module works in `no_std` environments; it only depends on `core`.
+//!
+//! ---
+//!
+//! Happy redacting 👋
+
+pub use protected_derive::OpaqueDebug;
+
+/// Marker trait implemented by `#[derive(OpaqueDebug)]`.
+/// See [the module level documentation](self) for more.
+pub trait OpaqueDebug {}
+
+/// Wrapper type for redacting debug output.
+/// See [the module level documentation](self) for more.
+#[repr(transparent)]
+pub struct Redacted<T>(T);
+
+impl<T> Redacted<T> {
+    /// Create a new `Redacted` instance.
+    pub const fn new(value: T) -> Self {
+        Self(value)
+    }
+}
+
+impl<T> core::fmt::Debug for Redacted<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "Redacted<{} ***>", std::any::type_name::<T>())
+    }
+}
+
+impl<T> OpaqueDebug for Redacted<T> {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_redacted_debug() {
+        let redacted = Redacted(42);
+        assert_eq!(format!("{:?}", redacted), "Redacted<i32 ***>");
+    }
+}

--- a/packages/protected/src/lib.rs
+++ b/packages/protected/src/lib.rs
@@ -5,6 +5,7 @@ mod conversions;
 mod digest;
 mod equatable;
 mod exportable;
+pub mod debug;
 mod ops;
 mod protected;
 mod usage;

--- a/packages/protected/src/lib.rs
+++ b/packages/protected/src/lib.rs
@@ -2,10 +2,10 @@
 mod as_protected_ref;
 mod controlled;
 mod conversions;
+pub mod debug;
 mod digest;
 mod equatable;
 mod exportable;
-pub mod debug;
 mod ops;
 mod protected;
 mod usage;

--- a/packages/protected/tests/opaque_debug_runtime.rs
+++ b/packages/protected/tests/opaque_debug_runtime.rs
@@ -1,0 +1,110 @@
+#![allow(dead_code)]
+use vitaminc_protected::debug::OpaqueDebug;
+
+#[test]
+fn no_plaintext_leak_in_debug() {
+    #[derive(OpaqueDebug)]
+    struct S {
+        secret: String,
+    }
+
+    let s = S {
+        secret: "do-not-leak".into(),
+    };
+    let out = format!("{:?}", s);
+    assert!(!out.contains("do-not-leak"));
+    assert!(out.contains("***"));
+}
+
+#[test]
+fn struct_named_fields_are_masked() {
+    #[derive(OpaqueDebug)]
+    struct Credentials {
+        user: String,
+        pass: String,
+    }
+
+    let c = Credentials {
+        user: "u".into(),
+        pass: "p".into(),
+    };
+    let out = format!("{:?}", c);
+    let tn = core::any::type_name::<Credentials>();
+
+    assert!(
+        out == format!("{tn} {{ user: ***, pass: *** }}")
+            || out == format!("{tn} {{ pass: ***, user: *** }}"),
+        "got: {out}"
+    );
+}
+
+#[test]
+fn struct_tuple_fields_are_masked() {
+    #[derive(OpaqueDebug)]
+    struct Blob(u8, u16, u32);
+
+    let out = format!("{:?}", Blob(1, 2, 3));
+    let tn = core::any::type_name::<Blob>();
+    assert_eq!(out, format!("{tn} (***, ***, ***)"));
+}
+
+#[test]
+fn struct_unit_prints_type_name_only() {
+    #[derive(OpaqueDebug)]
+    struct Marker;
+
+    let out = format!("{:?}", Marker);
+    assert_eq!(out, core::any::type_name::<Marker>());
+}
+
+#[test]
+fn enum_variants_masked() {
+    #[derive(OpaqueDebug)]
+    enum SecretThing {
+        A(u32),
+        B { x: u8, y: u8 },
+        C,
+    }
+
+    let tn = core::any::type_name::<SecretThing>();
+
+    let a = SecretThing::A(42);
+    assert_eq!(format!("{:?}", a), format!("{tn}::A (***)"));
+
+    let b = SecretThing::B { x: 7, y: 9 };
+    assert!(
+        format!("{:?}", b) == format!("{tn}::B {{ x: ***, y: *** }}")
+            || format!("{:?}", b) == format!("{tn}::B {{ y: ***, x: *** }}")
+    );
+
+    let c = SecretThing::C;
+    assert_eq!(format!("{:?}", c), format!("{tn}::C"));
+}
+
+#[test]
+fn generics_and_const_generics_show_in_type_name() {
+    #[derive(OpaqueDebug)]
+    struct Wrapper<T>(T);
+
+    #[derive(OpaqueDebug)]
+    struct Key<const N: usize>([u8; N]);
+
+    let w = Wrapper(Key::<32>([0u8; 32]));
+    let out = format!("{:?}", w);
+
+    assert!(out.starts_with("")); // cheap guard
+    assert!(out.contains("Wrapper"));
+    assert!(out.contains("Key"));
+    assert!(out.contains("32"));
+}
+
+#[test]
+fn custom_mask_attribute_is_used() {
+    #[derive(OpaqueDebug)]
+    #[opaque_debug(mask = "██")]
+    struct Token(String);
+
+    let out = format!("{:?}", Token("x".into()));
+    let tn = core::any::type_name::<Token>();
+    assert_eq!(out, format!("{tn} (██)"));
+}


### PR DESCRIPTION
Adds `debug` module to `protected` for opaque debugging of types.
Adds a trait, derive macro and convenience wrapper type.

```rust
#[derive(OpaqueDebug)]
struct Foo([u8; 32]);
let x = Foo([0; 32]);

assert_eq!(format("{x:?}"), "Foo (***)");
```