### PR TITLE
feat(aead, encrypt): HList-based static cipher shape behind `hlist` feature

### DIFF
--- a/packages/aead/Cargo.toml
+++ b/packages/aead/Cargo.toml
@@ -19,6 +19,19 @@ bytes = { version = "^1", features = ["serde"] }
 serde = { workspace = true }
 zeroize = { workspace = true }
 
+[features]
+test-utils = []
+# Opt-in HList-based ciphertext shape. Trades the dynamic `Cipher::Ok` enum
+# (heap-allocated `Vec`s, `Box<dyn Any>` passthrough) for a per-call typed
+# builder where the full structural shape is encoded in the type system —
+# no heap nodes, no type erasure, statically-typed passthrough access.
+#
+# Best suited to native Rust performance-sensitive paths; the dynamic
+# default remains preferable for wasm32 / JS bindings where bundle size
+# and runtime-determined shapes matter more.
+hlist = []
+
+
 [dev-dependencies]
 quickcheck = "1.1.0"
 quickcheck_macros = "1.2.0"

--- a/packages/aead/Cargo.toml
+++ b/packages/aead/Cargo.toml
@@ -20,7 +20,6 @@ serde = { workspace = true }
 zeroize = { workspace = true }
 
 [features]
-test-utils = []
 # Opt-in HList-based ciphertext shape. Trades the dynamic `Cipher::Ok` enum
 # (heap-allocated `Vec`s, `Box<dyn Any>` passthrough) for a per-call typed
 # builder where the full structural shape is encoded in the type system —

--- a/packages/aead/src/ciphertext/mod.rs
+++ b/packages/aead/src/ciphertext/mod.rs
@@ -74,7 +74,10 @@ mod tests {
             })
             .build()?;
 
