### PR TITLE
chore: minor fixups

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,11 +30,11 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: setup rust 1.88
-        uses: dtolnay/rust-toolchain@1.88
+      - name: setup rust stable
+        uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
-      
+
       - name: Start LocalStack
         uses: LocalStack/setup-localstack@v0.2.4
         with:

--- a/packages/aead/src/encrypt.rs
+++ b/packages/aead/src/encrypt.rs
@@ -97,6 +97,8 @@ where
     }
 }
 
+// FIXME: check with @coderdan if this should be converted to a static assertion that it simply *compiles*
+#[allow(dead_code)]
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
- use evergreen stable version of Rust in the github workflow
- add #[allow(dead_code)] annotation