### PR TITLE
feat(aead, encrypt): add encrypt_some/encrypt_none/passthrough

### DIFF
--- a/packages/aead/README.md
+++ b/packages/aead/README.md
@@ -34,6 +34,7 @@ A [`Cipher`] is consumed by the operation it drives — typically you implement 
 ```rust,no_run
 use std::any::Any;
 use vitaminc_aead::{Cipher, IntoAad, MapCipher, SeqCipher, Unspecified};
+use vitaminc_protected::Protected;
 
 pub struct MyCipher { /* key material, nonce generator, ... */ }
 
@@ -47,7 +48,11 @@ impl<'c> Cipher for &'c MyCipher {
     type SeqCipher = MySeqCipher<'c>;
     type MapCipher = MyMapCipher<'c>;
 
-    fn encrypt_bytes_vec<'a, A>(self, data: Vec<u8>, aad: A) -> Result<Self::Ok, Self::Error>
+    fn encrypt_bytes_vec<'a, A>(
+        self,
+        data: Protected<Vec<u8>>,
+        aad: A,
+    ) -> Result<Self::Ok, Self::Error>
     where
         A: IntoAad<'a>,
     {

--- a/packages/aead/README.md
+++ b/packages/aead/README.md
@@ -32,6 +32,7 @@ This crate provides traits and types for implementing AEAD operations in a safe 
 A [`Cipher`] is consumed by the operation it drives — typically you implement it for a *reference* to your cipher state (`&MyCipher`) so the same cipher can be reused across many calls. The trait declares the output (`Ok`) and error types, plus associated types for sequence and map encryption:
 
 ```rust,no_run
+use std::any::Any;
 use vitaminc_aead::{Cipher, IntoAad, MapCipher, SeqCipher, Unspecified};
 
 pub struct MyCipher { /* key material, nonce generator, ... */ }
@@ -50,15 +51,29 @@ impl<'c> Cipher for &'c MyCipher {
     where
         A: IntoAad<'a>,
     {
-        todo!("seal `data` with AAD and return a ciphertext")
+        unimplemented!("seal `data` with AAD and return a ciphertext")
     }
 
     fn encrypt_seq(self, size_hint: Option<usize>) -> Self::SeqCipher {
-        todo!("return a SeqCipher initialised with `size_hint` capacity")
+        unimplemented!("return a SeqCipher initialised with `size_hint` capacity")
     }
 
     fn encrypt_map(self) -> Self::MapCipher {
-        todo!("return a MapCipher")
+        unimplemented!("return a MapCipher")
+    }
+
+    fn encrypt_none<'a, A>(self, _aad: A) -> Result<Self::Ok, Self::Error>
+    where
+        A: IntoAad<'a>,
+    {
+        unimplemented!("produce an authenticated 'absent' marker bound to `aad`")
+    }
+
+    fn passthrough<T>(self, _value: T) -> Result<Self::Ok, Self::Error>
+    where
+        T: Any + Send + 'static,
+    {
+        unimplemented!("store `value` unencrypted inside the cipher's output container")
     }
 }
 