-        let (nonce, reader) = ciphertext.into_reader().read_nonce::<12>();
+        let (nonce, reader) = ciphertext
+            .into_reader()
+            .read_nonce::<12>()
+            .map_err(|_| ())?;
 
         let plaintext = reader
             .accepts_plaintext_ok(|data| {

--- a/packages/aead/src/ciphertext/read_monads.rs
+++ b/packages/aead/src/ciphertext/read_monads.rs
@@ -1,4 +1,4 @@
-use crate::Nonce;
+use crate::{Nonce, Unspecified};
 use bytes::{Buf, Bytes};
 use std::array;
 use vitaminc_protected::{Controlled, Protected};
@@ -10,14 +10,26 @@ impl CipherTextReader {
         Self(bytes)
     }
 
-    pub fn read_nonce<const N: usize>(self) -> (Nonce<N>, CiphertextAndTagReader) {
+    /// Split off the leading `N`-byte nonce, returning it plus a reader over the
+    /// remaining ciphertext-and-tag bytes.
+    ///
+    /// Returns [`Unspecified`] if fewer than `N` bytes are available, rather
+    /// than panicking — the input may be attacker-controlled (e.g. a
+    /// deserialized [`LocalCipherText`](crate::LocalCipherText) built from
+    /// untrusted bytes), so a short buffer must be a recoverable error.
+    pub fn read_nonce<const N: usize>(
+        self,
+    ) -> Result<(Nonce<N>, CiphertextAndTagReader), Unspecified> {
+        if self.0.len() < N {
+            return Err(Unspecified);
+        }
         let mut buf = self.0.take(N);
         let nonce_inner: [u8; N] = array::from_fn(|_| buf.get_u8());
 
-        (
+        Ok((
             Nonce::new(nonce_inner),
             CiphertextAndTagReader::new(buf.into_inner()),
-        )
+        ))
     }
 }
 

--- a/packages/aead/src/hlist/cipher.rs
+++ b/packages/aead/src/hlist/cipher.rs
@@ -3,6 +3,8 @@
 // it across each method signature.
 #![allow(clippy::type_complexity)]
 
+use vitaminc_protected::Protected;
+
 use crate::IntoAad;
 
 use super::types::{Absent, Encrypted, Entry, Map, Passthrough};
@@ -22,7 +24,15 @@ pub trait StaticCipher: Sized + Copy {
     type Error;
 
     /// Seal `data` under the supplied AAD.
-    fn encrypt_bytes<'a, A>(self, data: Vec<u8>, aad: A) -> Result<Encrypted, Self::Error>
+    ///
+    /// The plaintext is taken as `Protected<Vec<u8>>` so the chain of custody
+    /// — and the zeroize-on-drop guarantee — survives the trait boundary,
+    /// matching [`Cipher::encrypt_bytes_vec`](crate::Cipher::encrypt_bytes_vec).
+    fn encrypt_bytes<'a, A>(
+        self,
+        data: Protected<Vec<u8>>,
+        aad: A,
+    ) -> Result<Encrypted, Self::Error>
     where
         A: IntoAad<'a>;
 
@@ -61,7 +71,7 @@ where
     pub fn encrypt_entry<'a, A>(
         self,
         key: &'static str,
-        value: Vec<u8>,
+        value: Protected<Vec<u8>>,
         aad: A,
     ) -> Result<StaticMapBuilder<C, HCons<Entry<Encrypted>, L>>, C::Error>
     where

--- a/packages/aead/src/hlist/cipher.rs
+++ b/packages/aead/src/hlist/cipher.rs
@@ -26,8 +26,10 @@ pub trait StaticCipher: Sized + Copy {
     /// Seal `data` under the supplied AAD.
     ///
     /// The plaintext is taken as `Protected<Vec<u8>>` so the chain of custody
-    /// — and the zeroize-on-drop guarantee — survives the trait boundary,
-    /// matching [`Cipher::encrypt_bytes_vec`](crate::Cipher::encrypt_bytes_vec).
+    /// survives the trait boundary, matching
+    /// [`Cipher::encrypt_bytes_vec`](crate::Cipher::encrypt_bytes_vec). The
+    /// zeroize-on-drop guarantee is not yet in effect — `Protected<T>` has no
+    /// `Drop` impl today; that is tracked in #181.
     fn encrypt_bytes<'a, A>(
         self,
         data: Protected<Vec<u8>>,

--- a/packages/aead/src/hlist/cipher.rs
+++ b/packages/aead/src/hlist/cipher.rs
@@ -1,0 +1,136 @@
+// The growing-HList builder return types are intentionally large — that's
+// the whole design. Suppress the lint at module scope rather than smearing
+// it across each method signature.
+#![allow(clippy::type_complexity)]
+
+use crate::IntoAad;
+
+use super::types::{Absent, Encrypted, Entry, Map, Passthrough};
+use super::{HCons, HList, HNil};
+
+/// Statically-shaped counterpart to [`Cipher`](crate::Cipher).
+///
+/// Each operation produces a leaf or builder whose Rust type fully
+/// describes its content — no `Cipher::Ok` associated type, because the
+/// output type changes per call.
+///
+/// Implement for a reference type (e.g. `&MyCipher`) so the cipher can be
+/// reused across the builder chain; the trait requires `Copy` for this
+/// reason.
+pub trait StaticCipher: Sized + Copy {
+    /// Opaque error type — typically `Unspecified`.
+    type Error;
+
+    /// Seal `data` under the supplied AAD.
+    fn encrypt_bytes<'a, A>(self, data: Vec<u8>, aad: A) -> Result<Encrypted, Self::Error>
+    where
+        A: IntoAad<'a>;
+
+    /// Produce an authenticated "no value" marker bound to `aad`.
+    fn encrypt_none<'a, A>(self, aad: A) -> Result<Absent, Self::Error>
+    where
+        A: IntoAad<'a>;
+
+    /// Wrap `value` for passthrough — never fails, never encrypts.
+    fn passthrough<T>(self, value: T) -> Passthrough<T> {
+        Passthrough(value)
+    }
+
+    /// Begin building a typed map.
+    fn encrypt_map(self) -> StaticMapBuilder<Self, HNil> {
+        StaticMapBuilder {
+            cipher: self,
+            list: HNil,
+        }
+    }
+}
+
+/// HList-growing builder for typed maps. Each entry method consumes
+/// `self` and returns a builder whose HList parameter is one cell longer.
+pub struct StaticMapBuilder<C, L> {
+    cipher: C,
+    list: L,
+}
+
+impl<C, L> StaticMapBuilder<C, L>
+where
+    C: StaticCipher,
+    L: HList,
+{
+    /// Add an encrypted entry.
+    pub fn encrypt_entry<'a, A>(
+        self,
+        key: &'static str,
+        value: Vec<u8>,
+        aad: A,
+    ) -> Result<StaticMapBuilder<C, HCons<Entry<Encrypted>, L>>, C::Error>
+    where
+        A: IntoAad<'a>,
+    {
+        let encrypted = self.cipher.encrypt_bytes(value, aad)?;
+        Ok(StaticMapBuilder {
+            cipher: self.cipher,
+            list: HCons(
+                Entry {
+                    key,
+                    value: encrypted,
+                },
+                self.list,
+            ),
+        })
+    }
+
+    /// Add a passthrough entry whose value stays typed end-to-end.
+    pub fn passthrough_entry<T>(
+        self,
+        key: &'static str,
+        value: T,
+    ) -> StaticMapBuilder<C, HCons<Entry<Passthrough<T>>, L>> {
+        StaticMapBuilder {
+            cipher: self.cipher,
+            list: HCons(
+                Entry {
+                    key,
+                    value: Passthrough(value),
+                },
+                self.list,
+            ),
+        }
+    }
+
+    /// Add an authenticated absent entry.
+    pub fn none_entry<'a, A>(
+        self,
+        key: &'static str,
+        aad: A,
+    ) -> Result<StaticMapBuilder<C, HCons<Entry<Absent>, L>>, C::Error>
+    where
+        A: IntoAad<'a>,
+    {
+        let absent = self.cipher.encrypt_none(aad)?;
+        Ok(StaticMapBuilder {
+            cipher: self.cipher,
+            list: HCons(Entry { key, value: absent }, self.list),
+        })
+    }
+
+    /// Add a nested map entry — the value is itself a [`Map<Inner>`].
+    pub fn nested_entry<Inner>(
+        self,
+        key: &'static str,
+        value: Map<Inner>,
+    ) -> StaticMapBuilder<C, HCons<Entry<Map<Inner>>, L>>
+    where
+        Inner: HList,
+    {
+        StaticMapBuilder {
+            cipher: self.cipher,
+            list: HCons(Entry { key, value }, self.list),
+        }
+    }
+
+    /// Finalise the builder into a [`Map<L>`] container.
+    pub fn end(self) -> Map<L> {
+        Map(self.list)
+    }
+}

