### PR TITLE
fix: downgraded aws-lc-rs to 1.12.6 to maintain rustls compatibility

### DIFF
--- a/packages/encrypt/Cargo.toml
+++ b/packages/encrypt/Cargo.toml
@@ -11,7 +11,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-aws-lc-rs = "1.13.3"
+aws-lc-rs = "1.12.6"
 vitaminc-aead = { path = "../aead" }
 vitaminc-protected = { path = "../protected" }
 vitaminc-random = { path = "../random" }


### PR DESCRIPTION
The current stable Rustls pins aws-lc-rs to v1.12.