### PR TITLE
fix(permutation): make bitwise_permute constant-time

### DIFF
--- a/packages/permutation/src/bitwise.rs
+++ b/packages/permutation/src/bitwise.rs
@@ -1,7 +1,6 @@
-use crate::PermutationKey;
-use bitvec::{array::BitArray, order::Msb0};
+use crate::{elementwise::permute_array, PermutationKey};
 use std::num::{NonZeroU128, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8};
-use zeroize::Zeroize;
+use zeroize::{Zeroize, Zeroizing};
 
 // TODO: Make this a private trait
 // FIXME: This trait is backwards - self should be T and the argument should be a key
@@ -13,19 +12,25 @@ macro_rules! impl_bitwise_permutable {
     ($N:literal, $int_type:ty, $array_size:expr) => {
         impl BitwisePermute<$N, $int_type> for PermutationKey<$N> {
             fn bitwise_permute(&self, mut input: $int_type) -> $int_type {
-                let bytes = input.to_be_bytes();
-                let arr: BitArray<[u8; $array_size], Msb0> = BitArray::new(bytes);
-                let out: BitArray<[u8; $array_size], Msb0> = self.iter().enumerate().fold(
-                    BitArray::new([0; $array_size]),
-                    |mut out, (i, k)| {
-                        out.set(i, *unsafe { arr.get_unchecked(k) });
-                        out
-                    },
-                );
-
+                // Unpack the input into one byte per bit (MSB-first), permute
+                // the bit-vector through the constant-time `permute_array`
+                // primitive, then re-pack. The previous implementation used
+                // `bitvec::get_unchecked(secret_index)` which performs a
+                // secret-dependent bit load; even though the bit array fits in
+                // a single cache line, this defends against intra-cache-line
+                // microarchitectural leaks (port pressure, etc.).
+                let bytes = Zeroizing::new(input.to_be_bytes());
+                let mut bits: Zeroizing<[u8; $N]> = Zeroizing::new([0u8; $N]);
+                for j in 0..$N {
+                    bits[j] = (bytes[j / 8] >> (7 - (j % 8))) & 1;
+                }
+                let permuted = Zeroizing::new(permute_array(self, *bits));
+                let mut out = [0u8; $array_size];
+                for j in 0..$N {
+                    out[j / 8] |= (permuted[j] & 1) << (7 - (j % 8));
+                }
                 input.zeroize();
-
-                <$int_type>::from_be_bytes(out.into_inner())
+                <$int_type>::from_be_bytes(out)
             }
         }
     };

--- a/packages/permutation/src/bitwise.rs
+++ b/packages/permutation/src/bitwise.rs
@@ -97,4 +97,85 @@ mod tests {
         test_permute::<64, _>(NonZeroU64::new(7178231783183).unwrap());
         test_permute::<128, _>(NonZeroU128::new(29472929298731313).unwrap());
     }
+
+    // Zero in -> zero out, for every supported width.
+    // Catches sign/endian bugs in the unpack/repack glue: any path that
+    // accidentally introduces a stray bit would fail here.
+    #[test]
+    fn bitwise_permute_zero_in_zero_out() {
+        assert_eq!(tests::gen_key::<8>([0; 32]).bitwise_permute(0u8), 0);
+        assert_eq!(tests::gen_key::<16>([0; 32]).bitwise_permute(0u16), 0);
+        assert_eq!(tests::gen_key::<32>([0; 32]).bitwise_permute(0u32), 0);
+        assert_eq!(tests::gen_key::<64>([0; 32]).bitwise_permute(0u64), 0);
+        assert_eq!(tests::gen_key::<128>([0; 32]).bitwise_permute(0u128), 0);
+    }
+
+    // All-ones is a fixed point of every bit permutation (every bit position
+    // already holds a 1, so permuting positions can't change anything).
+    // Catches missing-bit bugs at the high or low boundary of each width.
+    #[test]
+    fn bitwise_permute_all_ones_invariant() {
+        assert_eq!(
+            tests::gen_key::<8>([0; 32]).bitwise_permute(u8::MAX),
+            u8::MAX
+        );
+        assert_eq!(
+            tests::gen_key::<16>([0; 32]).bitwise_permute(u16::MAX),
+            u16::MAX
+        );
+        assert_eq!(
+            tests::gen_key::<32>([0; 32]).bitwise_permute(u32::MAX),
+            u32::MAX
+        );
+        assert_eq!(
+            tests::gen_key::<64>([0; 32]).bitwise_permute(u64::MAX),
+            u64::MAX
+        );
+        assert_eq!(
+            tests::gen_key::<128>([0; 32]).bitwise_permute(u128::MAX),
+            u128::MAX
+        );
+    }
+
+    // Hamming weight (popcount) must be preserved — a permutation moves bits
+    // but neither creates nor destroys them. This is the strongest single
+    // property check available for the bit-shuffle glue: any bug that drops,
+    // duplicates, or mis-positions a bit will change the count. As a
+    // corollary, this is also what justifies the `unsafe new_unchecked` in
+    // the NonZero impls: popcount > 0 in -> popcount > 0 out.
+    #[test]
+    fn bitwise_permute_preserves_hamming_weight() {
+        let key8 = tests::gen_key::<8>([0; 32]);
+        for n in [0u8, 1, 0x80, 0x55, 0xaa, 0xff] {
+            assert_eq!(key8.bitwise_permute(n).count_ones(), n.count_ones());
+        }
+
+        let key32 = tests::gen_key::<32>([0; 32]);
+        for n in [0u32, 1, 0x8000_0000, 0xcafe_babe, 0x1234_5678, u32::MAX] {
+            assert_eq!(key32.bitwise_permute(n).count_ones(), n.count_ones());
+        }
+
+        let key128 = tests::gen_key::<128>([0; 32]);
+        for n in [
+            0u128,
+            1,
+            1 << 127,
+            0x0123_4567_89ab_cdef_fedc_ba98_7654_3210,
+            u128::MAX,
+        ] {
+            assert_eq!(key128.bitwise_permute(n).count_ones(), n.count_ones());
+        }
+    }
+
+    // Same key + same input must produce the same output. Cheap guard against
+    // any future change that accidentally introduces nondeterminism (e.g. a
+    // hash-seed in the permute path, or branching on uninitialised memory
+    // that happens to read consistent values in test but not in production).
+    #[test]
+    fn bitwise_permute_is_deterministic() {
+        let key_a = tests::gen_key::<64>([7; 32]);
+        let key_b = tests::gen_key::<64>([7; 32]);
+        let input = 0xcafe_babe_dead_beefu64;
+        assert_eq!(key_a.bitwise_permute(input), key_b.bitwise_permute(input));
+    }
 }