--- a/packages/aead/src/hlist/mod.rs
+++ b/packages/aead/src/hlist/mod.rs
@@ -1,0 +1,86 @@
+//! HList-based static ciphertext shape (opt-in via the `hlist` feature).
+//!
+//! # Why a second design?
+//!
+//! The default [`Cipher`](crate::Cipher) / [`AesCipherText`] path uses a
+//! recursive enum, with a `Vec` per nested container and a
+//! `Box<dyn Any + Send>` for passthrough values. This is the right trade-off
+//! for wasm32 / JS bindings (dynamic shapes, smaller monomorphisation
+//! footprint) and for code paths whose structure is only known at runtime.
+//!
+//! This module provides a parallel, **statically-shaped** encoding for
+//! performance-sensitive native Rust code where:
+//!
+//! - the ciphertext schema is known at compile time (typically derive-macro
+//!   generated `Encrypt` / `Decrypt` impls for fixed structs),
+//! - the cost of `Box<dyn Any>` allocation + downcast on every passthrough is
+//!   undesirable, or
+//! - passthrough must remain typed end-to-end with no runtime fallibility.
+//!
+//! # Shape
+//!
+//! Each cipher operation produces a *different* output type. The builder
+//! threads them into an [`HList`] so the final container type literally
+//! describes the encrypted structure:
+//!
+//! ```text
+//! Map<HCons<Entry<Passthrough<u8>>, HCons<Entry<Encrypted>, HNil>>>
+//! //  └── passthrough u8 field         └── encrypted bytes field
+//! ```
+//!
+//! Decryption is destructuring — no shape check, no downcast, no allocation
+//! for the structural nodes. The leaf ciphertexts (`Encrypted`, `Absent`)
+//! still carry their `LocalCipherText` payload.
+//!
+//! # Trade-offs
+//!
+//! - **Single `Cipher::Ok` is impossible**: a separate trait,
+//!   [`StaticCipher`], replaces [`Cipher`](crate::Cipher) here. The two trait
+//!   hierarchies coexist behind the feature flag.
+//! - **Homogeneous `Vec<_>` of varying length is not expressible** in HList
+//!   form — `Vec<Encrypted>` of uniform primitives still works, but the
+//!   dynamic path's `Vec<AesCipherText>` does not have a direct equivalent.
+//! - **Type spellings are large**. A derive macro should generate the
+//!   `type FooCiphertext = Map<HCons<...>>` aliases; humans should rarely
+//!   write them by hand.
+
+mod cipher;
+mod types;
+
+pub use cipher::{StaticCipher, StaticMapBuilder};
+pub use types::{Absent, Encrypted, Entry, Map, Passthrough, Seq};
+
+/// The empty HList — terminates an [`HCons`] chain.
+pub struct HNil;
+
+/// One cell of an HList: head element `H` plus tail HList `T`.
+pub struct HCons<H, T>(pub H, pub T);
+
+/// Marker for types that form a well-formed (terminated) HList.
+pub trait HList: sealed::Sealed {}
+impl HList for HNil {}
+impl<H, T: HList> HList for HCons<H, T> {}
+
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for super::HNil {}
+    impl<H, T: super::HList> Sealed for super::HCons<H, T> {}
+}
+
+/// Construct an HList literal: `hlist![1, "two", 3.0]`.
+#[macro_export]
+macro_rules! hlist {
+    () => { $crate::hlist::HNil };
+    ($head:expr $(, $tail:expr)* $(,)?) => {
+        $crate::hlist::HCons($head, $crate::hlist![$($tail),*])
+    };
+}
+
+/// Destructure an HList: `let hlist_pat![a, b, c] = list;`.
+#[macro_export]
+macro_rules! hlist_pat {
+    () => { $crate::hlist::HNil };
+    ($head:pat $(, $tail:pat)* $(,)?) => {
+        $crate::hlist::HCons($head, $crate::hlist_pat![$($tail),*])
+    };
+}

--- a/packages/aead/src/hlist/types.rs
+++ b/packages/aead/src/hlist/types.rs
@@ -3,12 +3,52 @@ use crate::LocalCipherText;
 use super::HList;
 
 /// A single sealed value (nonce + ciphertext + tag).
+///
+/// The inner `LocalCipherText` is private: leaves are produced by a cipher
+/// backend's `StaticCipher` impl (or, in future, a derive macro) via
+/// [`Encrypted::from_local`] rather than constructed field-wise by arbitrary
+/// callers. This is encapsulation, not unforgeability — `LocalCipherText:
+/// From<Vec<u8>>` is public and the constructor must be reachable cross-crate,
+/// so the cipher's tag verification on `open` remains the real authenticity
+/// guard.
 #[derive(Debug)]
-pub struct Encrypted(pub LocalCipherText);
+pub struct Encrypted(LocalCipherText);
+
+impl Encrypted {
+    /// Wrap a sealed `LocalCipherText`. Plumbing for cipher backends and derive
+    /// macros — not part of the stable public surface.
+    #[doc(hidden)]
+    pub fn from_local(ct: LocalCipherText) -> Self {
+        Self(ct)
+    }
+
+    /// Consume the leaf, yielding the inner `LocalCipherText` for decryption.
+    #[doc(hidden)]
+    pub fn into_local(self) -> LocalCipherText {
+        self.0
+    }
+}
 
 /// An authenticated "no value" marker — empty plaintext sealed under AAD.
+///
+/// Inner field is private for the same reason as [`Encrypted`].
 #[derive(Debug)]
-pub struct Absent(pub LocalCipherText);
+pub struct Absent(LocalCipherText);
+
+impl Absent {
+    /// Wrap a sealed `LocalCipherText`. Plumbing for cipher backends and derive
+    /// macros — not part of the stable public surface.
+    #[doc(hidden)]
+    pub fn from_local(ct: LocalCipherText) -> Self {
+        Self(ct)
+    }
+
+    /// Consume the marker, yielding the inner `LocalCipherText` for verification.
+    #[doc(hidden)]
+    pub fn into_local(self) -> LocalCipherText {
+        self.0
+    }
+}
 
 /// A typed value carried through the ciphertext container without
 /// encryption. Holds `T` directly — no `Box`, no `Any`.

--- a/packages/aead/src/hlist/types.rs
+++ b/packages/aead/src/hlist/types.rs
@@ -1,0 +1,35 @@
+use crate::LocalCipherText;
+
+use super::HList;
+
+/// A single sealed value (nonce + ciphertext + tag).
+#[derive(Debug)]
+pub struct Encrypted(pub LocalCipherText);
+
+/// An authenticated "no value" marker — empty plaintext sealed under AAD.
+#[derive(Debug)]
+pub struct Absent(pub LocalCipherText);
+
+/// A typed value carried through the ciphertext container without
+/// encryption. Holds `T` directly — no `Box`, no `Any`.
+#[derive(Debug)]
+pub struct Passthrough<T>(pub T);
+
+/// A map of typed `(key, value)` entries. The HList `L` encodes the
+/// structural shape of the map at the type level.
+#[derive(Debug)]
+pub struct Map<L: HList>(pub L);
+
+/// A heterogeneous sequence — length and per-element type known at compile
+/// time. For homogeneous, runtime-length sequences use a plain `Vec` of
+/// leaf types (e.g. `Vec<Encrypted>`).
+#[derive(Debug)]
+pub struct Seq<L: HList>(pub L);
+
+/// One map entry. `key` is a `&'static str`; `value` is one of the leaf
+/// or composite types above.
+#[derive(Debug)]
+pub struct Entry<V> {
+    pub key: &'static str,
+    pub value: V,
+}

--- a/packages/aead/src/lib.rs
+++ b/packages/aead/src/lib.rs
@@ -5,6 +5,8 @@ mod cipher;
 mod ciphertext;
 mod decipher;
 mod encrypt;
