### PR TITLE
Normalize vitaminc re-exports to module aliases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2016,6 +2016,7 @@ name = "vitaminc"
 version = "0.1.0-pre4.1"
 dependencies = [
  "vitaminc",
+ "vitaminc-aead",
  "vitaminc-async-traits",
  "vitaminc-encrypt",
  "vitaminc-kms",

--- a/packages/aead/src/context.rs
+++ b/packages/aead/src/context.rs
@@ -47,8 +47,9 @@ use crate::{Cipher, Decrypt, Encrypt, IntoAad, Unspecified};
 /// Encrypt a value with a context tag, then decrypt by providing the same AAD:
 ///
 /// ```
-/// use vitaminc_aead::{ContextTag, Encrypt, Decrypt};
-/// use vitaminc_aead::test_utils::TestCipher;
+/// # mod vitaminc { pub mod aead { pub use vitaminc_aead::*; } }
+/// use vitaminc::aead::{ContextTag, Encrypt, Decrypt};
+/// use vitaminc::aead::test_utils::TestCipher;
 ///
 /// let cipher = TestCipher;
 ///
@@ -67,8 +68,9 @@ use crate::{Cipher, Decrypt, Encrypt, IntoAad, Unspecified};
 /// to the tag. Both must be provided for decryption to succeed:
 ///
 /// ```
-/// use vitaminc_aead::{ContextTag, Encrypt, Decrypt};
-/// use vitaminc_aead::test_utils::TestCipher;
+/// # mod vitaminc { pub mod aead { pub use vitaminc_aead::*; } }
+/// use vitaminc::aead::{ContextTag, Encrypt, Decrypt};
+/// use vitaminc::aead::test_utils::TestCipher;
 ///
 /// let cipher = TestCipher;
 ///
@@ -93,8 +95,9 @@ use crate::{Cipher, Decrypt, Encrypt, IntoAad, Unspecified};
 /// If the AAD does not match what was used during encryption, decryption fails:
 ///
 /// ```
-/// use vitaminc_aead::{ContextTag, Encrypt, Decrypt};
-/// use vitaminc_aead::test_utils::TestCipher;
+/// # mod vitaminc { pub mod aead { pub use vitaminc_aead::*; } }
+/// use vitaminc::aead::{ContextTag, Encrypt, Decrypt};
+/// use vitaminc::aead::test_utils::TestCipher;
 ///
 /// let cipher = TestCipher;
 ///
@@ -112,8 +115,9 @@ use crate::{Cipher, Decrypt, Encrypt, IntoAad, Unspecified};
 /// can accept borrowed tags like `&str` without requiring higher-ranked trait bounds:
 ///
 /// ```
-/// use vitaminc_aead::{ContextTag, Encrypt};
-/// use vitaminc_aead::test_utils::TestCipher;
+/// # mod vitaminc { pub mod aead { pub use vitaminc_aead::*; } }
+/// use vitaminc::aead::{ContextTag, Encrypt};
+/// use vitaminc::aead::test_utils::TestCipher;
 ///
 /// let cipher = TestCipher;
 ///
@@ -135,8 +139,9 @@ impl<Tag, T> ContextTag<Tag, T> {
     /// # Example
     ///
     /// ```
-    /// use vitaminc_aead::{ContextTag, Encrypt};
-    /// use vitaminc_aead::test_utils::TestCipher;
+    /// # mod vitaminc { pub mod aead { pub use vitaminc_aead::*; } }
+    /// use vitaminc::aead::{ContextTag, Encrypt};
+    /// use vitaminc::aead::test_utils::TestCipher;
     ///
     /// let cipher = TestCipher;
     ///
@@ -159,8 +164,9 @@ impl<Tag, T> ContextTag<Tag, T> {
     /// # Example
     ///
     /// ```
-    /// use vitaminc_aead::{ContextTag, Encrypt, Decrypt};
-    /// use vitaminc_aead::test_utils::TestCipher;
+    /// # mod vitaminc { pub mod aead { pub use vitaminc_aead::*; } }
+    /// use vitaminc::aead::{ContextTag, Encrypt, Decrypt};
+    /// use vitaminc::aead::test_utils::TestCipher;
     ///
     /// let cipher = TestCipher;
     ///
@@ -182,8 +188,9 @@ impl<Tag, T> ContextTag<Tag, T> {
     /// # Chaining multiple refinements
     ///
     /// ```
-    /// use vitaminc_aead::{ContextTag, Encrypt, Decrypt};
-    /// use vitaminc_aead::test_utils::TestCipher;
+    /// # mod vitaminc { pub mod aead { pub use vitaminc_aead::*; } }
+    /// use vitaminc::aead::{ContextTag, Encrypt, Decrypt};
+    /// use vitaminc::aead::test_utils::TestCipher;
     ///
     /// let cipher = TestCipher;
     ///
@@ -241,8 +248,9 @@ impl<Tag> ContextTag<Tag, ()> {
     /// # Example
     ///
     /// ```
-    /// use vitaminc_aead::{ContextTag, Encrypt, Decrypt};
-    /// use vitaminc_aead::test_utils::TestCipher;
+    /// # mod vitaminc { pub mod aead { pub use vitaminc_aead::*; } }
+    /// use vitaminc::aead::{ContextTag, Encrypt, Decrypt};
+    /// use vitaminc::aead::test_utils::TestCipher;
     ///
     /// let cipher = TestCipher;
     ///
@@ -275,8 +283,9 @@ impl<Tag> ContextTag<Tag, ()> {
     /// # Example
     ///
     /// ```
-    /// use vitaminc_aead::{ContextTag, Encrypt, Decrypt};
-    /// use vitaminc_aead::test_utils::TestCipher;
+    /// # mod vitaminc { pub mod aead { pub use vitaminc_aead::*; } }
+    /// use vitaminc::aead::{ContextTag, Encrypt, Decrypt};
+    /// use vitaminc::aead::test_utils::TestCipher;
     ///
     /// let cipher = TestCipher;
     ///

--- a/packages/encrypt/src/lib.rs
+++ b/packages/encrypt/src/lib.rs
@@ -30,10 +30,11 @@ pub use vitaminc_aead::{
 /// # Example
 ///
 /// ```rust
-/// use vitaminc_encrypt::Key;
-/// use vitaminc_aead::Encrypt;
+/// # mod vitaminc { pub mod encrypt { pub use vitaminc_encrypt::*; } pub mod aead { pub use vitaminc_aead::*; } }
+/// use vitaminc::encrypt::Key;
+/// use vitaminc::aead::Encrypt;
 /// let key = Key::from([0u8; 32]);
-/// let encrypted = vitaminc_encrypt::encrypt(&key, "message").unwrap();
+/// let encrypted = vitaminc::encrypt::encrypt(&key, "message").unwrap();
 /// ```
 ///
 pub fn encrypt<'a, T>(key: &Key, plaintext: T) -> Result<T::Encrypted, Unspecified>
@@ -57,10 +58,11 @@ where
 /// # Example
 ///
 /// ```rust
-/// use vitaminc_encrypt::Key;
-/// use vitaminc_aead::Encrypt;
+/// # mod vitaminc { pub mod encrypt { pub use vitaminc_encrypt::*; } pub mod aead { pub use vitaminc_aead::*; } }
+/// use vitaminc::encrypt::Key;
+/// use vitaminc::aead::Encrypt;
 /// let key = Key::from([0u8; 32]);
-/// let encrypted = vitaminc_encrypt::encrypt_with_aad(&key, "message", "additional-data").unwrap();
+/// let encrypted = vitaminc::encrypt::encrypt_with_aad(&key, "message", "additional-data").unwrap();
 /// ```
 ///
 pub fn encrypt_with_aad<'a, T, A>(
@@ -85,11 +87,12 @@ where
 /// # Example
 ///
 /// ```rust
-/// use vitaminc_encrypt::Key;
-/// use vitaminc_aead::Decrypt;
+/// # mod vitaminc { pub mod encrypt { pub use vitaminc_encrypt::*; } pub mod aead { pub use vitaminc_aead::*; } }
+/// use vitaminc::encrypt::Key;
+/// use vitaminc::aead::Decrypt;
 /// let key = Key::from([0u8; 32]);
-/// let ciphertext = vitaminc_encrypt::encrypt(&key, "message").unwrap();
-/// let decrypted: String = vitaminc_encrypt::decrypt(&key, ciphertext).unwrap();
+/// let ciphertext = vitaminc::encrypt::encrypt(&key, "message").unwrap();
+/// let decrypted: String = vitaminc::encrypt::decrypt(&key, ciphertext).unwrap();
 /// assert_eq!(decrypted, "message");
 /// ```
 pub fn decrypt<T>(key: &Key, ciphertext: T::Encrypted) -> Result<T, Unspecified>
@@ -107,11 +110,12 @@ where
 /// # Example
 ///
 /// ```rust
-/// use vitaminc_encrypt::Key;
-/// use vitaminc_aead::Decrypt;
+/// # mod vitaminc { pub mod encrypt { pub use vitaminc_encrypt::*; } pub mod aead { pub use vitaminc_aead::*; } }
+/// use vitaminc::encrypt::Key;
+/// use vitaminc::aead::Decrypt;
 /// let key = Key::from([0u8; 32]);
-/// let ciphertext = vitaminc_encrypt::encrypt_with_aad(&key, "message", "additional-data").unwrap();
-/// let decrypted: String = vitaminc_encrypt::decrypt_with_aad(&key, ciphertext, "additional-data").unwrap();
+/// let ciphertext = vitaminc::encrypt::encrypt_with_aad(&key, "message", "additional-data").unwrap();
+/// let decrypted: String = vitaminc::encrypt::decrypt_with_aad(&key, ciphertext, "additional-data").unwrap();
 /// assert_eq!(decrypted, "message");
 /// ```
 ///
@@ -120,11 +124,12 @@ where
 /// If the AAD does not match the one used during encryption, decryption will fail with an [`Unspecified`] error.
 ///
 /// ```rust
-/// # use vitaminc_encrypt::Key;
-/// # use vitaminc_aead::Decrypt;
+/// # mod vitaminc { pub mod encrypt { pub use vitaminc_encrypt::*; } pub mod aead { pub use vitaminc_aead::*; } }
+/// # use vitaminc::encrypt::Key;
+/// # use vitaminc::aead::Decrypt;
 /// # let key = Key::from([0u8; 32]);
-/// let ciphertext = vitaminc_encrypt::encrypt_with_aad(&key, "message", "additional-data").unwrap();
-/// let result = vitaminc_encrypt::decrypt_with_aad::<String, _>(&key, ciphertext, "wrong-data");
+/// let ciphertext = vitaminc::encrypt::encrypt_with_aad(&key, "message", "additional-data").unwrap();
+/// let result = vitaminc::encrypt::decrypt_with_aad::<String, _>(&key, ciphertext, "wrong-data");
 /// assert!(result.is_err());
 /// ```
 ///

--- a/packages/permutation/src/key.rs
+++ b/packages/permutation/src/key.rs
@@ -47,8 +47,9 @@ impl<const N: usize> PermutationKey<N> {
     /// # Example
     ///
     /// ```
-    /// use vitaminc_permutation::{Permute, PermutationKey};
-    /// use vitaminc_random::{Generatable, SafeRand, SeedableRng};
+    /// # mod vitaminc { pub mod permutation { pub use vitaminc_permutation::*; } pub mod random { pub use vitaminc_random::*; } }
+    /// use vitaminc::permutation::{Permute, PermutationKey};
+    /// use vitaminc::random::{Generatable, SafeRand, SeedableRng};
     /// let mut rng = SafeRand::from_entropy().expect("Failed to seed RNG");
     /// let key = PermutationKey::random(&mut rng).expect("Random error");
     /// let target = PermutationKey::random(&mut rng).expect("Random error");

--- a/packages/protected/src/as_protected_ref.rs
+++ b/packages/protected/src/as_protected_ref.rs
@@ -13,7 +13,8 @@ use std::borrow::Cow;
 /// because `ProtectedRef` cannot be constructed from the inner type directly.
 ///
 /// ```
-/// use vitaminc_protected::{AsProtectedRef, Protected, ProtectedRef};
+/// # mod vitaminc { pub mod protected { pub use vitaminc_protected::*; } }
+/// use vitaminc::protected::{AsProtectedRef, Protected, ProtectedRef};
 ///
 /// pub struct SensitiveData(Protected<Vec<u8>>);
 ///

--- a/packages/protected/src/controlled.rs
+++ b/packages/protected/src/controlled.rs
@@ -23,7 +23,8 @@ pub trait Controlled: ControlledPrivate {
     /// Generate a new [Protected] from a function that returns an array.
     ///
     /// ```
-    /// use vitaminc_protected::{Controlled, Protected};
+    /// # mod vitaminc { pub mod protected { pub use vitaminc_protected::*; } }
+    /// use vitaminc::protected::{Controlled, Protected};
     /// fn array_gen<const N: usize>() -> [u8; N] {
     ///     let mut input: [u8; N] = [0; N];
     ///     input.iter_mut().enumerate().for_each(|(i, x)| {
@@ -50,7 +51,8 @@ pub trait Controlled: ControlledPrivate {
     /// Generate a new [Protected] from a function that returns a `Result` with the inner value.
     ///
     /// ```
-    /// use vitaminc_protected::{Controlled, Protected};
+    /// # mod vitaminc { pub mod protected { pub use vitaminc_protected::*; } }
+    /// use vitaminc::protected::{Controlled, Protected};
     /// use std::string::FromUtf8Error;
     ///
     /// let input: Result<Protected<String>, FromUtf8Error> = Protected::generate_ok(|| {
@@ -74,7 +76,8 @@ pub trait Controlled: ControlledPrivate {
     /// Map the inner value of a [Protected] to a new value.
     ///
     /// ```
-    /// use vitaminc_protected::{Controlled, Protected};
+    /// # mod vitaminc { pub mod protected { pub use vitaminc_protected::*; } }
+    /// use vitaminc::protected::{Controlled, Protected};
     /// let x = Protected::new(100u8);
     /// let y = x.map(|x| x + 10);
     /// assert_eq!(y.risky_unwrap(), 110);
@@ -97,7 +100,8 @@ pub trait Controlled: ControlledPrivate {
     /// Map the inner value of a [Protected] to a new value that is wrapped in a `Result`.
     ///
     /// ```
-    /// use vitaminc_protected::{Controlled, Protected};
+    /// # mod vitaminc { pub mod protected { pub use vitaminc_protected::*; } }
+    /// use vitaminc::protected::{Controlled, Protected};
     /// let x = Protected::new(vec![240, 159, 146, 150]);
     /// let y = x.map_ok(String::from_utf8);
     /// assert!(matches!(y, Ok(_)));
@@ -120,7 +124,8 @@ pub trait Controlled: ControlledPrivate {
     /// Add two [Protected] values together.
     ///
     /// ```
-    /// use vitaminc_protected::{Controlled, Protected};
+    /// # mod vitaminc { pub mod protected { pub use vitaminc_protected::*; } }
+    /// use vitaminc::protected::{Controlled, Protected};
     /// let x = Protected::new(1);
     /// let y = Protected::new(2);
     /// let z = x.zip(y, |x, y| x + y);
@@ -145,7 +150,8 @@ pub trait Controlled: ControlledPrivate {
     /// # Example
     ///
     /// ```
-    /// use vitaminc_protected::{Controlled, Protected};
+    /// # mod vitaminc { pub mod protected { pub use vitaminc_protected::*; } }
+    /// use vitaminc::protected::{Controlled, Protected};
     /// let x = Protected::new(String::from("hello "));
     /// let y = Protected::new(String::from("world"));
     /// let z = x.zip_ref(&y, |x, y| x + y);
@@ -174,7 +180,8 @@ pub trait Controlled: ControlledPrivate {
     /// # Example
     ///
     /// ```
-    /// # use vitaminc_protected::{Controlled, Protected};
+    /// # mod vitaminc { pub mod protected { pub use vitaminc_protected::*; } }
+    /// # use vitaminc::protected::{Controlled, Protected};
     /// let mut x = Protected::new([0u8; 4]);
     /// x.update(|x| {
     ///   x.iter_mut().for_each(|x| {
@@ -197,7 +204,8 @@ pub trait Controlled: ControlledPrivate {
     /// # Example
     ///
     /// ```
-    /// use vitaminc_protected::{Controlled, Protected};
+    /// # mod vitaminc { pub mod protected { pub use vitaminc_protected::*; } }
+    /// use vitaminc::protected::{Controlled, Protected};
     /// let mut x = Protected::new([0u8; 32]);
     /// let y = Protected::new([1u8; 32]);
     /// x.update_with(y, |x, y| {
@@ -225,8 +233,9 @@ pub trait Controlled: ControlledPrivate {
     /// # Example
     ///
     /// ```
-    /// # use vitaminc_protected::{Controlled, Protected};
-    /// use vitaminc_protected::AsProtectedRef;
+    /// # mod vitaminc { pub mod protected { pub use vitaminc_protected::*; } }
+    /// # use vitaminc::protected::{Controlled, Protected};
+    /// use vitaminc::protected::AsProtectedRef;
     ///
     /// let mut x = Protected::new([0u8; 32]);
     /// let y = Protected::new([1u8; 32]);
@@ -260,7 +269,8 @@ pub trait Controlled: ControlledPrivate {
     /// # Example
     ///
     /// ```
-    /// use vitaminc_protected::{Controlled, Protected};
+    /// # mod vitaminc { pub mod protected { pub use vitaminc_protected::*; } }
+    /// use vitaminc::protected::{Controlled, Protected};
     /// let mut x = Protected::new([0u8; 32]);
     /// let y = Protected::new([1u8; 32]);
     /// x.replace(y);

--- a/packages/protected/src/debug/mod.rs
+++ b/packages/protected/src/debug/mod.rs
@@ -8,7 +8,7 @@ use zeroize::Zeroize;
 /// **never** reveals internal data.
 ///
 /// By default, the generated `Debug` implementation prints a placeholder that includes
-/// the type’s fully-qualified name via [`core::any::type_name`]:
+/// the type's fully-qualified name via [`core::any::type_name`]:
 ///
 /// You can override this placeholder with an attribute on the type.
 ///
@@ -34,7 +34,8 @@ use zeroize::Zeroize;
 /// ### Basic: default placeholder uses the fully-qualified type name
 ///
 /// ```rust
-/// use vitaminc_protected::OpaqueDebug;
+/// # mod vitaminc { pub mod protected { pub use vitaminc_protected::*; } }
+/// use vitaminc::protected::OpaqueDebug;
 ///
 /// #[derive(OpaqueDebug)]
 /// struct ApiToken([u8; 32]);
@@ -49,7 +50,8 @@ use zeroize::Zeroize;
 /// The `Debug` impl includes the instantiated type parameters in the placeholder.
 ///
 /// ```rust
-/// use vitaminc_protected::OpaqueDebug;
+/// # mod vitaminc { pub mod protected { pub use vitaminc_protected::*; } }
+/// use vitaminc::protected::OpaqueDebug;
 ///
 /// #[derive(OpaqueDebug)]
 /// struct Key<const N: usize>([u8; N]);
@@ -64,7 +66,8 @@ use zeroize::Zeroize;
 /// The internal representation is still hidden.
 ///
 /// ```rust
-/// use vitaminc_protected::OpaqueDebug;
+/// # mod vitaminc { pub mod protected { pub use vitaminc_protected::*; } }
+/// use vitaminc::protected::OpaqueDebug;
 ///
 /// #[derive(OpaqueDebug)]
 /// enum SecretThing {
@@ -84,7 +87,8 @@ use zeroize::Zeroize;
 /// This is useful when you actually want to include certain fields in the debug output.
 ///
 /// ```rust
-/// use vitaminc_protected::OpaqueDebug;
+/// # mod vitaminc { pub mod protected { pub use vitaminc_protected::*; } }
+/// use vitaminc::protected::OpaqueDebug;
 ///
 /// #[derive(OpaqueDebug)]
 /// struct HasNonSensitiveField {
@@ -108,8 +112,9 @@ use zeroize::Zeroize;
 /// This is useful to manage external types.
 ///
 /// ```rust
+/// # mod vitaminc { pub mod protected { pub use vitaminc_protected::*; } }
 /// use core::fmt;
-/// use vitaminc_protected::{OpaqueDebug, Redacted};
+/// use vitaminc::protected::{OpaqueDebug, Redacted};
 ///
 /// let safe = Redacted::new([0u8; 32]);
 /// assert_eq!(format!("{:?}", safe), "Redacted<[u8; 32] ***>");
@@ -136,7 +141,8 @@ pub trait OpaqueDebug {}
 /// # Example
 ///
 /// ```
-/// use vitaminc_protected::Redacted;
+/// # mod vitaminc { pub mod protected { pub use vitaminc_protected::*; } }
+/// use vitaminc::protected::Redacted;
 ///
 /// let redacted = Redacted::new([0u8; 32]);
 /// assert_eq!(format!("{:?}", redacted), "Redacted<[u8; 32] ***>");

--- a/packages/protected/src/equatable/mod.rs
+++ b/packages/protected/src/equatable/mod.rs
@@ -12,7 +12,8 @@ use zeroize::Zeroize;
 /// Initializing an [Equatable]:
 ///
 /// ```
-/// use vitaminc_protected::{Equatable, Controlled, Protected};
+/// # mod vitaminc { pub mod protected { pub use vitaminc_protected::*; } }
+/// use vitaminc::protected::{Equatable, Controlled, Protected};
 /// let x: Equatable<Protected<u8>> = 42.into();
 /// let y: Equatable<Protected<u8>> = Equatable::<Protected<u8>>::new(42);
 /// ```
@@ -22,7 +23,8 @@ use zeroize::Zeroize;
 /// [Equatable] requires that types are equatable in constant time.
 ///
 /// ```
-/// use vitaminc_protected::{Equatable, Protected};
+/// # mod vitaminc { pub mod protected { pub use vitaminc_protected::*; } }
+/// use vitaminc::protected::{Equatable, Protected};
 /// let x: Equatable<Protected<u8>> = 112.into();
 /// let y: Equatable<Protected<u8>> = 112.into();
 ///
@@ -32,7 +34,8 @@ use zeroize::Zeroize;
 /// The [Equatable] type also implements `PartialEq` and `Eq` for easy comparison using the constant time implementation.
 ///
 /// ```
-/// use vitaminc_protected::{Equatable, Protected};
+/// # mod vitaminc { pub mod protected { pub use vitaminc_protected::*; } }
+/// use vitaminc::protected::{Equatable, Protected};
 /// let x: Equatable<Protected<u8>> = 112.into();
 /// let y: Equatable<Protected<u8>> = 112.into();
 /// assert_eq!(x, y);
@@ -46,7 +49,8 @@ use zeroize::Zeroize;
 /// See also [crate::Exportable].
 ///
 /// ```
-/// use vitaminc_protected::{Exportable, Equatable, Protected};
+/// # mod vitaminc { pub mod protected { pub use vitaminc_protected::*; } }
+/// use vitaminc::protected::{Exportable, Equatable, Protected};
 /// let x: Equatable<Protected<[u8; 16]>> = [0u8; 16].into();
 /// let y: Exportable<Equatable<Protected<[u8; 16]>>> = Exportable::new([0u8; 16]);
 ///
@@ -59,7 +63,8 @@ use zeroize::Zeroize;
 /// It's therefore safe to use it in debug output and in custom types.
 ///
 /// ```
-/// use vitaminc_protected::{Equatable, Controlled, Protected};
+/// # mod vitaminc { pub mod protected { pub use vitaminc_protected::*; } }
+/// use vitaminc::protected::{Equatable, Controlled, Protected};
 ///
 /// type Inner = Equatable<Protected<u8>>;
 ///
@@ -72,7 +77,8 @@ use zeroize::Zeroize;
 /// # Usage in a struct
 ///
 /// ```
-/// use vitaminc_protected::{Equatable, Protected};
+/// # mod vitaminc { pub mod protected { pub use vitaminc_protected::*; } }
+/// use vitaminc::protected::{Equatable, Protected};
 ///
 /// #[derive(Debug, PartialEq)]
 /// struct AuthenticatedString {

--- a/packages/protected/src/exportable/mod.rs
+++ b/packages/protected/src/exportable/mod.rs
@@ -21,7 +21,8 @@ pub use safe_serialize::SafeSerialize;
 /// # Example
 ///
 /// ```
-/// use vitaminc_protected::{Controlled, Exportable, Protected};
+/// # mod vitaminc { pub mod protected { pub use vitaminc_protected::*; } }
+/// use vitaminc::protected::{Controlled, Exportable, Protected};
 /// use serde::{Serialize, Deserialize};
 ///
 /// pub type Secret = Exportable<Protected<[u8; 32]>>;
@@ -37,7 +38,8 @@ pub use safe_serialize::SafeSerialize;
 /// Note that the order of the nesting does not matter.
 ///
 /// ```
-/// use vitaminc_protected::{Controlled, Exportable, Equatable, Protected};
+/// # mod vitaminc { pub mod protected { pub use vitaminc_protected::*; } }
+/// use vitaminc::protected::{Controlled, Exportable, Equatable, Protected};
 /// use serde::{Serialize, Deserialize};
 ///
 /// // Nesting order does not matter

--- a/packages/protected/src/protected/mod.rs
+++ b/packages/protected/src/protected/mod.rs
@@ -24,7 +24,8 @@ impl<T> Protected<Protected<T>> {
     /// Similar to `Option::flatten`.
     ///
     /// ```
-    /// use vitaminc_protected::{Controlled, Protected};
+    /// # mod vitaminc { pub mod protected { pub use vitaminc_protected::*; } }
+    /// use vitaminc::protected::{Controlled, Protected};
     /// let x = Protected::new(Protected::new([0u8; 32]));
     /// let y = x.flatten();
     /// assert_eq!(y.risky_unwrap(), [0u8; 32]);
@@ -43,7 +44,8 @@ impl<T> Protected<Option<T>> {
     /// Similar to `Option::transpose`.
     ///
     /// ```
-    /// use vitaminc_protected::Protected;
+    /// # mod vitaminc { pub mod protected { pub use vitaminc_protected::*; } }
+    /// use vitaminc::protected::Protected;
     /// let x = Protected::new(Some([0u8; 32]));
     /// let y = x.transpose();
     /// assert!(y.is_some())
@@ -119,7 +121,8 @@ where
 /// # Example
 ///
 /// ```
-/// use vitaminc_protected::{flatten_array, Controlled, Protected};
+/// # mod vitaminc { pub mod protected { pub use vitaminc_protected::*; } }
+/// use vitaminc::protected::{flatten_array, Controlled, Protected};
 /// let x = Protected::new(1);
 /// let y = Protected::new(2);
 /// let z = Protected::new(3);

--- a/packages/protected/src/timing_safe/mod.rs
+++ b/packages/protected/src/timing_safe/mod.rs
@@ -23,7 +23,8 @@ use subtle::ConstantTimeEq;
 /// ### Implementing `TimingSafeEq` manually
 ///
 /// ```
-/// use vitaminc_protected::{TimingSafeEq, Choice};
+/// # mod vitaminc { pub mod protected { pub use vitaminc_protected::*; } }
+/// use vitaminc::protected::{TimingSafeEq, Choice};
 ///
 /// #[derive(Clone, Copy)]
 /// struct CtU8(u8);
@@ -40,7 +41,8 @@ use subtle::ConstantTimeEq;
 /// ### Using `#[derive(TimingSafeEq)]`
 ///
 /// ```
-/// use vitaminc_protected::{TimingSafeEq, Choice};
+/// # mod vitaminc { pub mod protected { pub use vitaminc_protected::*; } }
+/// use vitaminc::protected::{TimingSafeEq, Choice};
 ///
 /// #[derive(TimingSafeEq)]
 /// struct Key<const N: usize>([u8; N]);

--- a/packages/random/src/generatable.rs
+++ b/packages/random/src/generatable.rs
@@ -5,7 +5,8 @@
 //! ## Example
 //!
 //! ```rust
-//! use vitaminc_random::{Generatable, SafeRand, SeedableRng};
+//! # mod vitaminc { pub mod random { pub use vitaminc_random::*; } }
+//! use vitaminc::random::{Generatable, SafeRand, SeedableRng};
 //! use std::num::NonZeroU16;
 //!
 //! let mut rng = SafeRand::from_entropy().expect("Failed to seed RNG");

--- a/packages/vitaminc/Cargo.toml
+++ b/packages/vitaminc/Cargo.toml
@@ -22,6 +22,7 @@ vitaminc-random = { path = "../random", version = "0.1.0-pre4.1", optional = tru
 vitaminc-traits = { path = "../traits", version = "0.1.0-pre4.1", optional = true }
 vitaminc-async-traits = { path = "../async-traits", version = "0.1.0-pre4.1", optional = true }
 vitaminc-encrypt = { path = "../encrypt", version = "0.1.0-pre4.1", optional = true }
+vitaminc-aead = { path = "../aead", version = "0.1.0-pre4.1", optional = true }
 
 [features]
 protected = ["dep:vitaminc-protected"]
@@ -30,7 +31,8 @@ permutation = ["dep:vitaminc-permutation", "protected"]
 traits = ["dep:vitaminc-traits"]
 async-traits = ["dep:vitaminc-async-traits", "traits"]
 aws-kms = ["traits", "dep:vitaminc-kms"]
-encrypt = ["traits", "dep:vitaminc-encrypt"]
+aead = ["dep:vitaminc-aead"]
+encrypt = ["traits", "aead", "dep:vitaminc-encrypt"]
 
 [[test]]
 name = "timing_safe_runtime"

--- a/packages/vitaminc/src/lib.rs
+++ b/packages/vitaminc/src/lib.rs
@@ -1,26 +1,34 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc = include_str!("../README.md")]
+
+#[cfg(feature = "aead")]
+#[cfg_attr(docsrs, doc(cfg(feature = "aead")))]
+pub use vitaminc_aead as aead;
+
+#[cfg(feature = "async-traits")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async-traits")))]
+pub use vitaminc_async_traits as async_traits;
+
+#[cfg(feature = "encrypt")]
+#[cfg_attr(docsrs, doc(cfg(feature = "encrypt")))]
+pub use vitaminc_encrypt as encrypt;
+
+#[cfg(feature = "aws-kms")]
+#[cfg_attr(docsrs, doc(cfg(feature = "aws-kms")))]
+pub use vitaminc_kms as aws_kms;
+
+#[cfg(feature = "permutation")]
+#[cfg_attr(docsrs, doc(cfg(feature = "permutation")))]
+pub use vitaminc_permutation as permutation;
+
 #[cfg(feature = "protected")]
+#[cfg_attr(docsrs, doc(cfg(feature = "protected")))]
 pub use vitaminc_protected as protected;
 
 #[cfg(feature = "random")]
 #[cfg_attr(docsrs, doc(cfg(feature = "random")))]
-#[doc(inline)]
-pub use vitaminc_random::{Generatable, RandomError, SafeRand, SeedableRng};
-
-#[cfg(feature = "permutation")]
-pub use vitaminc_permutation as permutation;
+pub use vitaminc_random as random;
 
 #[cfg(feature = "traits")]
+#[cfg_attr(docsrs, doc(cfg(feature = "traits")))]
 pub use vitaminc_traits as traits;
-
-#[cfg(feature = "async-traits")]
-pub use vitaminc_async_traits as async_traits;
-
-#[cfg(feature = "aws-kms")]
-pub use vitaminc_kms as aws_kms;
-
-#[cfg(feature = "encrypt")]
-#[cfg_attr(docsrs, doc(cfg(feature = "encrypt")))]
-#[doc(inline)]
-pub use vitaminc_encrypt::*;


### PR DESCRIPTION
## Summary

- **Normalize all re-exports** in the umbrella `vitaminc` crate to consistent `pub use vitaminc_foo as foo` module aliases, replacing the previous mix of selective imports (`random`), glob re-exports (`encrypt`), and plain aliases
- **Add `aead` as a standalone feature** with `vitaminc-aead` as an optional dependency; `encrypt` now implies `aead`
- **Update all 51 doctests** across 11 sub-crate files to show user-facing `vitaminc::*` import paths (e.g. `use vitaminc::protected::Controlled`) using hidden module shims, so rendered docs match how consumers will actually use the crate

### Breaking changes

- `vitaminc::SafeRand` → `vitaminc::random::SafeRand` (and other items previously flat-imported from `random`)
- `vitaminc::Key`, `vitaminc::encrypt(...)` → `vitaminc::encrypt::Key`, `vitaminc::encrypt::encrypt(...)` (previously glob-imported from `encrypt`)

No in-repo code depends on the flat style — only `vitaminc::protected::*` was used in tests, which is unchanged.