### PR TITLE
fix: remove circular dev-dependency between vitaminc-protected and vitaminc

### DIFF
--- a/packages/protected-derive/src/timing_safe.rs
+++ b/packages/protected-derive/src/timing_safe.rs
@@ -15,7 +15,7 @@ pub fn derive_timing_safe(input: DeriveInput) -> TokenStream {
         for ty in field_types {
             where_clause
                 .predicates
-                .push(syn::parse_quote!(#ty: ::vitaminc::protected::TimingSafeEq));
+                .push(syn::parse_quote!(#ty: ::vitaminc_protected::TimingSafeEq));
         }
     }
 
@@ -33,8 +33,8 @@ pub fn derive_timing_safe(input: DeriveInput) -> TokenStream {
                 #[automatically_derived]
                 impl #impl_generics TimingSafeEq for #ident #ty_generics #where_clause {
                     #[inline]
-                    fn ts_eq(&self, _other: &Self) -> ::vitaminc::protected::Choice {
-                        ::vitaminc::protected::Choice::from(0u8)
+                    fn ts_eq(&self, _other: &Self) -> ::vitaminc_protected::Choice {
+                        ::vitaminc_protected::Choice::from(0u8)
                     }
                 }
             }
@@ -131,20 +131,20 @@ fn ts_impl_struct(
                 let r = format_ident!("__ts_rhs_{}", name);
                 lhs_bind.push(quote!( #name: ref #l ));
                 rhs_bind.push(quote!( #name: ref #r ));
-                compares.push(quote!( acc &= ::vitaminc::protected::TimingSafeEq::ts_eq(#l, #r); ));
+                compares.push(quote!( acc &= ::vitaminc_protected::TimingSafeEq::ts_eq(#l, #r); ));
             }
 
             quote! {
                 #[automatically_derived]
                 impl #impl_generics TimingSafeEq for #ident #ty_generics #where_clause {
                     #[inline]
-                    fn ts_eq(&self, other: &Self) -> ::vitaminc::protected::Choice {
+                    fn ts_eq(&self, other: &Self) -> ::vitaminc_protected::Choice {
                         match (self, other) {
                             (
                                 Self { #(#lhs_bind,)* },
                                 Self { #(#rhs_bind,)* },
                             ) => {
-                                let mut acc = ::vitaminc::protected::Choice::from(1u8);
+                                let mut acc = ::vitaminc_protected::Choice::from(1u8);
                                 #(#compares)*
                                 acc
                             }
@@ -162,17 +162,17 @@ fn ts_impl_struct(
             let compares: Vec<_> = lhs
                 .iter()
                 .zip(rhs.iter())
-                .map(|(l, r)| quote!( acc &= ::vitaminc::protected::TimingSafeEq::ts_eq(#l, #r); ))
+                .map(|(l, r)| quote!( acc &= ::vitaminc_protected::TimingSafeEq::ts_eq(#l, #r); ))
                 .collect();
 
             quote! {
                 #[automatically_derived]
                 impl #impl_generics TimingSafeEq for #ident #ty_generics #where_clause {
                     #[inline]
-                    fn ts_eq(&self, other: &Self) -> ::vitaminc::protected::Choice {
+                    fn ts_eq(&self, other: &Self) -> ::vitaminc_protected::Choice {
                         let Self( #(ref #lhs),* ) = self;
                         let Self( #(ref #rhs),* ) = other;
-                        let mut acc = ::vitaminc::protected::Choice::from(1u8);
+                        let mut acc = ::vitaminc_protected::Choice::from(1u8);
                         #(#compares)*
                         acc
                     }
@@ -185,8 +185,8 @@ fn ts_impl_struct(
                 #[automatically_derived]
                 impl #impl_generics TimingSafeEq for #ident #ty_generics #where_clause {
                     #[inline]
-                    fn ts_eq(&self, _other: &Self) -> ::vitaminc::protected::Choice {
-                        ::vitaminc::protected::Choice::from(1u8)
+                    fn ts_eq(&self, _other: &Self) -> ::vitaminc_protected::Choice {
+                        ::vitaminc_protected::Choice::from(1u8)
                     }
                 }
             }
@@ -219,11 +219,11 @@ fn ts_impl_enum(
                     lbind.push(quote!( #fname: ref #l ));
                     rbind.push(quote!( #fname: ref #r ));
                     compares
-                        .push(quote!( acc &= ::vitaminc::protected::TimingSafeEq::ts_eq(#l, #r); ));
+                        .push(quote!( acc &= ::vitaminc_protected::TimingSafeEq::ts_eq(#l, #r); ));
                 }
                 arms.push(quote! {
                     (Self::#v_ident { #(#lbind,)* }, Self::#v_ident { #(#rbind,)* }) => {
-                        let mut acc = ::vitaminc::protected::Choice::from(1u8);
+                        let mut acc = ::vitaminc_protected::Choice::from(1u8);
                         #(#compares)*
                         acc
                     }
@@ -238,11 +238,11 @@ fn ts_impl_enum(
                     .map(|fi| format_ident!("__ts_rhs_{}_{}", vi, fi))
                     .collect();
                 let compares: Vec<_> = lhs.iter().zip(rhs.iter())
-                    .map(|(l, r)| quote!( acc &= ::vitaminc::protected::TimingSafeEq::ts_eq(#l, #r); ))
+                    .map(|(l, r)| quote!( acc &= ::vitaminc_protected::TimingSafeEq::ts_eq(#l, #r); ))
                     .collect();
                 arms.push(quote! {
                     (Self::#v_ident( #(ref #lhs),* ), Self::#v_ident( #(ref #rhs),* )) => {
-                        let mut acc = ::vitaminc::protected::Choice::from(1u8);
+                        let mut acc = ::vitaminc_protected::Choice::from(1u8);
                         #(#compares)*
                         acc
                     }
@@ -250,20 +250,20 @@ fn ts_impl_enum(
             }
             Fields::Unit => {
                 arms.push(quote! {
-                    (Self::#v_ident, Self::#v_ident) => ::vitaminc::protected::Choice::from(1u8)
+                    (Self::#v_ident, Self::#v_ident) => ::vitaminc_protected::Choice::from(1u8)
                 });
             }
         }
     }
 
     // Non-matching variants are not equal.
-    arms.push(quote! { _ => ::vitaminc::protected::Choice::from(0u8) });
+    arms.push(quote! { _ => ::vitaminc_protected::Choice::from(0u8) });
 
     quote! {
         #[automatically_derived]
         impl #impl_generics TimingSafeEq for #ident #ty_generics #where_clause {
             #[inline]
-            fn ts_eq(&self, other: &Self) -> ::vitaminc::protected::Choice {
+            fn ts_eq(&self, other: &Self) -> ::vitaminc_protected::Choice {
                 match (self, other) {
                     #(#arms),*
                 }

--- a/packages/protected/Cargo.toml
+++ b/packages/protected/Cargo.toml
@@ -28,8 +28,6 @@ vitaminc-protected-derive = { path = "../protected-derive", version = "0.1.0-pre
 rmp-serde = "1.3.1"
 serde_json = "1.0.149"
 sha2 = "0.10.9"
-# NOTE: we need this for doctests (particularly the derive macros)
-vitaminc = { path = "../vitaminc", version = "0.1.0-pre4.1", features = [ "protected"] }
 
 [features]
 bitvec = []


### PR DESCRIPTION
## Summary

- The `TimingSafeEq` derive macro was generating code referencing `::vitaminc::protected::` paths, which forced `vitaminc-protected` to dev-depend on the `vitaminc` umbrella crate
- Since `vitaminc` depends on `vitaminc-protected`, this created a circular dependency that made publishing to crates.io impossible — `cargo publish` tries to resolve dev-deps against the registry and fails
- Changed the derive macro to emit `::vitaminc_protected::` paths and removed the unnecessary dev-dependency