+#[cfg(feature = "hlist")]
+pub mod hlist;
 mod nonce;
 
 #[doc(inline)]

--- a/packages/encrypt/Cargo.toml
+++ b/packages/encrypt/Cargo.toml
@@ -41,6 +41,10 @@ aes-gcm = { version = "0.10", default-features = false, features = ["aes", "allo
 # from production deps.
 _test-rust-crypto-backend = ["dep:aes-gcm"]
 
+# Opt-in HList-based static ciphertext shape. See
+# `vitaminc-aead`'s `hlist` feature for the rationale.
+hlist = ["vitaminc-aead/hlist"]
+
 [dev-dependencies]
 vitaminc-protected = { path = "../protected", version = "0.2.0-pre", features = ["arbitrary"] }
 quickcheck = "1.1.0"

--- a/packages/encrypt/src/cipher.rs
+++ b/packages/encrypt/src/cipher.rs
@@ -37,8 +37,8 @@ pub enum AesCipherText {
 /// Implements AES-256-GCM. Backend is selected at compile time:
 /// `aws-lc-rs` on native targets, `aes-gcm` (RustCrypto) on `wasm32`.
 pub struct Aes256Cipher {
-    nonce_generator: RandomNonceGenerator<NONCE_LEN>,
-    key: CipherKey,
+    pub(crate) nonce_generator: RandomNonceGenerator<NONCE_LEN>,
+    pub(crate) key: CipherKey,
 }
 
 impl Aes256Cipher {

--- a/packages/encrypt/src/cipher.rs
+++ b/packages/encrypt/src/cipher.rs
@@ -279,7 +279,7 @@ impl AesDecipher<'_> {
         ct: LocalCipherText,
         aad: &[u8],
     ) -> Result<Protected<Vec<u8>>, Unspecified> {
-        let (nonce, reader) = ct.into_reader().read_nonce::<NONCE_LEN>();
+        let (nonce, reader) = ct.into_reader().read_nonce::<NONCE_LEN>()?;
         let nonce_bytes = nonce.into_inner();
 
         reader

--- a/packages/encrypt/src/cipher_static.rs
+++ b/packages/encrypt/src/cipher_static.rs
@@ -20,30 +20,44 @@ impl StaticCipher for &Aes256Cipher {
         A: IntoAad<'a>,
     {
         let local = seal_into_local(self, data, aad)?;
-        Ok(Encrypted(local))
+        Ok(Encrypted::from_local(local))
     }
 
     fn encrypt_none<'a, A>(self, aad: A) -> Result<Absent, Self::Error>
     where
         A: IntoAad<'a>,
     {
-        let local = seal_into_local(self, Protected::new(Vec::new()), aad)?;
-        Ok(Absent(local))
+        let local = seal_into_local(self, Protected::new(Vec::new()), absent_aad(aad))?;
+        Ok(Absent::from_local(local))
     }
+}
+
+/// Domain-separate the absence marker from an empty [`Encrypted`].
+///
+/// Both seal an empty plaintext, so without this their `LocalCipherText` bytes
+/// would be identical under the same `(key, AAD)` and an `Absent` slot could be
+/// swapped for an empty `Encrypted` one (and vice versa) without tripping tag
+/// verification. Prefixing a fixed label binds the "absent" role into the tag
+/// (PAE-encoded via the tuple `IntoAad` impl), so the two no longer
+/// cross-validate. `verify_absent` re-derives the same wrapped AAD.
+fn absent_aad<'a, A: IntoAad<'a>>(aad: A) -> (&'a [u8], A) {
+    (b"vitaminc:absent", aad)
 }
 
 impl Aes256Cipher {
     /// Open an [`Encrypted`] leaf under the supplied AAD. Counterpart to
     /// [`StaticCipher::encrypt_bytes`].
     ///
-    /// The plaintext is returned inside `Protected` so the zeroize-on-drop
-    /// guarantee survives the call boundary, matching
-    /// [`Aes256Cipher::decrypt_with_aad`].
+    /// The plaintext is returned inside `Protected` to thread the chain of
+    /// custody across the call boundary, matching
+    /// [`Aes256Cipher::decrypt_with_aad`]. Note the zeroize-on-drop guarantee
+    /// is not yet in effect — `Protected<T>` has no `Drop` impl today; that is
+    /// tracked in #181.
     pub fn open<'a, A>(&self, ct: Encrypted, aad: A) -> Result<Protected<Vec<u8>>, Unspecified>
     where
         A: IntoAad<'a>,
     {
-        open_local(self, ct.0, aad)
+        open_local(self, ct.into_local(), aad)
     }
 
     /// Verify an [`Absent`] marker under the supplied AAD. Returns
@@ -54,8 +68,8 @@ impl Aes256Cipher {
     {
         // Sealed plaintext is empty by construction; we only care about the
         // tag verification. The returned `Protected<Vec<u8>>` drops at the
-        // end of this expression.
-        open_local(self, ct.0, aad).map(|_| ())
+        // end of this expression. The AAD is wrapped to match `encrypt_none`.
+        open_local(self, ct.into_local(), absent_aad(aad)).map(|_| ())
     }
 }
 
@@ -92,7 +106,7 @@ where
     A: IntoAad<'a>,
 {
     let aad = aad.into_aad();
-    let (nonce, reader) = ct.into_reader().read_nonce::<NONCE_LEN>();
+    let (nonce, reader) = ct.into_reader().read_nonce::<NONCE_LEN>()?;
     let nonce_bytes = nonce.into_inner();
 
     reader
@@ -104,8 +118,11 @@ where
 #[allow(clippy::unwrap_used)]
 mod test {
     use super::*;
+    use crate::key::tests::DifferingKeyPair;
     use crate::Key;
+    use quickcheck_macros::quickcheck;
     use vitaminc_aead::hlist::{Entry, HCons, HNil, Map, Passthrough, StaticCipher};
+    use vitaminc_aead::LocalCipherText;
     use vitaminc_protected::Controlled;
 
     // A worked example. In production this type alias would be generated
@@ -221,5 +238,127 @@ mod test {
     fn _proof_send() {
         fn assert_send<T: Send>() {}
         assert_send::<UserCiphertext>();
+    }
+
+    // Arbitrary bytes that weren't produced by a real seal must return an
+    // error, never panic — `open` and `verify_absent` are the entry points a
+    // future deserializer would feed untrusted input to. Quickcheck shrinks to
+    // the empty buffer if the under-length nonce guard ever regresses.
+
+    #[quickcheck]
+    fn open_rejects_arbitrary_bytes(key: Key, bytes: Vec<u8>) -> bool {
+        let cipher = Aes256Cipher::new(&key).unwrap();
+        let leaf = Encrypted::from_local(LocalCipherText::from(bytes));
+        cipher.open(leaf, b"aad".as_slice()).is_err()
+    }
+
+    #[quickcheck]
+    fn verify_absent_rejects_arbitrary_bytes(key: Key, bytes: Vec<u8>) -> bool {
+        let cipher = Aes256Cipher::new(&key).unwrap();
+        let leaf = Absent::from_local(LocalCipherText::from(bytes));
+        cipher.verify_absent(leaf, b"aad".as_slice()).is_err()
+    }
+
+    // An empty `Encrypted` and an `Absent` seal the same empty plaintext; the
+    // domain separator on `encrypt_none` is what keeps their tags from
+    // cross-validating under the same (key, AAD). Single representative case
+    // each — the property is structural, not value-dependent.
+
+    #[test]
+    fn absent_does_not_validate_as_encrypted_empty() {
+        let cipher = Aes256Cipher::new(&Key::from([2u8; 32])).unwrap();
+        let aad = b"shared-aad".as_slice();
+        let absent = (&cipher).encrypt_none(aad).unwrap();
+        // Reinterpret the Absent's bytes as an Encrypted leaf under the same AAD.
+        let as_encrypted = Encrypted::from_local(absent.into_local());
+        assert!(cipher.open(as_encrypted, aad).is_err());
+    }
+
+    #[test]
+    fn encrypted_empty_does_not_validate_as_absent() {
+        let cipher = Aes256Cipher::new(&Key::from([2u8; 32])).unwrap();
+        let aad = b"shared-aad".as_slice();
+        let encrypted_empty = (&cipher)
+            .encrypt_bytes(Protected::new(Vec::new()), aad)
+            .unwrap();
+        let as_absent = Absent::from_local(encrypted_empty.into_local());
+        assert!(cipher.verify_absent(as_absent, aad).is_err());
+    }
+
+    // A ciphertext sealed under one key must not open under a different key.
+
+    #[quickcheck]
+    fn open_with_wrong_key_fails(keys: DifferingKeyPair, plaintext: Vec<u8>) -> bool {
+        let DifferingKeyPair(key_a, key_b) = keys;
+        let cipher_a = Aes256Cipher::new(&key_a).unwrap();
+        let cipher_b = Aes256Cipher::new(&key_b).unwrap();
+        let aad = b"aad".as_slice();
+        let ct = (&cipher_a)
+            .encrypt_bytes(Protected::new(plaintext), aad)
+            .unwrap();
+        cipher_b.open(ct, aad).is_err()
+    }
+
+    #[quickcheck]
+    fn verify_absent_with_wrong_key_fails(keys: DifferingKeyPair) -> bool {
+        let DifferingKeyPair(key_a, key_b) = keys;
+        let cipher_a = Aes256Cipher::new(&key_a).unwrap();
+        let cipher_b = Aes256Cipher::new(&key_b).unwrap();
+        let aad = b"aad".as_slice();
+        let absent = (&cipher_a).encrypt_none(aad).unwrap();
+        cipher_b.verify_absent(absent, aad).is_err()
+    }
+
+    // Flipping any single byte — across the nonce, ciphertext body, or tag —
+    // must fail verification. Exhaustive sweep over the whole ciphertext.
+
+    #[test]
+    fn open_fails_on_tampering_any_byte() {
+        let cipher = Aes256Cipher::new(&Key::from([3u8; 32])).unwrap();
+        let aad = b"aad".as_slice();
+        let ct = (&cipher)
+            .encrypt_bytes(Protected::new(b"hello".to_vec()), aad)
+            .unwrap();
+        let bytes = ct.into_local().as_ref().to_vec();
+        for idx in 0..bytes.len() {
+            let mut tampered = bytes.clone();
+            tampered[idx] ^= 1;
+            let leaf = Encrypted::from_local(LocalCipherText::from(tampered));
+            assert!(cipher.open(leaf, aad).is_err(), "tamper at byte {idx}");
+        }
+    }
+
+    // AES-GCM is non-deterministic: a fresh nonce per call means two seals of
+    // the same plaintext under the same (key, AAD) must differ. Running these
+    // as properties samples many nonce pairs, catching an RNG regression a
+    // single fixed case could miss.
+
+    #[quickcheck]
+    fn encrypt_bytes_is_nondeterministic(key: Key, plaintext: Vec<u8>) -> bool {
+        let cipher = Aes256Cipher::new(&key).unwrap();
+        let aad = b"aad".as_slice();
+        let b1 = (&cipher)
+            .encrypt_bytes(Protected::new(plaintext.clone()), aad)
+            .unwrap()
+            .into_local()
+            .as_ref()
+            .to_vec();
+        let b2 = (&cipher)
+            .encrypt_bytes(Protected::new(plaintext), aad)
+            .unwrap()
+            .into_local()
+            .as_ref()
+            .to_vec();
+        // Distinct ciphertexts, and specifically distinct nonce prefixes.
+        b1 != b2 && b1[..NONCE_LEN] != b2[..NONCE_LEN]
+    }
+
+    #[quickcheck]
+    fn encrypt_none_is_nondeterministic(key: Key) -> bool {
+        let cipher = Aes256Cipher::new(&key).unwrap();
+        let aad = b"aad".as_slice();
+        let a1 = (&cipher).encrypt_none(aad).unwrap().into_local();
+        let a2 = (&cipher).encrypt_none(aad).unwrap().into_local();
+        a1.as_ref() != a2.as_ref()
     }
 }

--- a/packages/encrypt/src/cipher_static.rs
+++ b/packages/encrypt/src/cipher_static.rs
@@ -6,12 +6,16 @@ use crate::backend::NONCE_LEN;
 use crate::Aes256Cipher;
 use vitaminc_aead::hlist::{Absent, Encrypted, StaticCipher};
 use vitaminc_aead::{CipherTextBuilder, IntoAad, NonceGenerator, Unspecified};
-use vitaminc_protected::Controlled;
+use vitaminc_protected::Protected;
 
 impl StaticCipher for &Aes256Cipher {
     type Error = Unspecified;
 
-    fn encrypt_bytes<'a, A>(self, data: Vec<u8>, aad: A) -> Result<Encrypted, Self::Error>
+    fn encrypt_bytes<'a, A>(
+        self,
+        data: Protected<Vec<u8>>,
+        aad: A,
+    ) -> Result<Encrypted, Self::Error>
     where
         A: IntoAad<'a>,
     {
@@ -23,7 +27,7 @@ impl StaticCipher for &Aes256Cipher {
     where
         A: IntoAad<'a>,
     {
-        let local = seal_into_local(self, Vec::new(), aad)?;
+        let local = seal_into_local(self, Protected::new(Vec::new()), aad)?;
         Ok(Absent(local))
     }
 }
@@ -31,7 +35,11 @@ impl StaticCipher for &Aes256Cipher {
 impl Aes256Cipher {
     /// Open an [`Encrypted`] leaf under the supplied AAD. Counterpart to
     /// [`StaticCipher::encrypt_bytes`].
-    pub fn open<'a, A>(&self, ct: Encrypted, aad: A) -> Result<Vec<u8>, Unspecified>
+    ///
+    /// The plaintext is returned inside `Protected` so the zeroize-on-drop
+    /// guarantee survives the call boundary, matching
+    /// [`Aes256Cipher::decrypt_with_aad`].
+    pub fn open<'a, A>(&self, ct: Encrypted, aad: A) -> Result<Protected<Vec<u8>>, Unspecified>
     where
         A: IntoAad<'a>,
     {
@@ -45,14 +53,15 @@ impl Aes256Cipher {
         A: IntoAad<'a>,
     {
         // Sealed plaintext is empty by construction; we only care about the
-        // tag verification.
-        open_local(self, ct.0, aad).map(|pt| debug_assert!(pt.is_empty()))
+        // tag verification. The returned `Protected<Vec<u8>>` drops at the
+        // end of this expression.
+        open_local(self, ct.0, aad).map(|_| ())
     }
 }
 
 fn seal_into_local<'a, A>(
     cipher: &Aes256Cipher,
-    data: Vec<u8>,
+    data: Protected<Vec<u8>>,
     aad: A,
 ) -> Result<vitaminc_aead::LocalCipherText, Unspecified>
 where
@@ -78,7 +87,7 @@ fn open_local<'a, A>(
     cipher: &Aes256Cipher,
     ct: vitaminc_aead::LocalCipherText,
     aad: A,
-) -> Result<Vec<u8>, Unspecified>
+) -> Result<Protected<Vec<u8>>, Unspecified>
 where
     A: IntoAad<'a>,
 {
@@ -89,7 +98,6 @@ where
     reader
         .accepts_plaintext_ok(|data| cipher.key.open(&nonce_bytes, aad.as_bytes(), data))
         .read()
-        .map(|data| data.risky_unwrap())
 }
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
@@ -98,6 +106,7 @@ mod test {
     use super::*;
     use crate::Key;
     use vitaminc_aead::hlist::{Entry, HCons, HNil, Map, Passthrough, StaticCipher};
+    use vitaminc_protected::Controlled;
 
     // A worked example. In production this type alias would be generated
     // by a derive macro from the user's struct definition.
@@ -127,13 +136,17 @@ mod test {
 
         let prefs = (&cipher)
             .encrypt_map()
-            .encrypt_entry("theme", b"midnight".to_vec(), INNER_AAD)
+            .encrypt_entry("theme", Protected::new(b"midnight".to_vec()), INNER_AAD)
             .expect("encrypt prefs")
             .end();
 
         let user_ct: UserCiphertext = (&cipher)
             .encrypt_map()
-            .encrypt_entry("password_hash", b"argon2id$hash".to_vec(), AAD)
+            .encrypt_entry(
+                "password_hash",
+                Protected::new(b"argon2id$hash".to_vec()),
+                AAD,
+            )
             .expect("encrypt pw")
             .passthrough_entry("version", 3u8)
             .none_entry("nickname", AAD)
@@ -144,15 +157,26 @@ mod test {
         // Decryption is destructuring. No downcast, no shape check, no Box.
         let Map(HCons(prefs_e, HCons(nickname_e, HCons(version_e, HCons(pw_e, HNil))))) = user_ct;
 
-        let pw = String::from_utf8(cipher.open(pw_e.value, AAD).expect("open pw")).unwrap();
+        let pw = String::from_utf8(
+            cipher
+                .open(pw_e.value, AAD)
+                .expect("open pw")
+                .risky_unwrap(),
+        )
+        .unwrap();
         let version: u8 = version_e.value.0; // typed access, no fallibility
         cipher
             .verify_absent(nickname_e.value, AAD)
             .expect("verify none");
 
         let Map(HCons(theme_e, HNil)) = prefs_e.value;
-        let theme =
-            String::from_utf8(cipher.open(theme_e.value, INNER_AAD).expect("open theme")).unwrap();
+        let theme = String::from_utf8(
+            cipher
+                .open(theme_e.value, INNER_AAD)
+                .expect("open theme")
+                .risky_unwrap(),
+        )
+        .unwrap();
 
         assert_eq!(pw, "argon2id$hash");
         assert_eq!(version, 3u8);
@@ -168,7 +192,7 @@ mod test {
         let key = Key::from([3u8; 32]);
         let cipher = Aes256Cipher::new(&key).expect("cipher init");
         let leaf = (&cipher)
-            .encrypt_bytes(b"hello".to_vec(), b"right".as_slice())
+            .encrypt_bytes(Protected::new(b"hello".to_vec()), b"right".as_slice())
             .expect("encrypt");
         assert!(cipher.open(leaf, b"wrong".as_slice()).is_err());
     }

--- a/packages/encrypt/src/cipher_static.rs
+++ b/packages/encrypt/src/cipher_static.rs
@@ -1,0 +1,201 @@
+//! `StaticCipher` impl for `&Aes256Cipher` — the HList-shaped output path.
+//!
+//! See `vitaminc_aead::hlist` for the design rationale.
+
+use crate::backend::NONCE_LEN;
+use crate::Aes256Cipher;
+use vitaminc_aead::hlist::{Absent, Encrypted, StaticCipher};
+use vitaminc_aead::{CipherTextBuilder, IntoAad, NonceGenerator, Unspecified};
+use vitaminc_protected::Controlled;
+
+impl StaticCipher for &Aes256Cipher {
+    type Error = Unspecified;
+
+    fn encrypt_bytes<'a, A>(self, data: Vec<u8>, aad: A) -> Result<Encrypted, Self::Error>
+    where
+        A: IntoAad<'a>,
+    {
+        let local = seal_into_local(self, data, aad)?;
+        Ok(Encrypted(local))
+    }
+
+    fn encrypt_none<'a, A>(self, aad: A) -> Result<Absent, Self::Error>
+    where
+        A: IntoAad<'a>,
+    {
+        let local = seal_into_local(self, Vec::new(), aad)?;
+        Ok(Absent(local))
+    }
+}
+
+impl Aes256Cipher {
+    /// Open an [`Encrypted`] leaf under the supplied AAD. Counterpart to
+    /// [`StaticCipher::encrypt_bytes`].
+    pub fn open<'a, A>(&self, ct: Encrypted, aad: A) -> Result<Vec<u8>, Unspecified>
+    where
+        A: IntoAad<'a>,
+    {
+        open_local(self, ct.0, aad)
+    }
+
+    /// Verify an [`Absent`] marker under the supplied AAD. Returns
+    /// `Ok(())` if the tag binds `aad`, `Err(Unspecified)` otherwise.
+    pub fn verify_absent<'a, A>(&self, ct: Absent, aad: A) -> Result<(), Unspecified>
+    where
+        A: IntoAad<'a>,
+    {
+        // Sealed plaintext is empty by construction; we only care about the
+        // tag verification.
+        open_local(self, ct.0, aad).map(|pt| debug_assert!(pt.is_empty()))
+    }
+}
+
+fn seal_into_local<'a, A>(
+    cipher: &Aes256Cipher,
+    data: Vec<u8>,
+    aad: A,
+) -> Result<vitaminc_aead::LocalCipherText, Unspecified>
+where
+    A: IntoAad<'a>,
+{
+    let nonce = cipher.nonce_generator.generate()?;
+    let nonce_bytes: [u8; NONCE_LEN] = nonce.as_ref().try_into().map_err(|_| Unspecified)?;
+    let aad = aad.into_aad();
+
+    CipherTextBuilder::new()
+        .append_nonce(nonce)
+        .append_target_plaintext(data)
+        .accepts_ciphertext_and_tag_ok(|mut buf| {
+            cipher
+                .key
+                .seal(&nonce_bytes, aad.as_bytes(), &mut buf)
+                .map(|()| buf)
+        })
+        .build()
+}
+
+fn open_local<'a, A>(
+    cipher: &Aes256Cipher,
+    ct: vitaminc_aead::LocalCipherText,
+    aad: A,
+) -> Result<Vec<u8>, Unspecified>
+where
+    A: IntoAad<'a>,
+{
+    let aad = aad.into_aad();
+    let (nonce, reader) = ct.into_reader().read_nonce::<NONCE_LEN>();
+    let nonce_bytes = nonce.into_inner();
+
+    reader
+        .accepts_plaintext_ok(|data| cipher.key.open(&nonce_bytes, aad.as_bytes(), data))
+        .read()
+        .map(|data| data.risky_unwrap())
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+#[allow(clippy::unwrap_used)]
+mod test {
+    use super::*;
+    use crate::Key;
+    use vitaminc_aead::hlist::{Entry, HCons, HNil, Map, Passthrough, StaticCipher};
+
+    // A worked example. In production this type alias would be generated
+    // by a derive macro from the user's struct definition.
+    type UserCiphertext = Map<
+        HCons<
+            Entry<Map<HCons<Entry<Encrypted>, HNil>>>, // preferences (nested)
+            HCons<
+                Entry<Absent>, // nickname: None
+                HCons<
+                    Entry<Passthrough<u8>>, // version (typed!)
+                    HCons<
+                        Entry<Encrypted>, // password_hash
+                        HNil,
+                    >,
+                >,
+            >,
+        >,
+    >;
+
+    const AAD: &[u8] = b"user:42";
+    const INNER_AAD: &[u8] = b"user:42/prefs";
+
+    #[test]
+    fn static_user_roundtrip() {
+        let key = Key::from([7u8; 32]);
+        let cipher = Aes256Cipher::new(&key).expect("cipher init");
+
+        let prefs = (&cipher)
+            .encrypt_map()
+            .encrypt_entry("theme", b"midnight".to_vec(), INNER_AAD)
+            .expect("encrypt prefs")
+            .end();
+
+        let user_ct: UserCiphertext = (&cipher)
+            .encrypt_map()
+            .encrypt_entry("password_hash", b"argon2id$hash".to_vec(), AAD)
+            .expect("encrypt pw")
+            .passthrough_entry("version", 3u8)
+            .none_entry("nickname", AAD)
+            .expect("encrypt none")
+            .nested_entry("preferences", prefs)
+            .end();
+
+        // Decryption is destructuring. No downcast, no shape check, no Box.
+        let Map(HCons(prefs_e, HCons(nickname_e, HCons(version_e, HCons(pw_e, HNil))))) = user_ct;
+
+        let pw = String::from_utf8(cipher.open(pw_e.value, AAD).expect("open pw")).unwrap();
+        let version: u8 = version_e.value.0; // typed access, no fallibility
+        cipher
+            .verify_absent(nickname_e.value, AAD)
+            .expect("verify none");
+
+        let Map(HCons(theme_e, HNil)) = prefs_e.value;
+        let theme =
+            String::from_utf8(cipher.open(theme_e.value, INNER_AAD).expect("open theme")).unwrap();
+
+        assert_eq!(pw, "argon2id$hash");
+        assert_eq!(version, 3u8);
+        assert_eq!(theme, "midnight");
+        assert_eq!(pw_e.key, "password_hash");
+        assert_eq!(version_e.key, "version");
+        assert_eq!(nickname_e.key, "nickname");
+        assert_eq!(prefs_e.key, "preferences");
+    }
+
+    #[test]
+    fn static_open_fails_with_wrong_aad() {
+        let key = Key::from([3u8; 32]);
+        let cipher = Aes256Cipher::new(&key).expect("cipher init");
+        let leaf = (&cipher)
+            .encrypt_bytes(b"hello".to_vec(), b"right".as_slice())
+            .expect("encrypt");
+        assert!(cipher.open(leaf, b"wrong".as_slice()).is_err());
+    }
+
+    #[test]
+    fn static_verify_absent_fails_with_wrong_aad() {
+        let key = Key::from([4u8; 32]);
+        let cipher = Aes256Cipher::new(&key).expect("cipher init");
+        let absent = (&cipher)
+            .encrypt_none(b"right".as_slice())
+            .expect("encrypt none");
+        assert!(cipher.verify_absent(absent, b"wrong".as_slice()).is_err());
+    }
+
+    #[test]
+    fn static_passthrough_keeps_type() {
+        // No cipher needed — passthrough is just wrapping.
+        let key = Key::from([5u8; 32]);
+        let cipher = Aes256Cipher::new(&key).expect("cipher init");
+        let p: Passthrough<(u16, &'static str)> = (&cipher).passthrough((42u16, "tag"));
+        let (n, s) = p.0;
+        assert_eq!(n, 42u16);
+        assert_eq!(s, "tag");
+    }
+
+    fn _proof_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<UserCiphertext>();
+    }
+}

--- a/packages/encrypt/src/lib.rs
+++ b/packages/encrypt/src/lib.rs
@@ -2,6 +2,8 @@
 #![doc = include_str!("../README.md")]
 mod backend;
 mod cipher;
+#[cfg(feature = "hlist")]
+mod cipher_static;
 mod key;
 
 pub use cipher::{Aes256Cipher, AesCipherText};


### PR DESCRIPTION
Stacked on #174. Prototype of the **statically-shaped** ciphertext container, parallel to the existing dynamic `Cipher` / `AesCipherText` path, behind an opt-in `hlist` feature.

## Why a second design?

The two designs target different use cases — the feature flag lets users pick:

|                          | dynamic (default)                   | static (`hlist` feature)            |
|--------------------------|-------------------------------------|-------------------------------------|
| Ciphertext container     | recursive enum + `Vec` nodes        | typed HList — shape is in the type  |
| Passthrough storage      | `Box<dyn Any + Send + 'static>`     | `Passthrough<T>(T)` — direct        |
| Decrypt access           | runtime downcast / shape check      | destructuring, statically infallible |
| Best for                 | wasm32, JS bindings, dynamic schemas | native Rust, derive-macro output    |

## API surface (under `vitaminc_aead::hlist`)

- `HNil` / `HCons<H, T>` HList primitives + `hlist!` / `hlist_pat!` macros
- Leaf types: `Encrypted(LocalCipherText)`, `Absent(LocalCipherText)`, `Passthrough<T>(T)`
- Composite types: `Map<L: HList>`, `Seq<L: HList>`, `Entry<V>`
- `StaticCipher` trait — counterpart to `Cipher` (no `type Ok` — each call produces a different type)
- `StaticMapBuilder<C, L>` — the growing-HList builder
- `Aes256Cipher::open` / `verify_absent` — decrypt-side helpers for the leaf types

## The worked example

The `User`-shaped struct test produces this fully-typed ciphertext:

```rust
type UserCiphertext = Map<HCons<
    Entry<Map<HCons<Entry<Encrypted>, HNil>>>, // preferences (nested)
    HCons<Entry<Absent>,                       // nickname: None
    HCons<Entry<Passthrough<u8>>,              // version (typed!)
    HCons<Entry<Encrypted>,                    // password_hash
    HNil>>>>>;
```

In production this alias would be generated by a derive macro — humans should rarely write it. A `Send` proof in the test file confirms no `Box`/`dyn Any` is introduced.

Decryption is destructuring:

```rust
let Map(HCons(prefs, HCons(nickname, HCons(version, HCons(pw, HNil))))) = ct;
let version: u8 = version.value.0;        // typed, infallible
let pw = cipher.open(pw.value, AAD)?;     // real crypto, fallible only on AAD/tag
```

## Known limitations (documented in `hlist/mod.rs`)

- **`Cipher::Ok` cannot stay a single associated type** — replaced by a separate `StaticCipher` trait. The two trait hierarchies coexist behind the feature flag.
- **Homogeneous `Vec<_>` of varying length is not expressible** in HList form. `Vec<Encrypted>` of uniform primitives still works, but the dynamic path's polymorphic `Vec<AesCipherText>` has no direct equivalent.
- **Type spellings are large** — derive macro should generate the aliases.

## Test plan

- [x] `static_user_roundtrip` — full mixed-field struct round-trip
- [x] `static_open_fails_with_wrong_aad` — AAD verification
- [x] `static_verify_absent_fails_with_wrong_aad` — `None` AAD verification
- [x] `static_passthrough_keeps_type` — passthrough is identity
- [x] `cargo test -p vitaminc-encrypt --features hlist` — 33 pass (29 base + 4 new)
- [x] `cargo test -p vitaminc-aead -p vitaminc-encrypt` (no feature) — 29 + 29 pass (no regression)
- [x] `cargo clippy --workspace --all-targets [--features vitaminc-encrypt/hlist] -- -D warnings` — clean both ways
- [x] `Send` proof on `UserCiphertext` (compile-time)

## Follow-ups

- Derive macro generating the `Encrypt` impl + `type ...Ciphertext = Map<HCons<...>>` alias from a struct definition
- `StaticSeqBuilder` for fixed-length heterogeneous sequences (currently only `Map` is implemented)
- Decide whether the dynamic and static paths should share leaf types (`Encrypted(LocalCipherText)`) or stay isolated

## Internal change

`Aes256Cipher.nonce_generator` and `.key` are now `pub(crate)` so the new `cipher_static` module can reuse them without going through the existing `Cipher` trait surface (which doesn't fit the HList shape).