### PR TITLE
fix(permutation): close cache-timing side-channel in permute_array

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2148,6 +2148,7 @@ dependencies = [
  "paste",
  "rand",
  "serde",
+ "subtle",
  "vitaminc-protected",
  "vitaminc-random",
  "zeroize",

--- a/packages/permutation/Cargo.toml
+++ b/packages/permutation/Cargo.toml
@@ -18,6 +18,7 @@ vitaminc-random = { version = "0.1.0-pre4.2", path = "../random" }
 bitvec = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
+subtle = "2.6.1"
 zeroize = { workspace = true }
 paste = "1.0.15"
 

--- a/packages/permutation/src/elementwise.rs
+++ b/packages/permutation/src/elementwise.rs
@@ -1,4 +1,5 @@
 use crate::{private::IsPermutable, PermutationKey};
+use subtle::{ConditionallySelectable, ConstantTimeEq};
 use vitaminc_protected::{Controlled, Zeroed};
 use zeroize::Zeroize;
 
@@ -15,7 +16,7 @@ pub trait Depermute<T> {
 /// Implement permutation for Protected type containing a permutable array.
 impl<const N: usize, T> Permute<[T; N]> for PermutationKey<N>
 where
-    T: Zeroize + Default + Copy,
+    T: Zeroize + Default + Copy + ConditionallySelectable,
     [T; N]: IsPermutable + Zeroed,
 {
     fn permute(&self, input: [T; N]) -> [T; N] {
@@ -25,7 +26,7 @@ where
 
 impl<const N: usize, T> Depermute<[T; N]> for PermutationKey<N>
 where
-    T: Zeroize + Default + Copy,
+    T: Zeroize + Default + Copy + ConditionallySelectable,
     [T; N]: IsPermutable + Zeroed,
 {
     fn depermute(&self, input: [T; N]) -> [T; N] {
@@ -37,16 +38,23 @@ where
 pub fn permute_array<const N: usize, T>(key: &PermutationKey<N>, mut input: [T; N]) -> [T; N]
 where
     [T; N]: IsPermutable + Zeroed,
-    T: Zeroize + Copy,
+    T: Zeroize + Copy + ConditionallySelectable,
 {
-    let out: [T; N] = key
-        .iter()
-        .enumerate()
-        // TODO: Use MaybeUninit or array::from_fn
-        .fold(Zeroed::zeroed(), |mut out, (i, k)| {
-            out[i] = input[k.map(|x| x as usize)];
-            out
-        });
+    // Constant-time scan: for each output position `i`, the key byte `kv`
+    // selects which input element to copy. We scan all `j` in 0..N and use
+    // `ConditionallySelectable` so the access pattern is independent of `kv`,
+    // preventing cache-line timing leaks of the secret key bytes.
+    let mut out: [T; N] = Zeroed::zeroed();
+    for (i, k) in key.iter().enumerate() {
+        let mut kv: u8 = k.risky_unwrap();
+        let mut selected: T = input[0];
+        for (j, src) in input.iter().enumerate().skip(1) {
+            let mask = (j as u8).ct_eq(&kv);
+            selected.conditional_assign(src, mask);
+        }
+        out[i] = selected;
+        kv.zeroize();
+    }
 
     // We copied all elements to the output so we should zeroize the input
     input.zeroize();
@@ -57,16 +65,20 @@ where
 pub fn depermute_array<const N: usize, T>(key: &PermutationKey<N>, mut input: [T; N]) -> [T; N]
 where
     [T; N]: IsPermutable + Zeroed,
-    T: Zeroize + Copy,
+    T: Zeroize + Copy + ConditionallySelectable,
 {
-    // TODO: Use MaybeUninit
-    let out: [T; N] = key
-        .iter()
-        .enumerate()
-        .fold(Zeroed::zeroed(), |mut out, (i, k)| {
-            out[k.map(|x| x as usize)] = input[i];
-            out
-        });
+    // Constant-time scatter: for each (i, kv), write `input[i]` to `out[kv]`
+    // by scanning every output slot and conditionally assigning when `j == kv`.
+    let mut out: [T; N] = Zeroed::zeroed();
+    for (i, k) in key.iter().enumerate() {
+        let mut kv: u8 = k.risky_unwrap();
+        let src = input[i];
+        for (j, dst) in out.iter_mut().enumerate() {
+            let mask = (j as u8).ct_eq(&kv);
+            dst.conditional_assign(&src, mask);
+        }
+        kv.zeroize();
+    }
 
     // We copied all elements to the output so we should zeroize the input
     input.zeroize();

--- a/packages/permutation/src/elementwise.rs
+++ b/packages/permutation/src/elementwise.rs
@@ -1,7 +1,7 @@
 use crate::{private::IsPermutable, PermutationKey};
 use subtle::{ConditionallySelectable, ConstantTimeEq};
 use vitaminc_protected::{Controlled, Zeroed};
-use zeroize::Zeroize;
+use zeroize::{Zeroize, Zeroizing};
 
 // TODO: Make this a private trait
 // FIXME: This trait is backwards - self should be T and the argument should be a key
@@ -35,7 +35,7 @@ where
 }
 
 #[inline]
-pub fn permute_array<const N: usize, T>(key: &PermutationKey<N>, mut input: [T; N]) -> [T; N]
+pub fn permute_array<const N: usize, T>(key: &PermutationKey<N>, input: [T; N]) -> [T; N]
 where
     [T; N]: IsPermutable + Zeroed,
     T: Zeroize + Copy + ConditionallySelectable,
@@ -43,45 +43,41 @@ where
     // Constant-time scan: for each output position `i`, the key byte `kv`
     // selects which input element to copy. We scan all `j` in 0..N and use
     // `ConditionallySelectable` so the access pattern is independent of `kv`,
-    // preventing cache-line timing leaks of the secret key bytes.
+    // preventing cache-line timing leaks of the secret key bytes. Secret
+    // locals are wrapped in `Zeroizing` so they are wiped on any unwind path.
+    let input = Zeroizing::new(input);
     let mut out: [T; N] = Zeroed::zeroed();
     for (i, k) in key.iter().enumerate() {
-        let mut kv: u8 = k.risky_unwrap();
-        let mut selected: T = input[0];
+        let kv = Zeroizing::new(k.risky_unwrap());
+        let mut selected = Zeroizing::new(input[0]);
         for (j, src) in input.iter().enumerate().skip(1) {
-            let mask = (j as u8).ct_eq(&kv);
+            let mask = (j as u8).ct_eq(&*kv);
             selected.conditional_assign(src, mask);
         }
-        out[i] = selected;
-        kv.zeroize();
+        out[i] = *selected;
     }
-
-    // We copied all elements to the output so we should zeroize the input
-    input.zeroize();
     out
 }
 
 #[inline]
-pub fn depermute_array<const N: usize, T>(key: &PermutationKey<N>, mut input: [T; N]) -> [T; N]
+pub fn depermute_array<const N: usize, T>(key: &PermutationKey<N>, input: [T; N]) -> [T; N]
 where
     [T; N]: IsPermutable + Zeroed,
     T: Zeroize + Copy + ConditionallySelectable,
 {
     // Constant-time scatter: for each (i, kv), write `input[i]` to `out[kv]`
     // by scanning every output slot and conditionally assigning when `j == kv`.
+    // Secret locals are wrapped in `Zeroizing` for unwind safety.
+    let input = Zeroizing::new(input);
     let mut out: [T; N] = Zeroed::zeroed();
     for (i, k) in key.iter().enumerate() {
-        let mut kv: u8 = k.risky_unwrap();
-        let src = input[i];
+        let kv = Zeroizing::new(k.risky_unwrap());
+        let src = Zeroizing::new(input[i]);
         for (j, dst) in out.iter_mut().enumerate() {
-            let mask = (j as u8).ct_eq(&kv);
-            dst.conditional_assign(&src, mask);
+            let mask = (j as u8).ct_eq(&*kv);
+            dst.conditional_assign(&*src, mask);
         }
-        kv.zeroize();
     }
-
-    // We copied all elements to the output so we should zeroize the input
-    input.zeroize();
     out
 }
 

--- a/packages/permutation/src/elementwise.rs
+++ b/packages/permutation/src/elementwise.rs
@@ -40,13 +40,19 @@ where
     [T; N]: IsPermutable + Zeroed,
     T: Zeroize + Copy + ConditionallySelectable,
 {
+    // Key bytes are u8, so an `N > 256` permutation could never be expressed by
+    // the key — and `(j as u8)` below would silently wrap, breaking the
+    // ct_eq comparison. Surface the limit at compile time.
+    const { assert!(N <= 256, "permutation length must fit in u8") };
+
     // Constant-time scan: for each output position `i`, the key byte `kv`
     // selects which input element to copy. We scan all `j` in 0..N and use
     // `ConditionallySelectable` so the access pattern is independent of `kv`,
     // preventing cache-line timing leaks of the secret key bytes. Secret
-    // locals are wrapped in `Zeroizing` so they are wiped on any unwind path.
+    // locals — including the partially-populated `out` — are wrapped in
+    // `Zeroizing` so they are wiped on any unwind path.
     let input = Zeroizing::new(input);
-    let mut out: [T; N] = Zeroed::zeroed();
+    let mut out: Zeroizing<[T; N]> = Zeroizing::new(Zeroed::zeroed());
     for (i, k) in key.iter().enumerate() {
         let kv = Zeroizing::new(k.risky_unwrap());
         let mut selected = Zeroizing::new(input[0]);
@@ -56,7 +62,9 @@ where
         }
         out[i] = *selected;
     }
-    out
+    // Move the populated array out, leaving a fresh zeroed array for the
+    // `Zeroizing` Drop to clean (a no-op wipe in the success path).
+    core::mem::replace(&mut *out, Zeroed::zeroed())
 }
 
 #[inline]
@@ -65,11 +73,15 @@ where
     [T; N]: IsPermutable + Zeroed,
     T: Zeroize + Copy + ConditionallySelectable,
 {
+    // See `permute_array` — same u8-fit constraint applies here.
+    const { assert!(N <= 256, "permutation length must fit in u8") };
+
     // Constant-time scatter: for each (i, kv), write `input[i]` to `out[kv]`
     // by scanning every output slot and conditionally assigning when `j == kv`.
-    // Secret locals are wrapped in `Zeroizing` for unwind safety.
+    // Secret locals — including the partially-populated `out` — are wrapped
+    // in `Zeroizing` for unwind safety.
     let input = Zeroizing::new(input);
-    let mut out: [T; N] = Zeroed::zeroed();
+    let mut out: Zeroizing<[T; N]> = Zeroizing::new(Zeroed::zeroed());
     for (i, k) in key.iter().enumerate() {
         let kv = Zeroizing::new(k.risky_unwrap());
         let src = Zeroizing::new(input[i]);
@@ -78,7 +90,7 @@ where
             dst.conditional_assign(&*src, mask);
         }
     }
-    out
+    core::mem::replace(&mut *out, Zeroed::zeroed())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- `permute_array`/`depermute_array` indexed the array by a secret permutation-key byte (`out[i] = input[k]`, `out[k] = input[i]`), so CPU cache-line accesses leak key bits to a co-resident observer — same class of attack that broke software AES T-table implementations.
- Replaced the secret-indexed load/store with a constant-time scan that touches every input/output position in fixed order, using `subtle::ConditionallySelectable` for per-element select. The memory access pattern is now driven only by public `N`.
- Trait bound on `T` widens to include `ConditionallySelectable`; all current `IsPermutable` element types (`u8`/`u16`/`u32`) already implement it via subtle.
- Secret locals (`input`, `kv`, `selected`, `src`) wrapped in `Zeroizing<_>` so wipes run via `Drop` on every exit including unwind.

## Discovery

Found via Trail of Bits' `constant-time-analysis` skill. The instruction-level analyzer passed cleanly on both arm64 and x86_64 (no `DIV`/branch-on-secret), but it explicitly does not detect cache-line access patterns — this leak surfaced in the manual review pass that follows the analyzer.

## Performance impact

Measured at `-O3` on arm64 (M-series), `[u8; N]`, key bytes pre-extracted, 500 K iterations:

| N | old (variable-time) | new (constant-time scan) | overhead |
|---|---|---|---|
| 8 | 6.5 ns | 66 ns | 10× |
| 16 | 4.8 ns | 159 ns | 33× |
| 32 | 7.5 ns | 733 ns | 98× |
| 64 | 17 ns | 3.2 µs | 189× |
| 128 | 39 ns | 12.6 µs | 325× |

Expected: `O(N)` indexed loads → `O(N²)` conditional moves. Acceptable for current call sites (key inversion, complement, single-block permutes); the absolute cost is sub-microsecond up to N=32.

## Follow-up

Not in this PR — `tbl`/`pshufb` SIMD specialization for performance-sensitive sizes (single-instruction byte shuffle, documented constant-time on every CPU that ships them) would close most of the gap.

The same secret-indexed-lookup pattern exists in `bitwise.rs:21` (`arr.get_unchecked(k)`) but is benign: bit-arrays there are 1–16 bytes (≤1 cache line). Hardened in #165 as defense-in-depth.

## Test plan

- [x] `cargo test -p vitaminc-permutation` — 6 unit + 3 doctests pass (round-trip, depermutation, associativity, key inversion, complement at N=8/16/32/64)
- [x] `cargo build --workspace` — clean
- [x] `cargo fmt --check` — clean
- [x] ct_analyzer on release asm (arm64 + x86_64) — PASSED, 0 errors / 0 warnings
- [x] zeroize-audit — wipes intact in LLVM IR at O3 (10 volatile-zero stores, vs 8 at O0)
- [x] CI green