### PR DESCRIPTION
**Stacked on #164** — review/merge that one first.

## Summary

- `bitwise_permute` previously used `BitArray::get_unchecked(secret_index)` to fetch bits at key-derived positions. The bit array fits in a single cache line (≤16 bytes) so it's not exploitable by classic cache-line probing, but it's still a microarchitectural hazard — port pressure, store-buffer effects, and other intra-cache-line side channels can leak secret indices on some CPUs.
- Reimplemented as: unpack input to one byte per bit (MSB-first) → permute through the constant-time `permute_array` primitive → repack to bytes. This routes the bit-level operation through the same scan-and-mask machinery introduced in #164.
- Secret intermediates (`bytes`, `bits`, `permuted`) wrapped in `Zeroizing<_>` for unwind safety, matching the elementwise pattern.
- Drops direct `bitvec` usage in `bitwise.rs`; the `BitArray` machinery is no longer needed there.

## Performance impact

Apple silicon (arm64), `--release`, 500K iterations, key bytes pre-extracted via the public `Permute` API for the "old" reference:

| N | old (variable-time) | new (constant-time) | overhead |
|---|---|---|---|
| 8 | 1.9 ns | 53.9 ns | 28× |
| 16 | 5.7 ns | 267 ns | 47× |
| 32 | 34 ns | 1.45 µs | 42× |
| 64 | 80 ns | 5.6 µs | 70× |
| 128 | 137 ns | 27.3 µs | 199× |

In line with the elementwise overhead — bit-level `bitwise_permute` reuses `permute_array` internally, so the cost profile matches. Same SIMD-shuffle follow-up (`tbl`/`pshufb`) applies if these sizes show up in a hot path.

## Verification

- `cargo test -p vitaminc-permutation` — 6 unit + 3 doctests pass (round-trip, key inversion, bitwise correctness across u8/u16/u32/u64/u128 + NonZero variants)
- `cargo fmt --check` — clean
- ct_analyzer on release asm (arm64 + x86_64) — PASSED, 0 errors / 0 warnings
- Constant-time scan-via-`permute_array`, no secret-indexed loads remain in `bitwise.rs`

## Test plan

- [x] Existing `bitwise_permute_case` exercises N=8/16/32/64/128 across all int and NonZero variants
- [x] CI green