### PR TITLE
fix: remove unnecessary readme.workspace entry from Cargo.toml

### DIFF
--- a/packages/password/Cargo.toml
+++ b/packages/password/Cargo.toml
@@ -7,7 +7,6 @@ edition.workspace = true
 repository.workspace = true
 homepage.workspace = true
 license.workspace = true
-readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
 


### PR DESCRIPTION
This was breaking dependabot.