### PR TITLE
feat(encrypt): add wasm32 support via RustCrypto backend

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,6 @@
+# `getrandom 0.3+` requires this rustflag to select the browser/Deno backend
+# when building for wasm32-unknown-unknown. Without it, the crate fails to
+# compile because no backend is selected.
+# See: https://docs.rs/getrandom/latest/getrandom/#opt-in-backends
+[target.wasm32-unknown-unknown]
+rustflags = ['--cfg', 'getrandom_backend="wasm_js"']

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,3 +69,14 @@ jobs:
 
       - name: build check (vitaminc-encrypt, wasm32)
         run: cargo check --target wasm32-unknown-unknown -p vitaminc-encrypt
+
+      - name: install wasm-pack
+        uses: jetli/wasm-pack-action@v0.4.0
+        with:
+          version: 'latest'
+
+      - name: test (vitaminc-encrypt, wasm32 in Node)
+        # Compiles to wasm32-unknown-unknown and runs tests inside Node — this
+        # is what gates the *actual* wasm codegen path (the native
+        # `_test-rust-crypto-backend` step above is just a proxy).
+        run: wasm-pack test --node packages/encrypt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
+          targets: wasm32-unknown-unknown
 
       - name: Start LocalStack
         uses: LocalStack/setup-localstack@v0.3.2
@@ -43,11 +44,28 @@ jobs:
         env:
           LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
 
-      - name: clippy
-        run: cargo clippy --no-deps --all-targets --all-features  -- -D warnings
+      - name: clippy (all features)
+        # `--all-features` enables `_test-rust-crypto-backend`, which selects
+        # the RustCrypto encrypt backend on native. The step below covers the
+        # aws-lc-rs path that this configuration leaves unchecked.
+        run: cargo clippy --no-deps --all-targets --all-features -- -D warnings
+
+      - name: clippy (vitaminc-encrypt, aws-lc-rs backend)
+        run: cargo clippy --no-deps -p vitaminc-encrypt --all-targets -- -D warnings
+
+      - name: clippy (vitaminc-encrypt, wasm32)
+        run: cargo clippy --no-deps --target wasm32-unknown-unknown -p vitaminc-encrypt --tests -- -D warnings
 
       - name: format
         run: cargo fmt -- --check
 
-      - name: test
+      - name: test (default — aws-lc-rs backend)
         run: cargo test
+
+      - name: test (vitaminc-encrypt, RustCrypto backend on native)
+        # Forces the RustCrypto path that wasm32 uses, so the same property
+        # tests run against both backends in CI.
+        run: cargo test -p vitaminc-encrypt --features _test-rust-crypto-backend
+
+      - name: build check (vitaminc-encrypt, wasm32)
+        run: cargo check --target wasm32-unknown-unknown -p vitaminc-encrypt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,9 +71,10 @@ jobs:
         run: cargo check --target wasm32-unknown-unknown -p vitaminc-encrypt
 
       - name: install wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: 'latest'
+        # Inline via the official install script — avoids depending on a
+        # third-party GitHub Action that the org actions allowlist may not
+        # permit.
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - name: test (vitaminc-encrypt, wasm32 in Node)
         # Compiles to wasm32-unknown-unknown and runs tests inside Node — this

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,7 @@ dependencies = [
  "ctr",
  "ghash",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -51,6 +52,17 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "atomic-waker"
@@ -544,6 +556,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -845,6 +863,7 @@ dependencies = [
  "futures-core",
  "futures-task",
  "pin-project-lite",
+ "slab",
 ]
 
 [[package]]
@@ -1331,6 +1350,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1349,6 +1374,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1356,6 +1391,15 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
  "windows-sys 0.61.2",
 ]
 
@@ -1381,6 +1425,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1388,6 +1433,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "opaque-debug"
@@ -1700,6 +1751,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -2219,6 +2279,7 @@ dependencies = [
  "vitaminc-aead",
  "vitaminc-protected",
  "vitaminc-random",
+ "wasm-bindgen-test",
  "zeroize",
 ]
 
@@ -2325,6 +2386,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2371,6 +2442,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2401,6 +2486,45 @@ checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6311c867385cc7d5602463b31825d454d0837a3aba7cdb5e56d5201792a3f7fe"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67008cdde4769831958536b0f11b3bdd0380bde882be17fff9c2f34bb4549abd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe29135b180b72b04c74aa97b2b4a2ef275161eff9a6c7955ea9eaedc7e1d4e"
 
 [[package]]
 name = "wasm-encoder"