@@ -70,24 +85,34 @@ impl<'c> SeqCipher for MySeqCipher<'c> {
     where
         T: vitaminc_aead::Encrypt,
         A: IntoAad<'a>,
-    { todo!() }
+    { unimplemented!() }
 
-    fn end(self) -> Result<Self::Ok, Self::Error> { todo!() }
+    fn passthrough_next<T>(self, _value: T) -> Result<Self, Self::Error>
+    where
+        T: Any + Send + 'static,
+    { unimplemented!() }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> { unimplemented!() }
 }
 
 impl<'c> MapCipher for MyMapCipher<'c> {
     type Ok = MyCipherText;
     type Error = Unspecified;
 
-    fn encrypt_key(self, _key: &'static str) -> Result<Self, Self::Error> { todo!() }
+    fn encrypt_key(self, _key: &'static str) -> Result<Self, Self::Error> { unimplemented!() }
 
     fn encrypt_value<'a, T, A>(self, _value: T, _aad: A) -> Result<Self, Self::Error>
     where
         T: vitaminc_aead::Encrypt,
         A: IntoAad<'a>,
-    { todo!() }
+    { unimplemented!() }
 
-    fn end(self) -> Result<Self::Ok, Self::Error> { todo!() }
+    fn passthrough_entry<T>(self, _key: &'static str, _value: T) -> Result<Self, Self::Error>
+    where
+        T: Any + Send + 'static,
+    { unimplemented!() }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> { unimplemented!() }
 }
 ```
 

--- a/packages/aead/src/cipher.rs
+++ b/packages/aead/src/cipher.rs
@@ -1,5 +1,7 @@
 use std::any::Any;
 
+use vitaminc_protected::{Controlled, Protected};
+
 use crate::{Encrypt, IntoAad};
 
 /// An error that provides **no information** about the failure.
@@ -43,23 +45,39 @@ pub trait Cipher: Sized {
     type MapCipher: MapCipher<Ok = Self::Ok, Error = Self::Error>;
 
     /// Encrypt the given byte vector with the supplied associated data.
-    fn encrypt_bytes_vec<'a, A>(self, data: Vec<u8>, aad: A) -> Result<Self::Ok, Self::Error>
+    ///
+    /// The plaintext is taken as `Protected<Vec<u8>>` so the chain of custody
+    /// — and the zeroize-on-drop guarantee — survives the trait boundary.
+    /// Implementations should keep the value inside `Protected` for the
+    /// duration of the encryption and let it drop (and wipe) at end of scope.
+    fn encrypt_bytes_vec<'a, A>(
+        self,
+        data: Protected<Vec<u8>>,
+        aad: A,
+    ) -> Result<Self::Ok, Self::Error>
     where
         A: IntoAad<'a>;
 
     /// Encrypt a fixed-size byte array. The default implementation forwards to
     /// [`encrypt_bytes_vec`](Cipher::encrypt_bytes_vec).
+    ///
+    /// As with [`encrypt_bytes_vec`](Cipher::encrypt_bytes_vec), the plaintext
+    /// is taken inside `Protected` so the stack array is wiped on drop after
+    /// `to_vec` has copied its contents onto the heap.
     fn encrypt_bytes_array<'a, const N: usize, A>(
         self,
-        data: [u8; N],
+        data: Protected<[u8; N]>,
         aad: A,
     ) -> Result<Self::Ok, Self::Error>
     where
         A: IntoAad<'a>,
     {
-        // See https://github.com/cipherstash/vitaminc/issues/170 — verify
-        // `to_vec` behaviour and zeroize the original stack array.
-        self.encrypt_bytes_vec(data.to_vec(), aad)
+        // Borrow the protected array so it stays owned by `data` and is
+        // wiped by ZeroizeOnDrop at end of scope. A `risky_unwrap` here
+        // would partially-move out of `data`, skipping its Drop and
+        // leaving the bare `[u8; N]` on the stack — see issue #170.
+        let copy = Protected::new(data.risky_ref().to_vec());
+        self.encrypt_bytes_vec(copy, aad)
     }
 
     /// Begin encrypting a sequence of values. `size_hint` lets the implementation
@@ -94,6 +112,16 @@ pub trait Cipher: Sized {
     /// The value is typed at the API boundary but stored opaquely by the
     /// cipher; the corresponding [`Decipher::decrypt_passthrough`] checks the
     /// type at runtime.
+    ///
+    /// # ⚠️ Non-sensitive data only
+    ///
+    /// Passthrough values travel **in the clear** alongside the ciphertext.
+    /// Do not use this for secret-bearing data such as keys, plaintexts, or
+    /// credentials — there is no encryption, no zeroize discipline applied
+    /// to the boxed value, and no guarantee about when the storage is freed.
+    /// For secrets, use [`encrypt_with_aad`](crate::Encrypt::encrypt_with_aad)
+    /// (via the [`Encrypt`](crate::Encrypt) trait) or wrap in
+    /// [`vitaminc_protected::Protected`].
     fn passthrough<T>(self, value: T) -> Result<Self::Ok, Self::Error>
     where
         T: Any + Send + 'static;
@@ -117,6 +145,9 @@ pub trait SeqCipher: Sized {
         A: IntoAad<'a>;
 
     /// Append a passthrough (unencrypted) element to the sequence.
+    ///
+    /// See [`Cipher::passthrough`] — passthrough values are non-sensitive by
+    /// design and must not carry secret data.
     fn passthrough_next<T>(self, value: T) -> Result<Self, Self::Error>
     where
         T: Any + Send + 'static;
@@ -181,6 +212,9 @@ pub trait MapCipher: Sized {
     /// Insert a passthrough (unencrypted) entry under `key`. Equivalent to
     /// [`encrypt_key`](MapCipher::encrypt_key) followed by storing the value
     /// without AEAD treatment.
+    ///
+    /// See [`Cipher::passthrough`] — passthrough values are non-sensitive by
+    /// design and must not carry secret data.
     fn passthrough_entry<T>(self, key: &'static str, value: T) -> Result<Self, Self::Error>
     where
         T: Any + Send + 'static;

--- a/packages/aead/src/cipher.rs
+++ b/packages/aead/src/cipher.rs
@@ -1,3 +1,5 @@
+use std::any::Any;
+
 use crate::{Encrypt, IntoAad};
 
 /// An error that provides **no information** about the failure.
@@ -67,17 +69,34 @@ pub trait Cipher: Sized {
     /// Begin encrypting a map of key/value pairs.
     fn encrypt_map(self) -> Self::MapCipher;
 
-    // Tracked: https://github.com/cipherstash/vitaminc/issues/171
-    // fn encrypt_some<T>(self, value: T) -> Result<Self::Ok, Self::Error>
-    // where
-    //     T: Encrypt,
-    // {
-    //     value.encrypt(self)
-    // }
-    //
-    // fn encrypt_none(self) -> Result<Self::Ok, Self::Error>;
-    //
-    // fn passthrough<T: 'static>(self, data: T) -> Result<Self::Ok, Self::Error>;
+    /// Encrypt a present optional value. Default forwards to the inner value's
+    /// [`Encrypt`] impl — the `Some` discriminator is implicit in the structural
+    /// shape of the ciphertext (any non-`None` variant means `Some`).
+    fn encrypt_some<'a, T, A>(self, value: T, aad: A) -> Result<Self::Ok, Self::Error>
+    where
+        T: Encrypt,
+        A: IntoAad<'a>,
+    {
+        value.encrypt_with_aad(self, aad)
+    }
+
+    /// Encrypt the absent case of an optional value. Must produce a
+    /// cryptographically authenticated marker — distinguishable from any
+    /// `Some(_)` ciphertext and bound to `aad` so it cannot be forged.
+    fn encrypt_none<'a, A>(self, aad: A) -> Result<Self::Ok, Self::Error>
+    where
+        A: IntoAad<'a>;
+
+    /// Pass a typed value through the cipher's output container **without**
+    /// encrypting it. Intended for fields that need to survive the encryption
+    /// envelope in the clear (e.g. a schema version tag).
+    ///
+    /// The value is typed at the API boundary but stored opaquely by the
+    /// cipher; the corresponding [`Decipher::decrypt_passthrough`] checks the
+    /// type at runtime.
+    fn passthrough<T>(self, value: T) -> Result<Self::Ok, Self::Error>
+    where
+        T: Any + Send + 'static;
 }
 
 /// Sub-cipher driving the encryption of a sequence of values.
@@ -96,6 +115,11 @@ pub trait SeqCipher: Sized {
     where
         T: Encrypt,
         A: IntoAad<'a>;
+
+    /// Append a passthrough (unencrypted) element to the sequence.
+    fn passthrough_next<T>(self, value: T) -> Result<Self, Self::Error>
+    where
+        T: Any + Send + 'static;
 
     /// Finalise the sequence and return the produced ciphertext container.
     fn end(self) -> Result<Self::Ok, Self::Error>;
@@ -154,13 +178,12 @@ pub trait MapCipher: Sized {
             .and_then(|mc| mc.encrypt_value(value, aad))
     }
 
-    /*fn encrypt_passthrough_entry<T>(self, key: &'static str, value: T) -> Self
+    /// Insert a passthrough (unencrypted) entry under `key`. Equivalent to
+    /// [`encrypt_key`](MapCipher::encrypt_key) followed by storing the value
+    /// without AEAD treatment.
+    fn passthrough_entry<T>(self, key: &'static str, value: T) -> Result<Self, Self::Error>
     where
-        T: erased_serde::Serialize + Send + Sync + 'static,
-        Self: Sized,
-    {
-        self.encrypt_key(key).passthrough(value)
-    }*/
+        T: Any + Send + 'static;
 
     /// Finalise the map and return the produced ciphertext container.
     fn end(self) -> Result<Self::Ok, Self::Error>;

--- a/packages/aead/src/ciphertext/write_monads.rs
+++ b/packages/aead/src/ciphertext/write_monads.rs
@@ -54,7 +54,12 @@ impl<const N: usize, E> EncryptedWithTag<N, E> {
     }
 
     pub fn build(self) -> Result<LocalCipherText, E> {
-        // The value has been encrypted, so we can unwrap it
+        // SAFETY: at this point `self.bytes` is the *ciphertext* (sealed by
+        // the AEAD primitive — nonce || ciphertext || tag, with the tag
+        // bound to AAD). It is not secret-bearing, so unwrapping the
+        // `Protected` guard does not leak plaintext. The resulting
+        // `LocalCipherText` is intentionally durable: it is what we return
+        // to the caller.
         let inner = self.bytes?.risky_unwrap();
         let mut bytes = BytesMut::with_capacity(N + inner.len());
         bytes.extend(self.nonce.into_inner());

--- a/packages/aead/src/decipher/impls.rs
+++ b/packages/aead/src/decipher/impls.rs
@@ -111,3 +111,12 @@ where
         D::map_ok(T::decrypt(decipher), Protected::init_from_inner)
     }
 }
+
+impl<'c, T> Decrypt<'c> for Option<T>
+where
+    T: Decrypt<'c> + 'c,
+{
+    fn decrypt<D: Decipher<'c>>(decipher: D) -> D::Ok<Self> {
+        decipher.decrypt_option::<T>()
+    }
+}

--- a/packages/aead/src/decipher/impls.rs
+++ b/packages/aead/src/decipher/impls.rs
@@ -9,10 +9,7 @@ impl<'c> Decrypt<'c> for Vec<u8> {
         struct BytesVisitor;
         impl<'c> DecipherVisitor<'c> for BytesVisitor {
             type Value = Vec<u8>;
-            fn visit_bytes_vec(
-                self,
-                data: Protected<Vec<u8>>,
-            ) -> Result<Self::Value, Unspecified> {
+            fn visit_bytes_vec(self, data: Protected<Vec<u8>>) -> Result<Self::Value, Unspecified> {
                 // The caller asked for a bare `Vec<u8>` — this is the
                 // explicit extraction boundary where ownership leaves the
                 // cipher pipeline.
@@ -28,10 +25,7 @@ impl<'c> Decrypt<'c> for String {
         struct StringVisitor;
         impl<'c> DecipherVisitor<'c> for StringVisitor {
             type Value = String;
-            fn visit_bytes_vec(
-                self,
-                data: Protected<Vec<u8>>,
-            ) -> Result<Self::Value, Unspecified> {
+            fn visit_bytes_vec(self, data: Protected<Vec<u8>>) -> Result<Self::Value, Unspecified> {
                 String::from_utf8(data.risky_unwrap()).map_err(|_| Unspecified)
             }
         }
@@ -44,10 +38,7 @@ impl<'c, const N: usize> Decrypt<'c> for [u8; N] {
         struct ArrayVisitor<const N: usize>;
         impl<'c, const N: usize> DecipherVisitor<'c> for ArrayVisitor<N> {
             type Value = [u8; N];
-            fn visit_bytes_vec(
-                self,
-                data: Protected<Vec<u8>>,
-            ) -> Result<Self::Value, Unspecified> {
+            fn visit_bytes_vec(self, data: Protected<Vec<u8>>) -> Result<Self::Value, Unspecified> {
                 data.risky_unwrap().try_into().map_err(|_| Unspecified)
             }
         }
@@ -60,10 +51,7 @@ impl<'c> Decrypt<'c> for u32 {
         struct U32Visitor;
         impl<'c> DecipherVisitor<'c> for U32Visitor {
             type Value = u32;
-            fn visit_bytes_vec(
-                self,
-                data: Protected<Vec<u8>>,
-            ) -> Result<Self::Value, Unspecified> {
+            fn visit_bytes_vec(self, data: Protected<Vec<u8>>) -> Result<Self::Value, Unspecified> {
                 let bytes: [u8; 4] = data.risky_unwrap().try_into().map_err(|_| Unspecified)?;
                 Ok(u32::from_le_bytes(bytes))
             }

--- a/packages/aead/src/decipher/impls.rs
+++ b/packages/aead/src/decipher/impls.rs
@@ -9,8 +9,14 @@ impl<'c> Decrypt<'c> for Vec<u8> {
         struct BytesVisitor;
         impl<'c> DecipherVisitor<'c> for BytesVisitor {
             type Value = Vec<u8>;
-            fn visit_bytes_vec(self, data: Vec<u8>) -> Result<Self::Value, Unspecified> {
-                Ok(data)
+            fn visit_bytes_vec(
+                self,
+                data: Protected<Vec<u8>>,
+            ) -> Result<Self::Value, Unspecified> {
+                // The caller asked for a bare `Vec<u8>` — this is the
+                // explicit extraction boundary where ownership leaves the
+                // cipher pipeline.
+                Ok(data.risky_unwrap())
             }
         }
         decipher.decrypt_bytes(BytesVisitor)
@@ -22,8 +28,11 @@ impl<'c> Decrypt<'c> for String {
         struct StringVisitor;
         impl<'c> DecipherVisitor<'c> for StringVisitor {
             type Value = String;
-            fn visit_bytes_vec(self, data: Vec<u8>) -> Result<Self::Value, Unspecified> {
-                String::from_utf8(data).map_err(|_| Unspecified)
+            fn visit_bytes_vec(
+                self,
+                data: Protected<Vec<u8>>,
+            ) -> Result<Self::Value, Unspecified> {
+                String::from_utf8(data.risky_unwrap()).map_err(|_| Unspecified)
             }
         }
         decipher.decrypt_bytes(StringVisitor)
@@ -35,8 +44,11 @@ impl<'c, const N: usize> Decrypt<'c> for [u8; N] {
         struct ArrayVisitor<const N: usize>;
         impl<'c, const N: usize> DecipherVisitor<'c> for ArrayVisitor<N> {
             type Value = [u8; N];
-            fn visit_bytes_vec(self, data: Vec<u8>) -> Result<Self::Value, Unspecified> {
-                data.try_into().map_err(|_| Unspecified)
+            fn visit_bytes_vec(
+                self,
+                data: Protected<Vec<u8>>,
+            ) -> Result<Self::Value, Unspecified> {
+                data.risky_unwrap().try_into().map_err(|_| Unspecified)
             }
         }
         decipher.decrypt_bytes(ArrayVisitor::<N>)
@@ -48,8 +60,11 @@ impl<'c> Decrypt<'c> for u32 {
         struct U32Visitor;
         impl<'c> DecipherVisitor<'c> for U32Visitor {
             type Value = u32;
-            fn visit_bytes_vec(self, data: Vec<u8>) -> Result<Self::Value, Unspecified> {
-                let bytes: [u8; 4] = data.try_into().map_err(|_| Unspecified)?;
+            fn visit_bytes_vec(
+                self,
+                data: Protected<Vec<u8>>,
+            ) -> Result<Self::Value, Unspecified> {
+                let bytes: [u8; 4] = data.risky_unwrap().try_into().map_err(|_| Unspecified)?;
                 Ok(u32::from_le_bytes(bytes))
             }
         }

--- a/packages/aead/src/decipher/mod.rs
+++ b/packages/aead/src/decipher/mod.rs
@@ -2,6 +2,8 @@ pub mod impls;
 
 use std::any::Any;
 
+use vitaminc_protected::Protected;
+
 use crate::Unspecified;
 
 /// A trait for types that can decrypt data, driving a [`DecipherVisitor`] to produce values.
@@ -58,6 +60,9 @@ pub trait Decipher<'c>: Sized {
     /// Recover a value stored via [`Cipher::passthrough`](crate::Cipher::passthrough).
     /// Returns an error if the ciphertext is not a passthrough or the stored
     /// type does not match `T`.
+    ///
+    /// See [`Cipher::passthrough`] — passthrough values are non-sensitive by
+    /// design and must not be used to carry secret data.
     fn decrypt_passthrough<T>(self) -> Self::Ok<T>
     where
         T: Any + Send + 'static;
@@ -81,7 +86,17 @@ pub trait DecipherVisitor<'c>: Sized {
     type Value: Send;
 
     /// Called when the decipher produced raw bytes. Default returns an error.
-    fn visit_bytes_vec(self, _data: Vec<u8>) -> Result<Self::Value, Unspecified> {
+    ///
+    /// The plaintext is delivered inside `Protected<Vec<u8>>` so the
+    /// zeroize-on-drop guarantee survives the trait boundary. Visitor
+    /// implementations that need to hand a value of a different shape to
+    /// their caller should extract via [`Controlled::risky_ref`] /
+    /// [`Controlled::risky_unwrap`] only at the explicit boundary where
+    /// ownership leaves the cipher pipeline.
+    ///
+    /// [`Controlled::risky_ref`]: vitaminc_protected::Controlled::risky_ref
+    /// [`Controlled::risky_unwrap`]: vitaminc_protected::Controlled::risky_unwrap
+    fn visit_bytes_vec(self, _data: Protected<Vec<u8>>) -> Result<Self::Value, Unspecified> {
         Err(Unspecified)
     }
 

--- a/packages/aead/src/decipher/mod.rs
+++ b/packages/aead/src/decipher/mod.rs
@@ -1,5 +1,7 @@
 pub mod impls;
 
+use std::any::Any;
+
 use crate::Unspecified;
 
 /// A trait for types that can decrypt data, driving a [`DecipherVisitor`] to produce values.
@@ -52,6 +54,20 @@ pub trait Decipher<'c>: Sized {
     /// Decrypt a map of ciphertexts, driving the visitor's
     /// [`visit_map`](DecipherVisitor::visit_map).
     fn decrypt_map<V: DecipherVisitor<'c> + Send + 'c>(self, visitor: V) -> Self::Ok<V::Value>;
+
+    /// Recover a value stored via [`Cipher::passthrough`](crate::Cipher::passthrough).
+    /// Returns an error if the ciphertext is not a passthrough or the stored
+    /// type does not match `T`.
+    fn decrypt_passthrough<T>(self) -> Self::Ok<T>
+    where
+        T: Any + Send + 'static;
+
+    /// Decrypt an `Option<T>`. The decipher inspects the ciphertext shape:
+    /// a `None`-marker variant produces `Ok(None)` (after AAD verification);
+    /// any other shape is decrypted as `T` and wrapped in `Some`.
+    fn decrypt_option<T>(self) -> Self::Ok<Option<T>>
+    where
+        T: Decrypt<'c> + 'c;
 }
 
 /// A visitor over the structural shape of a ciphertext, analogous to serde's

--- a/packages/aead/src/encrypt/impls.rs
+++ b/packages/aead/src/encrypt/impls.rs
@@ -13,8 +13,7 @@ impl Encrypt for u32 {
         C: Cipher,
         A: IntoAad<'a>,
     {
-        let bytes = self.to_le_bytes().to_vec();
-        cipher.encrypt_bytes_vec(bytes, aad)
+        cipher.encrypt_bytes_vec(Protected::new(self.to_le_bytes().to_vec()), aad)
     }
 }
 
@@ -24,8 +23,7 @@ impl Encrypt for String {
         C: Cipher,
         A: IntoAad<'a>,
     {
-        let bytes = self.into_bytes();
-        cipher.encrypt_bytes_vec(bytes, aad)
+        cipher.encrypt_bytes_vec(Protected::new(self.into_bytes()), aad)
     }
 }
 
@@ -35,8 +33,7 @@ impl Encrypt for &str {
         C: Cipher,
         A: IntoAad<'a>,
     {
-        let bytes = self.as_bytes().to_vec();
-        cipher.encrypt_bytes_vec(bytes, aad)
+        cipher.encrypt_bytes_vec(Protected::new(self.as_bytes().to_vec()), aad)
     }
 }
 
@@ -68,7 +65,7 @@ impl<const N: usize> Encrypt for [u8; N] {
         C: Cipher,
         A: IntoAad<'a>,
     {
-        cipher.encrypt_bytes_array(self, aad)
+        cipher.encrypt_bytes_array(Protected::new(self), aad)
     }
 }
 
@@ -101,6 +98,12 @@ where
         C: Cipher,
         A: IntoAad<'a>,
     {
+        // SAFETY: chain of custody. Every built-in leaf `Encrypt` impl
+        // (`[u8; N]`, `Vec<T>`, `String`, `&str`, `u32`, …) rewraps its byte
+        // payload in `Protected` before crossing the `Cipher` trait
+        // boundary, so the bare-`T` stack window opened here is bounded by
+        // the inner `Encrypt::encrypt_with_aad` call. Custom `Encrypt` impls
+        // are responsible for their own discipline.
         self.risky_unwrap().encrypt_with_aad(cipher, aad)
     }
 }

--- a/packages/aead/src/encrypt/impls.rs
+++ b/packages/aead/src/encrypt/impls.rs
@@ -105,20 +105,18 @@ where
     }
 }
 
-// Tracked: https://github.com/cipherstash/vitaminc/issues/173
-// (blocked on https://github.com/cipherstash/vitaminc/issues/171)
-// impl<T> Encrypt for Option<T>
-// where
-//     T: Encrypt,
-// {
-//     fn encrypt_with_aad<'a, C, A>(self, cipher: C, aad: A) -> Result<C::Ok, C::Error>
-//     where
-//         C: Cipher,
-//         A: IntoAad<'a>,
-//     {
-//         match self {
-//             Some(v) => v.encrypt_with_aad(cipher, aad),
-//             None => cipher.passthrough(()),
-//         }
-//     }
-// }
+impl<T> Encrypt for Option<T>
+where
+    T: Encrypt,
+{
+    fn encrypt_with_aad<'a, C, A>(self, cipher: C, aad: A) -> Result<C::Ok, C::Error>
+    where
+        C: Cipher,
+        A: IntoAad<'a>,
+    {
+        match self {
+            Some(v) => cipher.encrypt_some(v, aad),
+            None => cipher.encrypt_none(aad),
+        }
+    }
+}

--- a/packages/aead/src/encrypt/impls.rs
+++ b/packages/aead/src/encrypt/impls.rs
@@ -13,7 +13,7 @@ impl Encrypt for u32 {
         C: Cipher,
         A: IntoAad<'a>,
     {
-        cipher.encrypt_bytes_vec(Protected::new(self.to_le_bytes().to_vec()), aad)
+        cipher.encrypt_bytes_array(Protected::new(self.to_le_bytes()), aad)
     }
 }
 

--- a/packages/encrypt/src/cipher.rs
+++ b/packages/encrypt/src/cipher.rs
@@ -708,4 +708,64 @@ mod test {
         let decrypted: Vec<Option<String>> = cipher.decrypt(ciphertext).expect("Decryption failed");
         decrypted == items
     }
+
+    // --- MapCipher state-machine contract ---
+    //
+    // `AesMapCipher` enforces a strict key→value pairing: every `encrypt_key`
+    // must be followed by exactly one `encrypt_value` (or `passthrough_entry`
+    // for the unencrypted variant) before the next key or `end`. The four
+    // tests below pin down each branch where the contract can be violated.
+
+    #[test]
+    fn encrypt_key_twice_without_value_fails() {
+        let key = Key::from([42u8; 32]);
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+        let map = (&cipher).encrypt_map().encrypt_key("first").unwrap();
+        assert!(map.encrypt_key("second").is_err());
+    }
+
+    #[test]
+    fn encrypt_value_without_pending_key_fails() {
+        let key = Key::from([42u8; 32]);
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+        let map = (&cipher).encrypt_map();
+        assert!(map.encrypt_value("orphan-value", ()).is_err());
+    }
+
+    #[test]
+    fn passthrough_entry_with_pending_key_fails() {
+        let key = Key::from([42u8; 32]);
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+        let map = (&cipher).encrypt_map().encrypt_key("pending").unwrap();
+        // Adopting the new key here would silently drop "pending".
+        assert!(map.passthrough_entry("other", 42u32).is_err());
+    }
+
+    #[test]
+    fn end_with_pending_key_fails() {
+        let key = Key::from([42u8; 32]);
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+        let map = (&cipher).encrypt_map().encrypt_key("pending").unwrap();
+        assert!(map.end().is_err());
+    }
+
+    #[test]
+    fn passthrough_entry_succeeds_with_no_pending_key() {
+        let key = Key::from([42u8; 32]);
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+        // Sanity: the new guard does not break the happy path.
+        let ciphertext = (&cipher)
+            .encrypt_map()
+            .passthrough_entry("version", 1u32)
+            .and_then(|m| m.end())
+            .expect("passthrough_entry should succeed without a pending key");
+        match ciphertext {
+            AesCipherText::Map(entries) => {
+                assert_eq!(entries.len(), 1);
+                assert_eq!(entries[0].0, "version");
+                assert!(matches!(entries[0].1, AesCipherText::Passthrough(_)));
+            }
+            _ => panic!("expected Map ciphertext"),
+        }
+    }
 }

--- a/packages/encrypt/src/cipher.rs
+++ b/packages/encrypt/src/cipher.rs
@@ -6,7 +6,7 @@ use vitaminc_aead::{
     LocalCipherText, MapAccess, MapCipher, NonceGenerator, RandomNonceGenerator, SeqAccess,
     SeqCipher, Unspecified,
 };
-use vitaminc_protected::Controlled;
+use vitaminc_protected::Protected;
 
 /// The recursive ciphertext container produced by [`Aes256Cipher`].
 ///
@@ -61,7 +61,11 @@ impl<'c> Cipher for &'c Aes256Cipher {
     type SeqCipher = AesSeqCipher<'c>;
     type MapCipher = AesMapCipher<'c>;
 
-    fn encrypt_bytes_vec<'a, A>(self, data: Vec<u8>, aad: A) -> Result<Self::Ok, Self::Error>
+    fn encrypt_bytes_vec<'a, A>(
+        self,
+        data: Protected<Vec<u8>>,
+        aad: A,
+    ) -> Result<Self::Ok, Self::Error>
     where
         A: IntoAad<'a>,
     {
@@ -251,14 +255,13 @@ impl AesDecipher<'_> {
         cipher: &Aes256Cipher,
         ct: LocalCipherText,
         aad: &[u8],
-    ) -> Result<Vec<u8>, Unspecified> {
+    ) -> Result<Protected<Vec<u8>>, Unspecified> {
         let (nonce, reader) = ct.into_reader().read_nonce::<NONCE_LEN>();
         let nonce_bytes = nonce.into_inner();
 
         reader
             .accepts_plaintext_ok(|data| cipher.key.open(&nonce_bytes, aad, data))
             .read()
-            .map(|data| data.risky_unwrap())
     }
 }
 

--- a/packages/encrypt/src/cipher.rs
+++ b/packages/encrypt/src/cipher.rs
@@ -1,5 +1,6 @@
 use crate::backend::{CipherKey, NONCE_LEN};
 use crate::Key;
+use std::any::Any;
 use vitaminc_aead::{
     Cipher, CipherTextBuilder, Decipher, DecipherVisitor, Decrypt, Encrypt, IntoAad,
     LocalCipherText, MapAccess, MapCipher, NonceGenerator, RandomNonceGenerator, SeqAccess,
@@ -22,6 +23,15 @@ pub enum AesCipherText {
     /// A map of (cleartext key, ciphertext value) pairs produced from a
     /// `HashMap`-shaped plaintext. Keys are not encrypted.
     Map(Vec<(String, AesCipherText)>),
+    /// The authenticated absent marker produced by [`Cipher::encrypt_none`].
+    /// Stores a sealed empty plaintext whose tag binds the supplied AAD.
+    None(LocalCipherText),
+    /// A typed value passed through unencrypted via [`Cipher::passthrough`].
+    /// Not serializable to bytes — see
+    /// `packages/aead/src/cipher.rs` for the API-level type bound and the
+    /// runtime downcast performed by
+    /// [`Decipher::decrypt_passthrough`](vitaminc_aead::Decipher::decrypt_passthrough).
+    Passthrough(Box<dyn Any + Send + 'static>),
 }
 
 /// Implements AES-256-GCM. Backend is selected at compile time:
@@ -86,9 +96,32 @@ impl<'c> Cipher for &'c Aes256Cipher {
         }
     }
 
-    // Tracked: https://github.com/cipherstash/vitaminc/issues/172
-    // fn encrypt_none(self) -> Result<Self::Ok, Self::Error> { }
-    // fn passthrough<T: 'static>(self, data: T) -> Result<Self::Ok, Self::Error> { }
+    fn encrypt_none<'a, A>(self, aad: A) -> Result<Self::Ok, Self::Error>
+    where
+        A: IntoAad<'a>,
+    {
+        let nonce = self.nonce_generator.generate()?;
+        let nonce_bytes: [u8; NONCE_LEN] = nonce.as_ref().try_into().map_err(|_| Unspecified)?;
+        let aad = aad.into_aad();
+
+        CipherTextBuilder::new()
+            .append_nonce(nonce)
+            .append_target_plaintext(Vec::<u8>::new())
+            .accepts_ciphertext_and_tag_ok(|mut buf| {
+                self.key
+                    .seal(&nonce_bytes, aad.as_bytes(), &mut buf)
+                    .map(|()| buf)
+            })
+            .build()
+            .map(AesCipherText::None)
+    }
+
+    fn passthrough<T>(self, value: T) -> Result<Self::Ok, Self::Error>
+    where
+        T: Any + Send + 'static,
+    {
+        Ok(AesCipherText::Passthrough(Box::new(value)))
+    }
 }
 
 /// [`SeqCipher`] driver for [`Aes256Cipher`]. Encrypts each element under its
@@ -110,6 +143,14 @@ impl<'c> SeqCipher for AesSeqCipher<'c> {
     {
         let encrypted = data.encrypt_with_aad(self.cipher, aad)?;
         self.items.push(encrypted);
+        Ok(self)
+    }
+
+    fn passthrough_next<T>(mut self, value: T) -> Result<Self, Self::Error>
+    where
+        T: Any + Send + 'static,
+    {
+        self.items.push(AesCipherText::Passthrough(Box::new(value)));
         Ok(self)
     }
 
@@ -150,6 +191,15 @@ impl<'c> MapCipher for AesMapCipher<'c> {
         let key = self.current_key.take().ok_or(Unspecified)?;
         let encrypted = value.encrypt_with_aad(self.cipher, aad)?;
         self.entries.push((key.to_string(), encrypted));
+        Ok(self)
+    }
+
+    fn passthrough_entry<T>(mut self, key: &'static str, value: T) -> Result<Self, Self::Error>
+    where
+        T: Any + Send + 'static,
+    {
+        self.entries
+            .push((key.to_string(), AesCipherText::Passthrough(Box::new(value))));
         Ok(self)
     }
 
@@ -262,6 +312,41 @@ impl<'c> Decipher<'c> for AesDecipher<'c> {
                 visitor.visit_map(map_access)
             }
             _ => Err(Unspecified),
+        }
+    }
+
+    fn decrypt_passthrough<T>(self) -> Self::Ok<T>
+    where
+        T: Any + Send + 'static,
+    {
+        match self.ciphertext {
+            AesCipherText::Passthrough(boxed) => {
+                boxed.downcast::<T>().map(|b| *b).map_err(|_| Unspecified)
+            }
+            _ => Err(Unspecified),
+        }
+    }
+
+    fn decrypt_option<T>(self) -> Self::Ok<Option<T>>
+    where
+        T: Decrypt<'c> + 'c,
+    {
+        match self.ciphertext {
+            AesCipherText::None(ct) => {
+                // Verify the AAD-bound tag over the empty plaintext.
+                Self::decrypt_local_ciphertext(self.cipher, ct, &self.aad)?;
+                Ok(None)
+            }
+            // Passthrough must never be decoded as an Option payload.
+            AesCipherText::Passthrough(_) => Err(Unspecified),
+            other => {
+                let inner = AesDecipher {
+                    cipher: self.cipher,
+                    ciphertext: other,
+                    aad: self.aad,
+                };
+                T::decrypt(inner).map(Some)
+            }
         }
     }
 }
@@ -477,5 +562,136 @@ mod test {
         let ciphertext = protected.encrypt(&cipher).expect("Encryption failed");
         let decrypted: Protected<String> = cipher.decrypt(ciphertext).expect("Decryption failed");
         decrypted.risky_unwrap() == plaintext
+    }
+
+    #[quickcheck]
+    fn roundtrip_option_some_string(key: Key, plaintext: String) -> bool {
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+        let value = Some(plaintext.clone());
+        let ciphertext = value.encrypt(&cipher).expect("Encryption failed");
+        let decrypted: Option<String> = cipher.decrypt(ciphertext).expect("Decryption failed");
+        decrypted == Some(plaintext)
+    }
+
+    #[test]
+    fn roundtrip_option_none_string() {
+        let key = Key::from([7u8; 32]);
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+        let value: Option<String> = None;
+        let ciphertext = value.encrypt(&cipher).expect("Encryption failed");
+        let decrypted: Option<String> = cipher.decrypt(ciphertext).expect("Decryption failed");
+        assert_eq!(decrypted, None);
+    }
+
+    #[quickcheck]
+    fn roundtrip_option_some_with_aad(key: Key, plaintext: String) -> bool {
+        let aad = "opt-aad";
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+        let ciphertext = Some(plaintext.clone())
+            .encrypt_with_aad(&cipher, aad)
+            .expect("Encryption failed");
+        let decrypted: Option<String> = cipher
+            .decrypt_with_aad(ciphertext, aad)
+            .expect("Decryption failed");
+        decrypted == Some(plaintext)
+    }
+
+    #[quickcheck]
+    fn roundtrip_option_none_with_aad(key: Key) -> bool {
+        let aad = "opt-none-aad";
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+        let ciphertext = None::<String>
+            .encrypt_with_aad(&cipher, aad)
+            .expect("Encryption failed");
+        let decrypted: Option<String> = cipher
+            .decrypt_with_aad(ciphertext, aad)
+            .expect("Decryption failed");
+        decrypted.is_none()
+    }
+
+    #[quickcheck]
+    fn decrypt_option_none_fails_with_wrong_aad(key: Key) -> bool {
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+        let ciphertext = None::<String>
+            .encrypt_with_aad(&cipher, "correct")
+            .expect("Encryption failed");
+        cipher
+            .decrypt_with_aad::<Option<String>, _>(ciphertext, "wrong")
+            .is_err()
+    }
+
+    #[test]
+    fn decrypt_string_rejects_none_ciphertext() {
+        // Closes the empty-plaintext masking concern: an authenticated `None`
+        // marker must not be decodable as `String("")`.
+        let key = Key::from([9u8; 32]);
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+        let ciphertext = None::<String>.encrypt(&cipher).expect("Encryption failed");
+        assert!(cipher.decrypt::<String>(ciphertext).is_err());
+    }
+
+    #[test]
+    fn decrypt_option_rejects_passthrough_ciphertext() {
+        // Type-laundering guard: a passthrough must not satisfy Option<T>.
+        let key = Key::from([11u8; 32]);
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+        let ciphertext = (&cipher).passthrough(42u32).expect("passthrough failed");
+        assert!(cipher.decrypt::<Option<u32>>(ciphertext).is_err());
+    }
+
+    #[test]
+    fn roundtrip_passthrough_u32() {
+        let key = Key::from([1u8; 32]);
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+        let ciphertext = (&cipher).passthrough(12345u32).expect("passthrough failed");
+        let decrypted: u32 = decrypt_passthrough_via(&cipher, ciphertext).expect("decode failed");
+        assert_eq!(decrypted, 12345u32);
+    }
+
+    #[test]
+    fn roundtrip_passthrough_string() {
+        let key = Key::from([2u8; 32]);
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+        let ciphertext = (&cipher)
+            .passthrough(String::from("version-tag"))
+            .expect("passthrough failed");
+        let decrypted: String = decrypt_passthrough_via(&cipher, ciphertext).expect("decode failed");
+        assert_eq!(decrypted, "version-tag");
+    }
+
+    #[test]
+    fn passthrough_type_mismatch_returns_err() {
+        let key = Key::from([3u8; 32]);
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+        let ciphertext = (&cipher).passthrough(42u32).expect("passthrough failed");
+        let result: Result<String, _> = decrypt_passthrough_via(&cipher, ciphertext);
+        assert!(result.is_err());
+    }
+
+    // Convenience: drive `Decipher::decrypt_passthrough` from a known
+    // ciphertext. Mirrors what a derive-generated `Decrypt` impl would do
+    // for a `#[encrypt(passthrough)]` field.
+    fn decrypt_passthrough_via<T>(
+        cipher: &Aes256Cipher,
+        ciphertext: AesCipherText,
+    ) -> Result<T, Unspecified>
+    where
+        T: Any + Send + 'static,
+    {
+        let decipher = AesDecipher {
+            cipher,
+            ciphertext,
+            aad: Vec::new(),
+        };
+        decipher.decrypt_passthrough::<T>()
+    }
+
+    #[quickcheck]
+    fn roundtrip_vec_of_option_string(key: Key, items: Vec<Option<String>>) -> bool {
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+        let ciphertext = items.clone().encrypt(&cipher).expect("Encryption failed");
+        let decrypted: Vec<Option<String>> =
+            cipher.decrypt(ciphertext).expect("Decryption failed");
+        decrypted == items
     }
 }

--- a/packages/encrypt/src/cipher.rs
+++ b/packages/encrypt/src/cipher.rs
@@ -166,6 +166,18 @@ impl<'c> SeqCipher for AesSeqCipher<'c> {
 /// [`MapCipher`] driver for [`Aes256Cipher`]. Keys are stored in the clear;
 /// values are encrypted under their own fresh nonce and accumulated into an
 /// [`AesCipherText::Map`].
+///
+/// This driver is intended for encrypting sources that already enforce key
+/// uniqueness themselves — `HashMap`s and structs (whose field names are
+/// unique by construction). It therefore stores `entries` as a *positional
+/// list* and performs **no duplicate-key checks** of its own.
+///
+/// Implementors should be aware: if the same key is pushed by two completed
+/// `encrypt_value` / `passthrough_entry` calls, both are kept, and on decrypt
+/// the `HashMap`-shaped visitor is **last-wins**. The built-in
+/// `Encrypt for HashMap` impl never does this (the source map already dedups),
+/// so it is unreachable today; a custom encoder driving this trait directly is
+/// responsible for not emitting duplicate keys.
 pub struct AesMapCipher<'c> {
     cipher: &'c Aes256Cipher,
     entries: Vec<(String, AesCipherText)>,
@@ -353,6 +365,18 @@ impl<'c> Decipher<'c> for AesDecipher<'c> {
             }
             // Passthrough must never be decoded as an Option payload.
             AesCipherText::Passthrough(_) => Err(Unspecified),
+            // Any other variant is the `Some` payload: recurse into `T`. This is
+            // what lets `Option<Vec<T>>`, `Option<HashMap<K, V>>`,
+            // `Option<Protected<T>>` compose naturally.
+            //
+            // Note: there is no depth tag in the ciphertext, so the *shape* of
+            // nested options is decided by `T` at the call site, not by the
+            // bytes — `Some(Some(x))` and `Some(x)` seal to identical
+            // `Single(_)` ciphertexts. Decoding the same ciphertext as
+            // `Option<String>` yields `Some("x")` and as `Option<Option<String>>`
+            // yields `Some(Some("x"))`; both succeed. This mirrors serde's
+            // treatment of `Option` and is intentional — every caller fixes a
+            // concrete type at the call site. See `nested_option_shape_is_caller_decided`.
             other => {
                 let inner = AesDecipher {
                     cipher: self.cipher,

--- a/packages/encrypt/src/cipher.rs
+++ b/packages/encrypt/src/cipher.rs
@@ -792,4 +792,319 @@ mod test {
             _ => panic!("expected Map ciphertext"),
         }
     }
+
+    // --- Nonce uniqueness (fundamental AEAD property) ---
+
+    #[quickcheck]
+    fn nonce_is_unique_across_encryptions(key: Key, plaintext: String) -> bool {
+        // Two encryptions of the same plaintext under the same cipher must
+        // produce different ciphertexts — each `encrypt_*` call draws a fresh
+        // nonce. The plaintext is incidental (the nonce is drawn independently),
+        // but running this as a property samples a fresh nonce pair per case,
+        // exercising many more of the generator's outputs than a single fixed
+        // run would. Catches a future RNG / nonce-reuse regression before it
+        // becomes a catastrophic AEAD failure.
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+        let ct1 = plaintext
+            .clone()
+            .encrypt(&cipher)
+            .expect("Encryption failed");
+        let ct2 = plaintext.encrypt(&cipher).expect("Encryption failed");
+        match (ct1, ct2) {
+            (AesCipherText::Single(a), AesCipherText::Single(b)) => a.as_ref() != b.as_ref(),
+            _ => panic!("expected Single ciphertexts"),
+        }
+    }
+
+    // --- Variant-rejection catch-alls (FC.1 cluster) ---
+    //
+    // Each `decrypt_*` method accepts exactly one `AesCipherText` variant and
+    // routes every other variant to `Err(Unspecified)`. These are the
+    // structural type-laundering guards the design relies on. The four tests
+    // below pin every catch-all sub-path (the `None`/`Passthrough` cases
+    // already pinned individually above are re-asserted here for completeness).
+    // `AesCipherText` is not `Clone`, so each rejected variant is rebuilt fresh.
+
+    fn single_ct(cipher: &Aes256Cipher) -> AesCipherText {
+        "single".to_string().encrypt(cipher).expect("encrypt")
+    }
+    fn sequence_ct(cipher: &Aes256Cipher) -> AesCipherText {
+        vec!["a".to_string(), "b".to_string()]
+            .encrypt(cipher)
+            .expect("encrypt")
+    }
+    fn map_ct(cipher: &Aes256Cipher) -> AesCipherText {
+        let mut m = HashMap::new();
+        m.insert("k", "v");
+        m.encrypt(cipher).expect("encrypt")
+    }
+    fn none_ct(cipher: &Aes256Cipher) -> AesCipherText {
+        None::<String>.encrypt(cipher).expect("encrypt")
+    }
+    fn passthrough_ct(cipher: &Aes256Cipher) -> AesCipherText {
+        cipher.passthrough(7u32).expect("passthrough")
+    }
+
+    #[test]
+    fn decrypt_bytes_rejects_non_single_variants() {
+        let cipher = Aes256Cipher::new(&Key::from([20u8; 32])).expect("Failed to create cipher");
+        // `decrypt_bytes` (driving e.g. `String`) accepts only `Single`.
+        assert!(
+            cipher.decrypt::<String>(sequence_ct(&cipher)).is_err(),
+            "Sequence"
+        );
+        assert!(cipher.decrypt::<String>(map_ct(&cipher)).is_err(), "Map");
+        assert!(cipher.decrypt::<String>(none_ct(&cipher)).is_err(), "None");
+        assert!(
+            cipher.decrypt::<String>(passthrough_ct(&cipher)).is_err(),
+            "Passthrough"
+        );
+    }
+
+    #[test]
+    fn decrypt_seq_rejects_non_sequence_variants() {
+        let cipher = Aes256Cipher::new(&Key::from([21u8; 32])).expect("Failed to create cipher");
+        // `decrypt_seq` (driving `Vec<T>`) accepts only `Sequence`.
+        assert!(
+            cipher.decrypt::<Vec<String>>(single_ct(&cipher)).is_err(),
+            "Single"
+        );
+        assert!(
+            cipher.decrypt::<Vec<String>>(map_ct(&cipher)).is_err(),
+            "Map"
+        );
+        assert!(
+            cipher.decrypt::<Vec<String>>(none_ct(&cipher)).is_err(),
+            "None"
+        );
+        assert!(
+            cipher
+                .decrypt::<Vec<String>>(passthrough_ct(&cipher))
+                .is_err(),
+            "Passthrough"
+        );
+    }
+
+    #[test]
+    fn decrypt_map_rejects_non_map_variants() {
+        let cipher = Aes256Cipher::new(&Key::from([22u8; 32])).expect("Failed to create cipher");
+        // `decrypt_map` (driving `HashMap<String, T>`) accepts only `Map`.
+        assert!(
+            cipher
+                .decrypt::<HashMap<String, String>>(single_ct(&cipher))
+                .is_err(),
+            "Single"
+        );
+        assert!(
+            cipher
+                .decrypt::<HashMap<String, String>>(sequence_ct(&cipher))
+                .is_err(),
+            "Sequence"
+        );
+        assert!(
+            cipher
+                .decrypt::<HashMap<String, String>>(none_ct(&cipher))
+                .is_err(),
+            "None"
+        );
+        assert!(
+            cipher
+                .decrypt::<HashMap<String, String>>(passthrough_ct(&cipher))
+                .is_err(),
+            "Passthrough"
+        );
+    }
+
+    #[test]
+    fn decrypt_passthrough_rejects_non_passthrough_variants() {
+        let cipher = Aes256Cipher::new(&Key::from([23u8; 32])).expect("Failed to create cipher");
+        // `decrypt_passthrough` accepts only `Passthrough`.
+        assert!(
+            decrypt_passthrough_via::<u32>(&cipher, single_ct(&cipher)).is_err(),
+            "Single"
+        );
+        assert!(
+            decrypt_passthrough_via::<u32>(&cipher, sequence_ct(&cipher)).is_err(),
+            "Sequence"
+        );
+        assert!(
+            decrypt_passthrough_via::<u32>(&cipher, map_ct(&cipher)).is_err(),
+            "Map"
+        );
+        assert!(
+            decrypt_passthrough_via::<u32>(&cipher, none_ct(&cipher)).is_err(),
+            "None"
+        );
+    }
+
+    // --- Option<T> type variation: exercise the `other`-arm sub-paths ---
+    //
+    // `roundtrip_option_some_string` only lands the `Single` sub-path with a
+    // `String` leaf. These cover a non-String `Single` leaf (u32), the
+    // `Sequence` sub-path (Vec), the `Map` sub-path (HashMap), and the
+    // `Protected`-rewrap path.
+
+    #[quickcheck]
+    fn roundtrip_option_some_u32(key: Key, value: u32) -> bool {
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+        let ct = Some(value).encrypt(&cipher).expect("Encryption failed");
+        cipher
+            .decrypt::<Option<u32>>(ct)
+            .expect("Decryption failed")
+            == Some(value)
+    }
+
+    #[quickcheck]
+    fn roundtrip_option_some_vec_of_strings(items: Vec<String>) -> bool {
+        let cipher = Aes256Cipher::new(&Key::from([31u8; 32])).expect("Failed to create cipher");
+        let ct = Some(items.clone())
+            .encrypt(&cipher)
+            .expect("Encryption failed");
+        cipher
+            .decrypt::<Option<Vec<String>>>(ct)
+            .expect("Decryption failed")
+            == Some(items)
+    }
+
+    #[test]
+    fn roundtrip_option_some_hashmap() {
+        let cipher = Aes256Cipher::new(&Key::from([32u8; 32])).expect("Failed to create cipher");
+        let mut m = HashMap::new();
+        m.insert("name", "Alice");
+        let ct = Some(m).encrypt(&cipher).expect("Encryption failed");
+        let decoded: Option<HashMap<String, String>> =
+            cipher.decrypt(ct).expect("Decryption failed");
+        assert_eq!(
+            decoded.unwrap().get("name").map(String::as_str),
+            Some("Alice")
+        );
+    }
+
+    #[quickcheck]
+    fn roundtrip_option_some_protected_string(plaintext: String) -> bool {
+        use vitaminc_protected::{Controlled, Protected};
+        let cipher = Aes256Cipher::new(&Key::from([33u8; 32])).expect("Failed to create cipher");
+        let ct = Some(Protected::new(plaintext.clone()))
+            .encrypt(&cipher)
+            .expect("Encryption failed");
+        let decoded: Option<Protected<String>> = cipher.decrypt(ct).expect("Decryption failed");
+        decoded.map(Controlled::risky_unwrap) == Some(plaintext)
+    }
+
+    #[quickcheck]
+    fn decrypt_option_some_fails_with_wrong_aad(plaintext: String) -> bool {
+        // Wrong-AAD rejection threaded through the `Option` type itself (not just
+        // the inner leaf).
+        let cipher = Aes256Cipher::new(&Key::from([34u8; 32])).expect("Failed to create cipher");
+        let ct = Some(plaintext)
+            .encrypt_with_aad(&cipher, "correct")
+            .expect("Encryption failed");
+        cipher
+            .decrypt_with_aad::<Option<String>, _>(ct, "wrong")
+            .is_err()
+    }
+
+    #[test]
+    fn nested_option_shape_is_caller_decided() {
+        // `Some(Some(x))` seals to the same `Single(_)` as `Some(x)`; the
+        // call-site type decides the decoded shape. Pins the documented
+        // serde-style property so an accidental future "fix" can't close the
+        // recursion door. See the note on `decrypt_option`.
+        let cipher = Aes256Cipher::new(&Key::from([35u8; 32])).expect("Failed to create cipher");
+        let outer: Option<Option<String>> = Some(Some("x".into()));
+        let ct = outer.encrypt(&cipher).expect("Encryption failed");
+        let decoded: Option<String> = cipher.decrypt(ct).expect("Decryption failed");
+        assert_eq!(decoded, Some("x".into()));
+    }
+
+    // --- Mixed encrypted / passthrough entries + Any-TypeId ---
+
+    #[test]
+    fn seq_cipher_accepts_mixed_encrypt_next_and_passthrough_next() {
+        let cipher = Aes256Cipher::new(&Key::from([40u8; 32])).expect("Failed to create cipher");
+        let ct = (&cipher)
+            .encrypt_seq(Some(3))
+            .encrypt_next("first", ())
+            .unwrap()
+            .passthrough_next(99u32)
+            .unwrap()
+            .encrypt_next("third", ())
+            .unwrap()
+            .end()
+            .unwrap();
+        match ct {
+            AesCipherText::Sequence(items) => {
+                assert_eq!(items.len(), 3);
+                assert!(matches!(items[0], AesCipherText::Single(_)));
+                assert!(matches!(items[1], AesCipherText::Passthrough(_)));
+                assert!(matches!(items[2], AesCipherText::Single(_)));
+            }
+            _ => panic!("expected Sequence"),
+        }
+    }
+
+    #[test]
+    fn map_with_mixed_entries_cannot_decode_as_uniform_hashmap() {
+        // A passthrough value in a map cannot satisfy a uniform `HashMap<_, T>`
+        // decode: `T`'s bytes visitor hits the FC.1 catch-all on the
+        // Passthrough variant, failing the whole decode.
+        let cipher = Aes256Cipher::new(&Key::from([41u8; 32])).expect("Failed to create cipher");
+        let ct = (&cipher)
+            .encrypt_map()
+            .encrypt_key("name")
+            .unwrap()
+            .encrypt_value("Alice".to_string(), ())
+            .unwrap()
+            .passthrough_entry("schema_version", 1u32)
+            .unwrap()
+            .end()
+            .unwrap();
+        assert!(cipher.decrypt::<HashMap<String, String>>(ct).is_err());
+    }
+
+    #[test]
+    fn roundtrip_hashmap_of_option_values() {
+        // The companion happy case: mixed Some/None values decode correctly iff
+        // the decode type explicitly accepts the variation (`Option<T>`).
+        let cipher = Aes256Cipher::new(&Key::from([42u8; 32])).expect("Failed to create cipher");
+        let mut m: HashMap<&'static str, Option<String>> = HashMap::new();
+        m.insert("present", Some("Alice".to_string()));
+        m.insert("absent", None);
+        let ct = m.encrypt(&cipher).expect("Encryption failed");
+        let decoded: HashMap<String, Option<String>> =
+            cipher.decrypt(ct).expect("Decryption failed");
+        assert_eq!(decoded.get("present"), Some(&Some("Alice".to_string())));
+        assert_eq!(decoded.get("absent"), Some(&None));
+    }
+
+    #[test]
+    fn passthrough_option_is_distinct_type_from_inner() {
+        // `Any`/`TypeId` pin: `Option<u32>` and `u32` are distinct types even
+        // when the value is `Some(n)`. A passthrough sealed as `Option<u32>`
+        // must only downcast back to `Option<u32>`.
+        let cipher = Aes256Cipher::new(&Key::from([43u8; 32])).expect("Failed to create cipher");
+        let ct = cipher.passthrough(Some(42u32)).expect("passthrough failed");
+        let decoded: Option<u32> =
+            decrypt_passthrough_via(&cipher, ct).expect("decode as Option<u32> should succeed");
+        assert_eq!(decoded, Some(42u32));
+
+        let ct2 = cipher.passthrough(Some(42u32)).expect("passthrough failed");
+        assert!(
+            decrypt_passthrough_via::<u32>(&cipher, ct2).is_err(),
+            "Option<u32> passthrough must not downcast to u32"
+        );
+    }
+
+    #[quickcheck]
+    fn decrypt_byte_array_ciphertext_as_vec_u8(key: Key, bytes: [u8; 16]) -> bool {
+        // `Decrypt for Vec<u8>` reads the bytes pipeline (`Single`), not a
+        // `Sequence`. There is no `Encrypt for Vec<u8>` (no `Encrypt for u8`),
+        // so a `[u8; N]` ciphertext is the canonical `Single` producer
+        // decodable as `Vec<u8>`. Pins the otherwise-unexercised impl across
+        // arbitrary byte payloads.
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+        let ct = bytes.encrypt(&cipher).expect("Encryption failed");
+        let decoded: Vec<u8> = cipher.decrypt(ct).expect("Decryption failed");
+        decoded == bytes.to_vec()
+    }
 }

--- a/packages/encrypt/src/cipher.rs
+++ b/packages/encrypt/src/cipher.rs
@@ -658,7 +658,8 @@ mod test {
         let ciphertext = (&cipher)
             .passthrough(String::from("version-tag"))
             .expect("passthrough failed");
-        let decrypted: String = decrypt_passthrough_via(&cipher, ciphertext).expect("decode failed");
+        let decrypted: String =
+            decrypt_passthrough_via(&cipher, ciphertext).expect("decode failed");
         assert_eq!(decrypted, "version-tag");
     }
 
@@ -693,8 +694,7 @@ mod test {
     fn roundtrip_vec_of_option_string(key: Key, items: Vec<Option<String>>) -> bool {
         let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
         let ciphertext = items.clone().encrypt(&cipher).expect("Encryption failed");
-        let decrypted: Vec<Option<String>> =
-            cipher.decrypt(ciphertext).expect("Decryption failed");
+        let decrypted: Vec<Option<String>> = cipher.decrypt(ciphertext).expect("Decryption failed");
         decrypted == items
     }
 }

--- a/packages/encrypt/src/cipher.rs
+++ b/packages/encrypt/src/cipher.rs
@@ -202,12 +202,23 @@ impl<'c> MapCipher for AesMapCipher<'c> {
     where
         T: Any + Send + 'static,
     {
+        // A key already pending means `encrypt_key` ran without a matching
+        // `encrypt_value` — adopting it here would silently drop the pending
+        // key, which is the same trait-contract violation `encrypt_key`
+        // rejects.
+        if self.current_key.is_some() {
+            return Err(Unspecified);
+        }
         self.entries
             .push((key.to_string(), AesCipherText::Passthrough(Box::new(value))));
         Ok(self)
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
+        // Finalising with a pending key would silently drop the entry.
+        if self.current_key.is_some() {
+            return Err(Unspecified);
+        }
         Ok(AesCipherText::Map(self.entries))
     }
 }

--- a/packages/encrypt/src/key.rs
+++ b/packages/encrypt/src/key.rs
@@ -34,7 +34,9 @@ impl Encrypt for Key {
         C: Cipher,
         A: IntoAad<'a>,
     {
-        cipher.encrypt_bytes_array(self.0.risky_unwrap(), aad)
+        // The 32-byte key material stays inside `Protected` all the way to
+        // the cipher boundary — it is never exposed as a bare `[u8; 32]`.
+        cipher.encrypt_bytes_array(self.0, aad)
     }
 }
 

--- a/packages/encrypt/src/key.rs
+++ b/packages/encrypt/src/key.rs
@@ -12,6 +12,10 @@ pub struct Key(Protected<[u8; 32]>);
 
 impl Key {
     pub(crate) fn cipher_key(&self) -> Result<CipherKey, Unspecified> {
+        // SAFETY: the borrowed `&[u8; 32]` is consumed by `CipherKey::new` only
+        // for the duration of the constructor; the backend cipher-key handle
+        // holds an opaque copy thereafter, so no bare key material outlives this
+        // call. `self.0` stays owned by `Protected` and is wiped on drop.
         CipherKey::new(self.0.risky_ref())
     }
 }


### PR DESCRIPTION
Builds on top of #148. Closes the three deferrals tracked in #171, #172, #173.

## Summary

- `Cipher::encrypt_some` (default forwarder), `Cipher::encrypt_none` (required), `Cipher::passthrough<T: Any + Send + 'static>` (required)
- `SeqCipher::passthrough_next`, `MapCipher::passthrough_entry`
- `Decipher::decrypt_option<T>` and `decrypt_passthrough<T>` — typed direct accessors that bypass the visitor (target type is already concrete at the call site)
- `Encrypt` / `Decrypt` for `Option<T>`
- `AesCipherText` gains `None(LocalCipherText)` (sealed empty plaintext, AAD bound to the tag) and `Passthrough(Box<dyn Any + Send + 'static>)`

## Design notes

- **`None` is cryptographically authenticated**, not just a structural marker — seals an empty plaintext under the supplied AAD so the absent case cannot be forged or migrated between contexts
- **Visitor trait left unchanged** — `decrypt_option` and `decrypt_passthrough` are direct typed methods on `Decipher` because the target type is concrete at the call site, so dispatch via a visitor would only add stub methods to every existing visitor
- **`Box<dyn Any>` for passthrough** is documented as static-at-the-API-boundary with a runtime downcast on decryption. The earlier spike at `Spikes/protect-rs-spike` tried `erased_serde` and a fully-static cons-list — both were shelved. Trade-off: `AesCipherText` containing a `Passthrough` is not `Serialize` — a follow-up will be needed before it can be persisted across processes
- **Type-laundering guards**: `decrypt_option` rejects `Passthrough`, and `decrypt_passthrough` rejects every non-passthrough variant. The existing `_ => Err` arms in `decrypt_bytes` / `decrypt_seq` / `decrypt_map` already reject `None` and `Passthrough`

## Deviation from the design

- `Cipher::encrypt_none` and `Cipher::passthrough` are **required** rather than defaulted to `Err`. `Self::Error` is an associated type so a generic default can't construct one. Future mock ciphers will need stubs

## Protected<T> chain of custody (def6668)

Pushed `Protected<T>` — the workspace's chain-of-custody primitive — through the `Cipher` / `DecipherVisitor` trait surface so the protection guarantee is enforced at the choke-point rather than at every leaf. Driven by the zeroize audit (see Validation below).

- `Cipher::encrypt_bytes_vec` / `encrypt_bytes_array` take `Protected<Vec<u8>>` / `Protected<[u8; N]>`
- `DecipherVisitor::visit_bytes_vec` takes `Protected<Vec<u8>>`
- `AesDecipher::decrypt_local_ciphertext` returns `Protected<Vec<u8>>` — no trailing `risky_unwrap`
- `Key::encrypt_with_aad` passes `self.0` straight through — the 32-byte key never exists as a bare `[u8; 32]` at the trait boundary
- The default `encrypt_bytes_array` impl uses `risky_ref` so the outer `Protected<[u8; N]>` stays owned and is wiped on drop (resolves #170)

Passthrough's `T: Any + Send + 'static` bound is **deliberately not tightened** to add `Zeroize` — passthrough is for non-sensitive data (schema tags, format flags) by design. Doc comments strengthened to make this explicit and point secret-bearing callers at `Encrypt` / `Protected`.

Map-state guards (765ffac): `AesMapCipher::passthrough_entry` and `AesMapCipher::end` now reject a pending `current_key`, matching the check `encrypt_key` already had. `Encrypt for u32` routes via `encrypt_bytes_array(Protected::new(self.to_le_bytes()))` to skip a heap hop.

### Breaking

Two `Cipher` trait method signatures change shape. External implementers must update `encrypt_bytes_vec` / `encrypt_bytes_array`.

## Validation

- **Zeroize audit (`/zeroize-audit` skill)** — initial run on `vitaminc-aead` + `vitaminc-encrypt` surfaced 12 findings driving the refactor above. Re-run after `def6668`: 8 prior findings resolved (1 high, 7 medium), passthrough correctly not re-flagged (matches design intent). One **new cross-crate issue** surfaced: `vitaminc_protected::Protected<T>` derives `Zeroize` and asserts `ZeroizeOnDrop` but **has no `Drop` impl**, so the leaf zeroize threaded by this PR is not yet enforced at runtime. The type-level chain of custody is correct; the leaf wipe will start firing automatically once `Protected<T>` gains its `Drop`. Tracked in #181.
- **Copilot review** — 6 inline comments. Two addressed in 765ffac (`AesMapCipher::passthrough_entry` and `end` were missing the `current_key` contract check; plus a `u32` `Encrypt` impl simplification). Three deferred to #181 with explicit replies on each thread — the three `visit_bytes_vec` error-path comments are subsumed by the Protected `Drop` fix. One non-actionable.
- **Claude Code review (in-loop)** — planning agent designed the trait surface change before code was written; explore agent mapped all `risky_unwrap` call sites across the workspace; the plan was refined against a "prefer `Protected` over `Zeroizing`" preference and a "passthrough is intentionally non-sensitive" design intent saved as project memory.
- **Manual review** — by the PR author.

## Test plan

- [x] `roundtrip_option_some_string` (quickcheck)
- [x] `roundtrip_option_none_string`
- [x] `roundtrip_option_some_with_aad` / `roundtrip_option_none_with_aad`
- [x] `decrypt_option_none_fails_with_wrong_aad`
- [x] `decrypt_string_rejects_none_ciphertext` (empty-plaintext masking guard)
- [x] `decrypt_option_rejects_passthrough_ciphertext` (type-laundering guard)
- [x] `roundtrip_passthrough_u32` / `roundtrip_passthrough_string`
- [x] `passthrough_type_mismatch_returns_err`
- [x] `roundtrip_vec_of_option_string` (Option inside SeqAccess)
- [x] `encrypt_key_twice_without_value_fails` — MapCipher state-machine
- [x] `encrypt_value_without_pending_key_fails`
- [x] `passthrough_entry_with_pending_key_fails`
- [x] `end_with_pending_key_fails`
- [x] `passthrough_entry_succeeds_with_no_pending_key`
- [x] `cargo test --workspace` green (one unrelated `vitaminc-kms` test fails locally on missing localstack; CI-side `Test` job green)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

## Follow-ups

- #181 `Protected<T>` missing `Drop` impl (also affects `Equatable<T>` / `Exportable<T>`)
- Wire-format serialization of `AesCipherText` containing `Passthrough` (`Box<dyn Any>` is not `Serialize`)
- `SeqAccess::next_passthrough` / `MapAccess::next_passthrough_entry` — add only when the future derive macro needs them