### PR TITLE
fix(aead): remove circular dev-dependency on vitaminc-encrypt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2033,7 +2033,7 @@ dependencies = [
  "quickcheck",
  "quickcheck_macros",
  "serde",
- "vitaminc-encrypt",
+ "vitaminc-aead",
  "vitaminc-protected",
  "vitaminc-random",
  "zeroize",
@@ -2108,7 +2108,6 @@ dependencies = [
  "serde_json",
  "sha2",
  "subtle",
- "vitaminc",
  "vitaminc-protected-derive",
  "zeroize",
 ]

--- a/packages/aead/Cargo.toml
+++ b/packages/aead/Cargo.toml
@@ -19,7 +19,10 @@ bytes = { version = "^1", features = ["serde"] }
 serde = { workspace = true }
 zeroize = { workspace = true }
 
+[features]
+test-utils = []
+
 [dev-dependencies]
-vitaminc-encrypt = { version = "0.1.0-pre4.1", path = "../encrypt" } # Used only in doctests
+vitaminc-aead = { path = ".", features = ["test-utils"] }
 quickcheck = "1.1.0"
 quickcheck_macros = "1.2.0"

--- a/packages/aead/README.md
+++ b/packages/aead/README.md
@@ -120,14 +120,10 @@ fn decrypt_data<C: Cipher>(
 Many types can be used as AAD through the [`IntoAad`] trait:
 
 ```rust
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
 use vitaminc_aead::{Encrypt, Cipher};
-use vitaminc_encrypt::{Key, Aes256Cipher};
-use vitaminc_protected::Protected;
-use vitaminc_random::{Generatable, SafeRand, SeedableRng};
+use vitaminc_aead::test_utils::TestCipher;
 
-let key = Key::random(&mut SafeRand::from_entropy()?)?;
-let cipher = Aes256Cipher::new(&key)?;
+let cipher = TestCipher;
 
 // Use a string as AAD
 "my-secret".encrypt_with_aad(&cipher, "user_id:123")?;
@@ -143,8 +139,7 @@ let cipher = Aes256Cipher::new(&key)?;
 
 // Use no AAD
 "my-secret".encrypt_with_aad(&cipher, ())?;
-# Ok(())
-# }
+# Ok::<(), vitaminc_aead::Unspecified>(())
 ```
 
 ### Working with Protected Types
@@ -152,20 +147,16 @@ let cipher = Aes256Cipher::new(&key)?;
 The crate integrates with `vitaminc-protected` to handle sensitive data safely:
 
 ```rust
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
 use vitaminc_aead::{Encrypt, Cipher};
-use vitaminc_encrypt::{Key, Aes256Cipher};
+use vitaminc_aead::test_utils::TestCipher;
 use vitaminc_protected::Protected;
-use vitaminc_random::{Generatable, SafeRand, SeedableRng};
 
-let key = Key::random(&mut SafeRand::from_entropy()?)?;
-let cipher = Aes256Cipher::new(&key)?;
+let cipher = TestCipher;
 
 let sensitive_data = Protected::new([1, 2, 3, 4, 5]);
 
 let encrypted = sensitive_data.encrypt(&cipher)?;
-# Ok(())
-# }
+# Ok::<(), vitaminc_aead::Unspecified>(())
 ```
 
 ### Custom Types

--- a/packages/aead/src/context.rs
+++ b/packages/aead/src/context.rs
@@ -48,10 +48,9 @@ use crate::{Cipher, Decrypt, Encrypt, IntoAad, Unspecified};
 ///
 /// ```
 /// use vitaminc_aead::{ContextTag, Encrypt, Decrypt};
-/// use vitaminc_encrypt::{Key, Aes256Cipher};
+/// use vitaminc_aead::test_utils::TestCipher;
 ///
-/// let key = Key::from([0u8; 32]);
-/// let cipher = Aes256Cipher::new(&key).expect("cipher creation failed");
+/// let cipher = TestCipher;
 ///
 /// let tagged = ContextTag::new("secret message", "user:42");
 /// let ciphertext = tagged.encrypt(&cipher).expect("encryption failed");
@@ -69,10 +68,9 @@ use crate::{Cipher, Decrypt, Encrypt, IntoAad, Unspecified};
 ///
 /// ```
 /// use vitaminc_aead::{ContextTag, Encrypt, Decrypt};
-/// use vitaminc_encrypt::{Key, Aes256Cipher};
+/// use vitaminc_aead::test_utils::TestCipher;
 ///
-/// let key = Key::from([0u8; 32]);
-/// let cipher = Aes256Cipher::new(&key).expect("cipher creation failed");
+/// let cipher = TestCipher;
 ///
 /// let tagged = ContextTag::new("secret", "table:users");
 /// let ciphertext = tagged
@@ -96,10 +94,9 @@ use crate::{Cipher, Decrypt, Encrypt, IntoAad, Unspecified};
 ///
 /// ```
 /// use vitaminc_aead::{ContextTag, Encrypt, Decrypt};
-/// use vitaminc_encrypt::{Key, Aes256Cipher};
+/// use vitaminc_aead::test_utils::TestCipher;
 ///
-/// let key = Key::from([0u8; 32]);
-/// let cipher = Aes256Cipher::new(&key).expect("cipher creation failed");
+/// let cipher = TestCipher;
 ///
 /// let tagged = ContextTag::new("secret", "user:42");
 /// let ciphertext = tagged.encrypt(&cipher).expect("encryption failed");
@@ -116,10 +113,9 @@ use crate::{Cipher, Decrypt, Encrypt, IntoAad, Unspecified};
 ///
 /// ```
 /// use vitaminc_aead::{ContextTag, Encrypt};
-/// use vitaminc_encrypt::{Key, Aes256Cipher};
+/// use vitaminc_aead::test_utils::TestCipher;
 ///
-/// let key = Key::from([0u8; 32]);
-/// let cipher = Aes256Cipher::new(&key).expect("cipher creation failed");
+/// let cipher = TestCipher;
 ///
 /// // &str tags work naturally — no String::from() needed
 /// let tagged = ContextTag::new(vec![1u8, 2, 3], "my-context");
@@ -140,10 +136,9 @@ impl<Tag, T> ContextTag<Tag, T> {
     ///
     /// ```
     /// use vitaminc_aead::{ContextTag, Encrypt};
-    /// use vitaminc_encrypt::{Key, Aes256Cipher};
+    /// use vitaminc_aead::test_utils::TestCipher;
     ///
-    /// let key = Key::from([0u8; 32]);
-    /// let cipher = Aes256Cipher::new(&key).expect("cipher creation failed");
+    /// let cipher = TestCipher;
     ///
     /// let tagged = ContextTag::new("hello", "my-tag");
     /// let ciphertext = tagged.encrypt(&cipher).expect("encryption failed");
@@ -165,10 +160,9 @@ impl<Tag, T> ContextTag<Tag, T> {
     ///
     /// ```
     /// use vitaminc_aead::{ContextTag, Encrypt, Decrypt};
-    /// use vitaminc_encrypt::{Key, Aes256Cipher};
+    /// use vitaminc_aead::test_utils::TestCipher;
     ///
-    /// let key = Key::from([0u8; 32]);
-    /// let cipher = Aes256Cipher::new(&key).expect("cipher creation failed");
+    /// let cipher = TestCipher;
     ///
     /// let tagged = ContextTag::new("secret", "table:users")
     ///     .refine("column:email");
@@ -189,10 +183,9 @@ impl<Tag, T> ContextTag<Tag, T> {
     ///
     /// ```
     /// use vitaminc_aead::{ContextTag, Encrypt, Decrypt};
-    /// use vitaminc_encrypt::{Key, Aes256Cipher};
+    /// use vitaminc_aead::test_utils::TestCipher;
     ///
-    /// let key = Key::from([0u8; 32]);
-    /// let cipher = Aes256Cipher::new(&key).expect("cipher creation failed");
+    /// let cipher = TestCipher;
     ///
     /// let tagged = ContextTag::new("data", "a")
     ///     .refine("b")
@@ -249,10 +242,9 @@ impl<Tag> ContextTag<Tag, ()> {
     ///
     /// ```
     /// use vitaminc_aead::{ContextTag, Encrypt, Decrypt};
-    /// use vitaminc_encrypt::{Key, Aes256Cipher};
+    /// use vitaminc_aead::test_utils::TestCipher;
     ///
-    /// let key = Key::from([0u8; 32]);
-    /// let cipher = Aes256Cipher::new(&key).expect("cipher creation failed");
+    /// let cipher = TestCipher;
     ///
     /// let tagged = ContextTag::new("secret message", "user:42");
     /// let ciphertext = tagged.encrypt(&cipher).expect("encryption failed");
@@ -284,10 +276,9 @@ impl<Tag> ContextTag<Tag, ()> {
     ///
     /// ```
     /// use vitaminc_aead::{ContextTag, Encrypt, Decrypt};
-    /// use vitaminc_encrypt::{Key, Aes256Cipher};
+    /// use vitaminc_aead::test_utils::TestCipher;
     ///
-    /// let key = Key::from([0u8; 32]);
-    /// let cipher = Aes256Cipher::new(&key).expect("cipher creation failed");
+    /// let cipher = TestCipher;
     ///
     /// let tagged = ContextTag::new("secret", "table:users");
     /// let ciphertext = tagged

--- a/packages/aead/src/lib.rs
+++ b/packages/aead/src/lib.rs
@@ -7,6 +7,8 @@ mod context;
 mod decrypt;
 mod encrypt;
 mod nonce;
+#[cfg(feature = "test-utils")]
+pub mod test_utils;
 
 #[doc(inline)]
 pub use aad::{Aad, IntoAad};

--- a/packages/aead/src/test_utils.rs
+++ b/packages/aead/src/test_utils.rs
@@ -1,0 +1,78 @@
+//! Test utilities for `vitaminc-aead`.
+//!
+//! Provides [`TestCipher`], a no-dependency cipher for use in doctests and
+//! examples. It is **not** cryptographically secure — it simply stores the
+//! plaintext alongside the AAD so that decryption can verify the AAD matches.
+
+use crate::{Cipher, IntoAad, LocalCipherText, Unspecified};
+
+/// A cipher that performs no real encryption.
+///
+/// `TestCipher` embeds the AAD into the "ciphertext" during encryption and
+/// verifies it during decryption. This allows doctests to exercise the full
+/// encrypt/decrypt round-trip — including AAD mismatch detection — without
+/// depending on a real cipher implementation.
+pub struct TestCipher;
+
+impl Cipher for TestCipher {
+    fn encrypt_slice<'a, A>(
+        &self,
+        plaintext: &'a [u8],
+        aad: A,
+    ) -> Result<LocalCipherText, Unspecified>
+    where
+        A: IntoAad<'a>,
+    {
+        let aad_bytes = aad.into_aad();
+        let aad_bytes = aad_bytes.as_bytes();
+        let aad_len = (aad_bytes.len() as u32).to_le_bytes();
+
+        let mut out = Vec::with_capacity(4 + aad_bytes.len() + plaintext.len());
+        out.extend_from_slice(&aad_len);
+        out.extend_from_slice(aad_bytes);
+        out.extend_from_slice(plaintext);
+        Ok(LocalCipherText::from(out))
+    }
+
+    fn encrypt_vec<'a, A>(&self, plaintext: Vec<u8>, aad: A) -> Result<LocalCipherText, Unspecified>
+    where
+        A: IntoAad<'a>,
+    {
+        let aad_bytes = aad.into_aad();
+        let aad_bytes = aad_bytes.as_bytes();
+        let aad_len = (aad_bytes.len() as u32).to_le_bytes();
+
+        let mut out = Vec::with_capacity(4 + aad_bytes.len() + plaintext.len());
+        out.extend_from_slice(&aad_len);
+        out.extend_from_slice(aad_bytes);
+        out.extend_from_slice(&plaintext);
+        Ok(LocalCipherText::from(out))
+    }
+
+    fn decrypt_vec<'a, A>(
+        &self,
+        ciphertext: LocalCipherText,
+        aad: A,
+    ) -> Result<Vec<u8>, Unspecified>
+    where
+        A: IntoAad<'a>,
+    {
+        let data = ciphertext.into_inner();
+        if data.len() < 4 {
+            return Err(Unspecified);
+        }
+
+        let aad_len = u32::from_le_bytes(data[..4].try_into().map_err(|_| Unspecified)?) as usize;
+        if data.len() < 4 + aad_len {
+            return Err(Unspecified);
+        }
+
+        let stored_aad = &data[4..4 + aad_len];
+        let expected_aad = aad.into_aad();
+        if stored_aad != expected_aad.as_bytes() {
+            return Err(Unspecified);
+        }
+
+        Ok(data[4 + aad_len..].to_vec())
+    }
+}


### PR DESCRIPTION
## Summary

- Removes the circular dev-dependency between `vitaminc-aead` and `vitaminc-encrypt` that prevented `cargo publish`
- Adds a feature-gated `test-utils` module with `TestCipher` — a no-op cipher that embeds AAD for round-trip verification
- Updates all doctests in `context.rs` and `README.md` to use `TestCipher` instead of `Aes256Cipher`