@@ -2434,6 +2558,25 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,41 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,6 +573,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -609,6 +654,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -833,11 +887,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -1212,6 +1278,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1315,6 +1390,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1349,6 +1430,18 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "potential_utf"
@@ -2017,6 +2110,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2109,6 +2212,7 @@ dependencies = [
 name = "vitaminc-encrypt"
 version = "0.1.0-pre4.2"
 dependencies = [
+ "aes-gcm",
  "aws-lc-rs",
  "quickcheck",
  "quickcheck_macros",
@@ -2183,6 +2287,7 @@ dependencies = [
 name = "vitaminc-random"
 version = "0.1.0-pre4.2"
 dependencies = [
+ "getrandom 0.4.2",
  "rand",
  "thiserror",
  "vitaminc-protected",

--- a/packages/encrypt/Cargo.toml
+++ b/packages/encrypt/Cargo.toml
@@ -12,12 +12,20 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-aws-lc-rs = "1.16.3"
 vitaminc-aead = { version = "0.1.0-pre4.2", path = "../aead" }
 vitaminc-protected = { version = "0.1.0-pre4.2", path = "../protected" }
 vitaminc-random = { version = "0.1.0-pre4.2", path = "../random" }
 
 zeroize = { workspace = true }
+
+# Native: aws-lc-rs (FIPS-validated, AES-NI accelerated).
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+aws-lc-rs = "1.16.3"
+
+# Wasm32: pure-Rust AES-256-GCM. aws-lc-rs has C deps (aws-lc-sys) that
+# don't compile on wasm32-unknown-unknown.
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+aes-gcm = { version = "0.10", default-features = false, features = ["aes", "alloc"] }
 
 [dev-dependencies]
 vitaminc-protected = { path = "../protected", version = "0.1.0-pre4.2", features = ["arbitrary"] }

--- a/packages/encrypt/Cargo.toml
+++ b/packages/encrypt/Cargo.toml
@@ -24,12 +24,14 @@ zeroize = { workspace = true }
 # CI testing of the wasm32 backend on a native runner.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 aws-lc-rs = "1.16.3"
-aes-gcm = { version = "0.10", default-features = false, features = ["aes", "alloc"], optional = true }
+aes-gcm = { version = "0.10", default-features = false, features = ["aes", "alloc", "zeroize"], optional = true }
 
 # Wasm32: pure-Rust AES-256-GCM. aws-lc-rs has C deps (aws-lc-sys) that
-# don't compile on wasm32-unknown-unknown.
+# don't compile on wasm32-unknown-unknown. `zeroize` clears the AES round-key
+# schedule and GHASH state on drop — matches the defence-in-depth posture the
+# rest of the vitaminc stack already takes via `vitaminc-protected`.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-aes-gcm = { version = "0.10", default-features = false, features = ["aes", "alloc"] }
+aes-gcm = { version = "0.10", default-features = false, features = ["aes", "alloc", "zeroize"] }
 
 [features]
 # Internal/test-only. Forces the RustCrypto (`aes-gcm`) backend on native
@@ -43,3 +45,9 @@ _test-rust-crypto-backend = ["dep:aes-gcm"]
 vitaminc-protected = { path = "../protected", version = "0.1.0-pre4.2", features = ["arbitrary"] }
 quickcheck = "1.1.0"
 quickcheck_macros = "1.2.0"
+
+# wasm-bindgen-test drives `wasm-pack test --node`, which compiles the crate
+# to wasm32-unknown-unknown and runs tests inside Node — exercising the same
+# codegen that downstream wasm consumers will see, not the proxied native path.
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.3"

--- a/packages/encrypt/Cargo.toml
+++ b/packages/encrypt/Cargo.toml
@@ -19,13 +19,25 @@ vitaminc-random = { version = "0.1.0-pre4.2", path = "../random" }
 zeroize = { workspace = true }
 
 # Native: aws-lc-rs (FIPS-validated, AES-NI accelerated).
+# `aes-gcm` is normally only used on wasm32, but is exposed here as an
+# optional dep so the `_test-rust-crypto-backend` feature can pull it in for
+# CI testing of the wasm32 backend on a native runner.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 aws-lc-rs = "1.16.3"
+aes-gcm = { version = "0.10", default-features = false, features = ["aes", "alloc"], optional = true }
 
 # Wasm32: pure-Rust AES-256-GCM. aws-lc-rs has C deps (aws-lc-sys) that
 # don't compile on wasm32-unknown-unknown.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 aes-gcm = { version = "0.10", default-features = false, features = ["aes", "alloc"] }
+
+[features]
+# Internal/test-only. Forces the RustCrypto (`aes-gcm`) backend on native
+# targets so CI can run the same test suite against both backends without
+# wasm tooling. Wasm32 always uses RustCrypto regardless of this feature.
+# Underscore prefix marks it as not part of the public API — do not enable
+# from production deps.
+_test-rust-crypto-backend = ["dep:aes-gcm"]
 
 [dev-dependencies]
 vitaminc-protected = { path = "../protected", version = "0.1.0-pre4.2", features = ["arbitrary"] }

--- a/packages/encrypt/README.md
+++ b/packages/encrypt/README.md
@@ -10,7 +10,8 @@ This crate is part of the [Vitamin C](https://github.com/cipherstash/vitaminc) f
 ## Features
 
 - **Type-safe encryption**: Encrypt and decrypt Rust types with compile-time safety
-- **AES-256-GCM**: Uses AES-256-GCM authenticated encryption via AWS-LC
+- **AES-256-GCM**: Hardware-accelerated authenticated encryption — `aws-lc-rs` on native targets, RustCrypto's `aes-gcm` on `wasm32`. Both produce byte-identical ciphertext, so a value sealed in one environment opens cleanly in the other.
+- **`wasm32-unknown-unknown` support**: Builds and runs in browsers, Node.js, and edge runtimes (e.g. Supabase Edge Functions, Cloudflare Workers) with no C toolchain or feature flags
 - **256-bit keys only**: Enforces quantum-resistant key sizes for future security
 - **Protected types integration**: Works seamlessly with `vitaminc-protected` for sensitive data handling
 - **Additional Authenticated Data (AAD)**: Support for authenticated but unencrypted data
@@ -48,7 +49,7 @@ assert_eq!(plaintext, "secret message");
 
 ### Key Management
 
-The [`Key`] type represents a 256-bit encryption key. Vitamin C only supports 256-bit keys to ensure quantum security and compatibility with AWS-LC.
+The [`Key`] type represents a 256-bit encryption key. Vitamin C only supports 256-bit keys to ensure quantum security and consistent behaviour across both backends.
 
 #### Generating a Key
 
@@ -294,16 +295,25 @@ This crate uses AES-256-GCM (Galois/Counter Mode) which provides:
 - **Authenticity**: Built-in authentication prevents tampering
 - **Performance**: Hardware-accelerated on most modern CPUs
 
-### AWS-LC
+### Cryptographic Backends
 
-Encryption is powered by [AWS-LC](https://github.com/aws/aws-lc-rs), a FIPS-validated cryptographic library maintained by Amazon Web Services.
+The AES-256-GCM implementation is selected at compile time based on the target architecture — there is no feature flag to choose between them, and downstream code uses the same `Aes256Cipher` API regardless.
+
+| Target                                | Backend                                                                                    | Notes                                                                                  |
+| ------------------------------------- | ------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
+| `cfg(not(target_arch = "wasm32"))`    | [AWS-LC](https://github.com/aws/aws-lc-rs)                                                 | FIPS-validated, AES-NI accelerated. Maintained by Amazon Web Services.                 |
+| `cfg(target_arch = "wasm32")`         | [RustCrypto `aes-gcm`](https://github.com/RustCrypto/AEADs/tree/master/aes-gcm) | Pure Rust, no C toolchain. Required because `aws-lc-rs`'s C deps don't cross-compile to wasm. |
+
+Both backends conform to RFC 5116 AES-256-GCM and produce byte-identical ciphertext for the same inputs. CI gates this with a Known-Answer Test that runs against all three configurations on every PR — native `aws-lc-rs`, native RustCrypto, and RustCrypto compiled to `wasm32-unknown-unknown` and executed in Node via `wasm-pack test --node`.
+
+This means ciphertext written from a native server can be opened in a browser or edge runtime (and vice versa) without any compatibility shim.
 
 ### 256-bit Keys Only
 
 Vitamin C enforces 256-bit keys to ensure:
 
 - Resistance to quantum computer attacks (via AES-256)
-- Compatibility with AWS-LC's recommended parameters
+- Consistent parameters across both the AWS-LC and RustCrypto backends
 - No risk of accidentally using weaker key sizes
 
 ### Automatic Nonce Generation
@@ -328,8 +338,10 @@ Encryption and decryption operations return an [`Unspecified`] error type that r
 Vitamin C Encrypt is designed for both security and performance:
 
 - **Zero-copy operations** where possible
-- **Hardware acceleration** via AWS-LC's AES-NI support
+- **Hardware acceleration** via AWS-LC's AES-NI support on native targets
 - **Minimal allocations** during encryption/decryption
+
+On `wasm32-unknown-unknown` the RustCrypto backend takes over and runs as pure Rust — slower than AES-NI but still constant-time and substantially faster than a JavaScript polyfill.
 
 ## Error Handling
 

--- a/packages/encrypt/src/backend.rs
+++ b/packages/encrypt/src/backend.rs
@@ -33,19 +33,25 @@ pub(crate) const TAG_LEN: usize = 16;
 mod tests {
     use super::CipherKey;
 
+    // wasm-pack invokes Node by default — no `wasm_bindgen_test_configure!` needed.
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test;
+
     /// Cross-backend byte-parity check.
     ///
-    /// CI runs this same test against both backends:
-    /// - `cargo test -p vitaminc-encrypt` exercises `aws-lc-rs`
+    /// CI runs this same test against all three configurations:
+    /// - `cargo test -p vitaminc-encrypt` — `aws-lc-rs` on native
     /// - `cargo test -p vitaminc-encrypt --features _test-rust-crypto-backend`
-    ///   exercises RustCrypto's `aes-gcm`
+    ///   — RustCrypto on native
+    /// - `wasm-pack test --node packages/encrypt` — RustCrypto compiled to
+    ///   wasm32-unknown-unknown and run in Node
     ///
-    /// Both must produce the byte string in `EXPECTED`. If they agree, the two
-    /// backends are byte-identical for this input — which, with their
-    /// RFC 5116 conformance, is what guarantees ciphertexts written under one
-    /// backend decrypt cleanly under the other (the whole point of supporting
-    /// wasm32 alongside native).
-    #[test]
+    /// All three must produce the byte string in `EXPECTED`. The third gates
+    /// the actual wasm codegen path (not just the proxied native build) — so a
+    /// regression that only surfaces under wasm32 (e.g. SIMD intrinsic fallback,
+    /// 32-bit pointer arithmetic) would still be caught.
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn cross_backend_byte_parity() {
         // Fixed inputs — chosen to exercise: non-empty plaintext, non-empty AAD,
         // a plaintext length that's not a block boundary (so we cover GCM's

--- a/packages/encrypt/src/backend.rs
+++ b/packages/encrypt/src/backend.rs
@@ -83,9 +83,11 @@ mod tests {
         );
 
         let mut to_open = sealed.clone();
-        let pt_len = cipher
-            .open(&nonce, aad, &mut to_open)
-            .expect("open failed");
-        assert_eq!(&to_open[..pt_len], plaintext, "round-trip plaintext mismatch");
+        let pt_len = cipher.open(&nonce, aad, &mut to_open).expect("open failed");
+        assert_eq!(
+            &to_open[..pt_len],
+            plaintext,
+            "round-trip plaintext mismatch"
+        );
     }
 }

--- a/packages/encrypt/src/backend.rs
+++ b/packages/encrypt/src/backend.rs
@@ -96,4 +96,123 @@ mod tests {
             "round-trip plaintext mismatch"
         );
     }
+
+    // Deterministic counterparts to the quickcheck round-trip tests in
+    // `cipher::test`. Those property tests can't run under wasm-bindgen-test
+    // because quickcheck's runner uses `std::thread`, which isn't available on
+    // wasm32-unknown-unknown — so the cases below carry the same `#[cfg_attr]`
+    // attribute swap as the KAT and gate all three configurations (native
+    // aws-lc-rs, native RustCrypto, wasm32 RustCrypto in Node) on the same
+    // round-trip and failure-path behaviour.
+
+    fn fixed_key() -> [u8; 32] {
+        [
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,
+            0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b,
+            0x1c, 0x1d, 0x1e, 0x1f,
+        ]
+    }
+
+    fn fixed_nonce() -> [u8; 12] {
+        [
+            0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab,
+        ]
+    }
+
+    fn roundtrip(plaintext: &[u8], aad: &[u8]) {
+        let key = fixed_key();
+        let nonce = fixed_nonce();
+        let cipher = CipherKey::new(&key).expect("key");
+
+        let mut buf = plaintext.to_vec();
+        cipher.seal(&nonce, aad, &mut buf).expect("seal");
+
+        let pt_len = cipher.open(&nonce, aad, &mut buf).expect("open");
+        assert_eq!(&buf[..pt_len], plaintext);
+    }
+
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn roundtrip_no_aad() {
+        roundtrip(b"hello world", b"");
+    }
+
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn roundtrip_with_aad() {
+        roundtrip(b"hello world", b"associated data");
+    }
+
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn roundtrip_empty_plaintext() {
+        roundtrip(b"", b"some aad");
+    }
+
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn roundtrip_multi_block_plaintext() {
+        // 200 bytes — spans multiple AES blocks (16B each) plus a partial tail,
+        // catching any block-boundary handling regression.
+        let pt: Vec<u8> = (0..200u8).collect();
+        roundtrip(&pt, b"multi-block aad");
+    }
+
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn open_fails_with_wrong_aad() {
+        let key = fixed_key();
+        let nonce = fixed_nonce();
+        let cipher = CipherKey::new(&key).expect("key");
+
+        let mut buf = b"payload".to_vec();
+        cipher.seal(&nonce, b"correct-aad", &mut buf).expect("seal");
+
+        let mut tampered = buf.clone();
+        assert!(
+            cipher.open(&nonce, b"wrong-aad", &mut tampered).is_err(),
+            "open must reject mismatched AAD"
+        );
+    }
+
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn open_fails_with_wrong_key() {
+        let nonce = fixed_nonce();
+
+        let key_a = fixed_key();
+        let mut key_b = fixed_key();
+        key_b[0] ^= 0xff;
+
+        let cipher_a = CipherKey::new(&key_a).expect("key a");
+        let cipher_b = CipherKey::new(&key_b).expect("key b");
+
+        let mut buf = b"payload".to_vec();
+        cipher_a.seal(&nonce, b"", &mut buf).expect("seal");
+
+        assert!(
+            cipher_b.open(&nonce, b"", &mut buf).is_err(),
+            "open must reject ciphertext sealed under a different key"
+        );
+    }
+
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn open_fails_with_tampered_ciphertext() {
+        let key = fixed_key();
+        let nonce = fixed_nonce();
+        let cipher = CipherKey::new(&key).expect("key");
+
+        let mut buf = b"payload".to_vec();
+        cipher.seal(&nonce, b"", &mut buf).expect("seal");
+
+        // Flip a bit in the ciphertext (not the tag) — GCM authentication
+        // must catch this.
+        buf[0] ^= 0x01;
+
+        assert!(
+            cipher.open(&nonce, b"", &mut buf).is_err(),
+            "open must reject ciphertext whose bytes have been modified"
+        );
+    }
 }

--- a/packages/encrypt/src/backend.rs
+++ b/packages/encrypt/src/backend.rs
@@ -1,0 +1,27 @@
+//! Backend abstraction over AES-256-GCM implementations.
+//!
+//! Two implementations are selected via `cfg`:
+//!
+//! - **Native** (`cfg(not(target_arch = "wasm32"))`): `aws-lc-rs` —
+//!   FIPS-validated, hardware-accelerated.
+//! - **Wasm32** (`cfg(target_arch = "wasm32")`): `aes-gcm` from RustCrypto —
+//!   pure Rust, builds without a C toolchain.
+//!
+//! Both implementations conform to RFC 5116 AES-256-GCM and produce
+//! byte-identical ciphertext+tag output for the same inputs.
+
+#[cfg(not(target_arch = "wasm32"))]
+mod aws_lc;
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) use aws_lc::CipherKey;
+
+#[cfg(target_arch = "wasm32")]
+mod rust_crypto;
+#[cfg(target_arch = "wasm32")]
+pub(crate) use rust_crypto::CipherKey;
+
+/// AES-256-GCM nonce length, in bytes.
+pub(crate) const NONCE_LEN: usize = 12;
+
+/// AES-256-GCM authentication tag length, in bytes.
+pub(crate) const TAG_LEN: usize = 16;

--- a/packages/encrypt/src/backend.rs
+++ b/packages/encrypt/src/backend.rs
@@ -9,16 +9,19 @@
 //!
 //! Both implementations conform to RFC 5116 AES-256-GCM and produce
 //! byte-identical ciphertext+tag output for the same inputs.
+//!
+//! The internal `_test-rust-crypto-backend` feature forces the RustCrypto
+//! backend on native targets so CI can exercise it without wasm tooling.
 
-#[cfg(not(target_arch = "wasm32"))]
-mod aws_lc;
-#[cfg(not(target_arch = "wasm32"))]
-pub(crate) use aws_lc::CipherKey;
-
-#[cfg(target_arch = "wasm32")]
+#[cfg(any(target_arch = "wasm32", feature = "_test-rust-crypto-backend"))]
 mod rust_crypto;
-#[cfg(target_arch = "wasm32")]
+#[cfg(any(target_arch = "wasm32", feature = "_test-rust-crypto-backend"))]
 pub(crate) use rust_crypto::CipherKey;
+
+#[cfg(not(any(target_arch = "wasm32", feature = "_test-rust-crypto-backend")))]
+mod aws_lc;
+#[cfg(not(any(target_arch = "wasm32", feature = "_test-rust-crypto-backend")))]
+pub(crate) use aws_lc::CipherKey;
 
 /// AES-256-GCM nonce length, in bytes.
 pub(crate) const NONCE_LEN: usize = 12;

--- a/packages/encrypt/src/backend.rs
+++ b/packages/encrypt/src/backend.rs
@@ -28,3 +28,64 @@ pub(crate) const NONCE_LEN: usize = 12;
 
 /// AES-256-GCM authentication tag length, in bytes.
 pub(crate) const TAG_LEN: usize = 16;
+
+#[cfg(test)]
+mod tests {
+    use super::CipherKey;
+
+    /// Cross-backend byte-parity check.
+    ///
+    /// CI runs this same test against both backends:
+    /// - `cargo test -p vitaminc-encrypt` exercises `aws-lc-rs`
+    /// - `cargo test -p vitaminc-encrypt --features _test-rust-crypto-backend`
+    ///   exercises RustCrypto's `aes-gcm`
+    ///
+    /// Both must produce the byte string in `EXPECTED`. If they agree, the two
+    /// backends are byte-identical for this input — which, with their
+    /// RFC 5116 conformance, is what guarantees ciphertexts written under one
+    /// backend decrypt cleanly under the other (the whole point of supporting
+    /// wasm32 alongside native).
+    #[test]
+    fn cross_backend_byte_parity() {
+        // Fixed inputs — chosen to exercise: non-empty plaintext, non-empty AAD,
+        // a plaintext length that's not a block boundary (so we cover GCM's
+        // partial-block handling).
+        let key: [u8; 32] = [
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,
+            0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b,
+            0x1c, 0x1d, 0x1e, 0x1f,
+        ];
+        let nonce: [u8; 12] = [
+            0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab,
+        ];
+        let plaintext = b"vitaminc cross-backend parity vector";
+        let aad = b"vitaminc-encrypt KAT v1";
+
+        // Ciphertext (36 bytes) || GCM tag (16 bytes), computed deterministically
+        // from the inputs above by an RFC 5116 AES-256-GCM implementation.
+        // Verified to be produced identically by both `aws-lc-rs` and RustCrypto
+        // `aes-gcm` when this test was introduced.
+        const EXPECTED: [u8; 52] = [
+            0x90, 0x71, 0x08, 0x4c, 0x28, 0xa2, 0x6c, 0xdc, 0x42, 0x06, 0xf5, 0xbc, 0x74, 0x09,
+            0xed, 0xbc, 0x11, 0xcf, 0x32, 0x75, 0xfc, 0xd3, 0x62, 0x1c, 0xfd, 0x7c, 0x4f, 0xf2,
+            0x06, 0x8b, 0x03, 0x64, 0xb1, 0x02, 0x28, 0x8d, 0xed, 0x9a, 0xa3, 0xcf, 0x46, 0x3d,
+            0xa6, 0xb2, 0x0e, 0x7f, 0x86, 0x23, 0x76, 0x7a, 0xfb, 0x0a,
+        ];
+
+        let cipher = CipherKey::new(&key).expect("key construction failed");
+
+        let mut sealed = plaintext.to_vec();
+        cipher.seal(&nonce, aad, &mut sealed).expect("seal failed");
+        assert_eq!(
+            sealed,
+            EXPECTED.as_slice(),
+            "ciphertext+tag diverged from cross-backend KAT"
+        );
+
+        let mut to_open = sealed.clone();
+        let pt_len = cipher
+            .open(&nonce, aad, &mut to_open)
+            .expect("open failed");
+        assert_eq!(&to_open[..pt_len], plaintext, "round-trip plaintext mismatch");
+    }
+}

--- a/packages/encrypt/src/backend/aws_lc.rs
+++ b/packages/encrypt/src/backend/aws_lc.rs
@@ -11,29 +11,29 @@ impl CipherKey {
         Ok(Self(LessSafeKey::new(unbound)))
     }
 
-    /// Encrypts `in_out` in place and appends the 16-byte tag.
-    pub(crate) fn seal_in_place_append_tag(
+    /// Encrypts `in_out` in place and appends the authentication tag.
+    pub(crate) fn seal(
         &self,
-        nonce: &[u8; super::NONCE_LEN],
+        nonce: &[u8],
         aad: &[u8],
         in_out: &mut Vec<u8>,
     ) -> Result<(), Unspecified> {
-        let nonce = LcNonce::try_assume_unique_for_key(nonce.as_ref()).map_err(|_| Unspecified)?;
+        let nonce = LcNonce::try_assume_unique_for_key(nonce).map_err(|_| Unspecified)?;
         self.0
             .seal_in_place_append_tag(nonce, LcAad::from(aad), in_out)
             .map_err(|_| Unspecified)?;
         Ok(())
     }
 
-    /// Decrypts `in_out` (which contains ciphertext || tag) in place. Returns
-    /// the plaintext length — `in_out[..len]` is the plaintext after the call.
-    pub(crate) fn open_in_place(
+    /// Decrypts `in_out` (ciphertext || tag) in place. Returns the plaintext
+    /// length — `in_out[..len]` is the plaintext after the call.
+    pub(crate) fn open(
         &self,
-        nonce: &[u8; super::NONCE_LEN],
+        nonce: &[u8],
         aad: &[u8],
         in_out: &mut [u8],
     ) -> Result<usize, Unspecified> {
-        let nonce = LcNonce::assume_unique_for_key(*nonce);
+        let nonce = LcNonce::try_assume_unique_for_key(nonce).map_err(|_| Unspecified)?;
         self.0
             .open_in_place(nonce, LcAad::from(aad), in_out)
             .map(|plaintext| plaintext.len())

--- a/packages/encrypt/src/backend/aws_lc.rs
+++ b/packages/encrypt/src/backend/aws_lc.rs
@@ -1,0 +1,42 @@
+//! `aws-lc-rs` backend for AES-256-GCM.
+
+use aws_lc_rs::aead::{Aad as LcAad, LessSafeKey, Nonce as LcNonce, UnboundKey, AES_256_GCM};
+use vitaminc_aead::Unspecified;
+
+pub(crate) struct CipherKey(LessSafeKey);
+
+impl CipherKey {
+    pub(crate) fn new(key_bytes: &[u8; 32]) -> Result<Self, Unspecified> {
+        let unbound = UnboundKey::new(&AES_256_GCM, key_bytes.as_ref()).map_err(|_| Unspecified)?;
+        Ok(Self(LessSafeKey::new(unbound)))
+    }
+
+    /// Encrypts `in_out` in place and appends the 16-byte tag.
+    pub(crate) fn seal_in_place_append_tag(
+        &self,
+        nonce: &[u8; super::NONCE_LEN],
+        aad: &[u8],
+        in_out: &mut Vec<u8>,
+    ) -> Result<(), Unspecified> {
+        let nonce = LcNonce::try_assume_unique_for_key(nonce.as_ref()).map_err(|_| Unspecified)?;
+        self.0
+            .seal_in_place_append_tag(nonce, LcAad::from(aad), in_out)
+            .map_err(|_| Unspecified)?;
+        Ok(())
+    }
+
+    /// Decrypts `in_out` (which contains ciphertext || tag) in place. Returns
+    /// the plaintext length — `in_out[..len]` is the plaintext after the call.
+    pub(crate) fn open_in_place(
+        &self,
+        nonce: &[u8; super::NONCE_LEN],
+        aad: &[u8],
+        in_out: &mut [u8],
+    ) -> Result<usize, Unspecified> {
+        let nonce = LcNonce::assume_unique_for_key(*nonce);
+        self.0
+            .open_in_place(nonce, LcAad::from(aad), in_out)
+            .map(|plaintext| plaintext.len())
+            .map_err(|_| Unspecified)
+    }
+}

--- a/packages/encrypt/src/backend/rust_crypto.rs
+++ b/packages/encrypt/src/backend/rust_crypto.rs
@@ -12,40 +12,39 @@ impl CipherKey {
         Ok(Self(Aes256Gcm::new(key)))
     }
 
-    /// Encrypts `in_out` in place and appends the 16-byte tag.
-    pub(crate) fn seal_in_place_append_tag(
+    /// Encrypts `in_out` in place and appends the authentication tag.
+    pub(crate) fn seal(
         &self,
-        nonce: &[u8; super::NONCE_LEN],
+        nonce: &[u8],
         aad: &[u8],
         in_out: &mut Vec<u8>,
     ) -> Result<(), Unspecified> {
+        let nonce: &[u8; super::NONCE_LEN] = nonce.try_into().map_err(|_| Unspecified)?;
         let nonce = Nonce::from_slice(nonce);
-        let tag = self
-            .0
-            .encrypt_in_place_detached(nonce, aad, in_out)
-            .map_err(|_| Unspecified)?;
-        in_out.extend_from_slice(tag.as_slice());
-        Ok(())
+        self.0
+            .encrypt_in_place(nonce, aad, in_out)
+            .map_err(|_| Unspecified)
     }
 
     /// Decrypts `in_out` (ciphertext || tag) in place. Returns the plaintext
     /// length — `in_out[..len]` is the plaintext after the call. The tag bytes
-    /// at the tail are not zeroed but are not part of the returned length.
-    pub(crate) fn open_in_place(
+    /// at the tail are left untouched.
+    pub(crate) fn open(
         &self,
-        nonce: &[u8; super::NONCE_LEN],
+        nonce: &[u8],
         aad: &[u8],
         in_out: &mut [u8],
     ) -> Result<usize, Unspecified> {
-        if in_out.len() < super::TAG_LEN {
-            return Err(Unspecified);
-        }
-        let plaintext_len = in_out.len() - super::TAG_LEN;
-        let (ciphertext, tag_bytes) = in_out.split_at_mut(plaintext_len);
-        let tag = Tag::<Aes256Gcm>::clone_from_slice(tag_bytes);
+        let plaintext_len = in_out
+            .len()
+            .checked_sub(super::TAG_LEN)
+            .ok_or(Unspecified)?;
+        let nonce: &[u8; super::NONCE_LEN] = nonce.try_into().map_err(|_| Unspecified)?;
         let nonce = Nonce::from_slice(nonce);
+        let (ciphertext, tag_bytes) = in_out.split_at_mut(plaintext_len);
+        let tag = Tag::<Aes256Gcm>::from_slice(tag_bytes);
         self.0
-            .decrypt_in_place_detached(nonce, aad, ciphertext, &tag)
+            .decrypt_in_place_detached(nonce, aad, ciphertext, tag)
             .map_err(|_| Unspecified)?;
         Ok(plaintext_len)
     }

--- a/packages/encrypt/src/backend/rust_crypto.rs
+++ b/packages/encrypt/src/backend/rust_crypto.rs
@@ -1,0 +1,52 @@
+//! RustCrypto `aes-gcm` backend for AES-256-GCM.
+
+use aes_gcm::aead::{AeadInPlace, KeyInit, Tag};
+use aes_gcm::{Aes256Gcm, Key, Nonce};
+use vitaminc_aead::Unspecified;
+
+pub(crate) struct CipherKey(Aes256Gcm);
+
+impl CipherKey {
+    pub(crate) fn new(key_bytes: &[u8; 32]) -> Result<Self, Unspecified> {
+        let key = Key::<Aes256Gcm>::from_slice(key_bytes);
+        Ok(Self(Aes256Gcm::new(key)))
+    }
+
+    /// Encrypts `in_out` in place and appends the 16-byte tag.
+    pub(crate) fn seal_in_place_append_tag(
+        &self,
+        nonce: &[u8; super::NONCE_LEN],
+        aad: &[u8],
+        in_out: &mut Vec<u8>,
+    ) -> Result<(), Unspecified> {
+        let nonce = Nonce::from_slice(nonce);
+        let tag = self
+            .0
+            .encrypt_in_place_detached(nonce, aad, in_out)
+            .map_err(|_| Unspecified)?;
+        in_out.extend_from_slice(tag.as_slice());
+        Ok(())
+    }
+
+    /// Decrypts `in_out` (ciphertext || tag) in place. Returns the plaintext
+    /// length — `in_out[..len]` is the plaintext after the call. The tag bytes
+    /// at the tail are not zeroed but are not part of the returned length.
+    pub(crate) fn open_in_place(
+        &self,
+        nonce: &[u8; super::NONCE_LEN],
+        aad: &[u8],
+        in_out: &mut [u8],
+    ) -> Result<usize, Unspecified> {
+        if in_out.len() < super::TAG_LEN {
+            return Err(Unspecified);
+        }
+        let plaintext_len = in_out.len() - super::TAG_LEN;
+        let (ciphertext, tag_bytes) = in_out.split_at_mut(plaintext_len);
+        let tag = Tag::<Aes256Gcm>::clone_from_slice(tag_bytes);
+        let nonce = Nonce::from_slice(nonce);
+        self.0
+            .decrypt_in_place_detached(nonce, aad, ciphertext, &tag)
+            .map_err(|_| Unspecified)?;
+        Ok(plaintext_len)
+    }
+}

--- a/packages/encrypt/src/cipher.rs
+++ b/packages/encrypt/src/cipher.rs
@@ -76,7 +76,12 @@ impl Cipher for Aes256Cipher {
     }
 }
 
-#[cfg(test)]
+// quickcheck doesn't run under `wasm-pack test --node` (it shells out to
+// std::thread, which isn't available on wasm32-unknown-unknown). These property
+// tests already cover both backends on native via the
+// `_test-rust-crypto-backend` feature; the wasm32 codegen path is gated by the
+// KAT in `crate::backend::tests`.
+#[cfg(all(test, not(target_arch = "wasm32")))]
 mod test {
     use super::*;
     use quickcheck_macros::quickcheck;

--- a/packages/encrypt/src/cipher.rs
+++ b/packages/encrypt/src/cipher.rs
@@ -1,23 +1,23 @@
+use crate::backend::{CipherKey, NONCE_LEN, TAG_LEN};
 use crate::Key;
-use aws_lc_rs::aead::{Aad as LcAad, LessSafeKey, Nonce as LcNonce, AES_256_GCM, NONCE_LEN};
 use vitaminc_aead::{
     Cipher, CipherTextBuilder, IntoAad, LocalCipherText, NonceGenerator, RandomNonceGenerator,
     Unspecified,
 };
 use vitaminc_protected::Controlled;
 
-/// Implements the AES-256-GCM cipher using the `aws-lc-rs` library.
+/// Implements AES-256-GCM. Backend is selected at compile time:
+/// `aws-lc-rs` on native targets, `aes-gcm` (RustCrypto) on `wasm32`.
 pub struct Aes256Cipher {
     nonce_generator: RandomNonceGenerator<NONCE_LEN>,
-    key: LessSafeKey,
+    key: CipherKey,
 }
 
 impl Aes256Cipher {
     pub fn new(key: &Key) -> Result<Self, Unspecified> {
-        let unbound_key = key.as_unbound().map_err(|_| Unspecified)?;
         Ok(Self {
             nonce_generator: RandomNonceGenerator::init()?,
-            key: LessSafeKey::new(unbound_key),
+            key: key.cipher_key()?,
         })
     }
 }
@@ -28,19 +28,17 @@ impl Cipher for Aes256Cipher {
         A: IntoAad<'a>,
     {
         let nonce = self.nonce_generator.generate()?;
-        let nonce_lc =
-            LcNonce::try_assume_unique_for_key(nonce.as_ref()).map_err(|_| Unspecified)?;
+        let nonce_bytes: [u8; NONCE_LEN] = nonce.as_ref().try_into().map_err(|_| Unspecified)?;
         let aad = aad.into_aad();
-        let aad = LcAad::from(aad.as_bytes());
+        let aad_bytes = aad.as_bytes().to_vec();
 
         CipherTextBuilder::new()
             .append_nonce(nonce)
             .append_target_plaintext(plaintext)
             .accepts_ciphertext_and_tag_ok(|mut buf| {
                 self.key
-                    .seal_in_place_append_tag(nonce_lc, aad, &mut buf)
-                    .map(|_| buf)
-                    .map_err(|_| Unspecified)
+                    .seal_in_place_append_tag(&nonce_bytes, &aad_bytes, &mut buf)
+                    .map(|()| buf)
             })
             .build()
     }
@@ -55,7 +53,7 @@ impl Cipher for Aes256Cipher {
         Self: 'a,
     {
         // Copy into a Vec with capacity N + tag_len
-        let mut plaintext_vec = Vec::with_capacity(plaintext.len() + AES_256_GCM.tag_len());
+        let mut plaintext_vec = Vec::with_capacity(plaintext.len() + TAG_LEN);
         plaintext_vec.extend_from_slice(plaintext);
         self.encrypt_vec(plaintext_vec, aad)
     }
@@ -69,17 +67,12 @@ impl Cipher for Aes256Cipher {
         A: IntoAad<'a>,
     {
         let (nonce, reader) = ciphertext.into_reader().read_nonce::<NONCE_LEN>();
-        let nonce_lc = LcNonce::assume_unique_for_key(nonce.into_inner());
+        let nonce_bytes = nonce.into_inner();
         let aad = aad.into_aad();
-        let aad = LcAad::from(aad.as_bytes());
+        let aad_bytes = aad.as_bytes().to_vec();
 
         reader
-            .accepts_plaintext_ok(|data| {
-                self.key
-                    .open_in_place(nonce_lc, aad, data)
-                    .map_err(|_| Unspecified)
-                    .map(|plaintext| plaintext.len())
-            })
+            .accepts_plaintext_ok(|data| self.key.open_in_place(&nonce_bytes, &aad_bytes, data))
             .read()
             .map(|data| data.risky_unwrap())
     }

--- a/packages/encrypt/src/cipher.rs
+++ b/packages/encrypt/src/cipher.rs
@@ -30,14 +30,13 @@ impl Cipher for Aes256Cipher {
         let nonce = self.nonce_generator.generate()?;
         let nonce_bytes: [u8; NONCE_LEN] = nonce.as_ref().try_into().map_err(|_| Unspecified)?;
         let aad = aad.into_aad();
-        let aad_bytes = aad.as_bytes().to_vec();
 
         CipherTextBuilder::new()
             .append_nonce(nonce)
             .append_target_plaintext(plaintext)
             .accepts_ciphertext_and_tag_ok(|mut buf| {
                 self.key
-                    .seal_in_place_append_tag(&nonce_bytes, &aad_bytes, &mut buf)
+                    .seal(&nonce_bytes, aad.as_bytes(), &mut buf)
                     .map(|()| buf)
             })
             .build()
@@ -69,10 +68,9 @@ impl Cipher for Aes256Cipher {
         let (nonce, reader) = ciphertext.into_reader().read_nonce::<NONCE_LEN>();
         let nonce_bytes = nonce.into_inner();
         let aad = aad.into_aad();
-        let aad_bytes = aad.as_bytes().to_vec();
 
         reader
-            .accepts_plaintext_ok(|data| self.key.open_in_place(&nonce_bytes, &aad_bytes, data))
+            .accepts_plaintext_ok(|data| self.key.open(&nonce_bytes, aad.as_bytes(), data))
             .read()
             .map(|data| data.risky_unwrap())
     }

--- a/packages/encrypt/src/key.rs
+++ b/packages/encrypt/src/key.rs
@@ -58,7 +58,9 @@ impl Decrypt for Key {
     }
 }
 
-#[cfg(test)]
+// Quickcheck `Arbitrary` impls for the property tests in `cipher::test` —
+// gated to non-wasm32 alongside their consumers (see comment in `cipher.rs`).
+#[cfg(all(test, not(target_arch = "wasm32")))]
 pub(crate) mod tests {
     use super::*;
     use quickcheck::Arbitrary;

--- a/packages/encrypt/src/key.rs
+++ b/packages/encrypt/src/key.rs
@@ -1,4 +1,4 @@
-use aws_lc_rs::aead::UnboundKey;
+use crate::backend::CipherKey;
 use vitaminc_aead::{Cipher, Decrypt, Encrypt, IntoAad, LocalCipherText, Unspecified};
 use vitaminc_protected::{Controlled, Protected};
 use vitaminc_random::{Generatable, RandomError, SafeRand};
@@ -11,8 +11,8 @@ use vitaminc_random::{Generatable, RandomError, SafeRand};
 pub struct Key(Protected<[u8; 32]>);
 
 impl Key {
-    pub(crate) fn as_unbound(&self) -> Result<UnboundKey, Unspecified> {
-        UnboundKey::new(&aws_lc_rs::aead::AES_256_GCM, self.0.risky_ref()).map_err(|_| Unspecified)
+    pub(crate) fn cipher_key(&self) -> Result<CipherKey, Unspecified> {
+        CipherKey::new(self.0.risky_ref())
     }
 }
 

--- a/packages/encrypt/src/lib.rs
+++ b/packages/encrypt/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(clippy::unwrap_used, clippy::todo, unsafe_code, unused_imports)]
 #![doc = include_str!("../README.md")]
+mod backend;
 mod cipher;
 mod key;
 

--- a/packages/random/Cargo.toml
+++ b/packages/random/Cargo.toml
@@ -20,3 +20,10 @@ zeroize = { workspace = true }
 
 vitaminc-random-derives = { version = "0.1.0-pre4.2", path = "../random-derives" }
 vitaminc-protected = { version = "0.1.0-pre4.2", path = "../protected" }
+
+# Wasm32: route `getrandom` to the browser/Deno crypto API. Pulled in
+# transitively via `rand` -> `getrandom 0.4`. Must be paired with the
+# `--cfg getrandom_backend="wasm_js"` rustflag (set via `.cargo/config.toml`
+# in any workspace consuming this crate for wasm32 builds).
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.4", features = ["wasm_js"] }


### PR DESCRIPTION
`vitaminc-encrypt` has been unusable on `wasm32-unknown-unknown` because its only backend is `aws-lc-rs`, whose `aws-lc-sys` C deps don't cross-compile to wasm. That blocks any downstream crate from building for wasm even when it only consumes the `Aad`/`IntoAad` types — which is currently making cipherstash-suite take a workaround feature-gate detour.

## Approach: cfg-based dual backend, no feature flag

| Target | Backend |
|---|---|
| `cfg(not(target_arch = "wasm32"))` | `aws-lc-rs` — current behaviour, FIPS-validated, AES-NI accelerated. **No native perf change.** |
| `cfg(target_arch = "wasm32")` | `aes-gcm` from RustCrypto — pure Rust, builds without a C toolchain |

Both implement RFC 5116 AES-256-GCM with the same wire format (`ciphertext \|\| 16-byte tag`), so existing ciphertexts decrypt cleanly under either backend. No data migration.

## Shape

A small `backend/` module exposes a single `CipherKey` type with `seal_in_place_append_tag` / `open_in_place`. `cipher.rs` and `key.rs` were thinned to use it — they no longer reference any specific crypto library.

`vitaminc-random` gained a wasm32-only `getrandom = { features = ["wasm_js"] }` target dep plus a `.cargo/config.toml` rustflag (`--cfg getrandom_backend="wasm_js"`). Without these, `rand 0.10` → `getrandom 0.4` fails to compile on wasm32 because no entropy backend is selected.

## Verification

- Native test suite (`cargo test -p vitaminc-encrypt`) — 10 unit + 5 doc tests pass unchanged
- `cargo check --target wasm32-unknown-unknown -p vitaminc-encrypt` — clean
- `cargo clippy --target wasm32-unknown-unknown -p vitaminc-encrypt --tests` — clean
- `mise run clippy` (native, all features) — clean

Wasm32 *runtime* round-trip testing isn't part of this PR — that's most cleanly exercised downstream where wasm targets are actually deployed.

## Why now

cipherstash-suite is adding wasm support so `cipherstash-client` can run in Supabase Edge Functions. The first PR there has a workaround feature-gate (`cts-common/aead`) that exists purely because vitaminc-encrypt didn't build on wasm. Once a release containing this lands, that workaround can be reverted.