### PR TITLE
fix(deps): bump rustls-webpki to 0.103.13 for RUSTSEC advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1710,7 +1710,7 @@ dependencies = [
  "aws-lc-rs",
  "once_cell",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -1748,9 +1748,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## What

Bumps `rustls-webpki` `0.103.9 → 0.103.13` in `Cargo.lock` to resolve the patchable Dependabot advisories on the active TLS path. Lockfile-only — no `Cargo.toml` or source changes.

## Why

Four open Dependabot alerts on `main`, all for `rustls-webpki`, all transitive through the **AWS KMS SDK only** (`vitaminc-kms` → `aws-config`/`aws-sdk-kms`). Nothing in the crypto core (`aead`/`encrypt`/`protected`/`random`) is affected.

Two copies are in the tree:

| Copy | Pulled by | Advisories |
|------|-----------|-----------|
| `0.103.9` → **`0.103.13`** | `rustls 0.23` — the real KMS TLS path | #21 HIGH, #19/#20 LOW, **#17 MEDIUM** |
| `0.101.7` (unchanged) | `rustls 0.21` via `aws-smithy-http-client`'s `legacy-rustls` dep (server-side `acceptor` feature) | #21 HIGH, #19/#20 LOW |

This bump:
- **Fully closes #17 (MEDIUM)** — that advisory only applies to the `0.103.x` range.
- Removes the vulnerable version from the **active** TLS path.

## Residual: the `0.101.7` copy

`#21 / #19 / #20` will stay open until the `0.101.7` copy is gone, because Dependabot keeps an alert open while any vulnerable version remains. It **can't be fixed yet**:

- The `0.101.x` series ended at `0.101.7` with **no patched release** (fixes land only in `0.103.12+`).
- It can't be bumped because `rustls 0.21` requires `webpki ^0.101`, and **`aws-smithy-http-client 1.1.12` (the latest published version) hard-declares `legacy-rustls = "^0.21.8"`**. `cargo update` is already a no-op on the AWS crates.

It rides the server-side `acceptor` feature and is almost certainly **dead code** for a KMS *client*. Real-world exposure of all four is low: they are TLS cert/CRL-validation bugs, and the AWS SDK's default rustls config doesn't enable webpki CRL checking (the HIGH's trigger).

**Follow-up:** track `aws-smithy-http-client` for a release that drops/feature-gates `legacy-rustls`, then bump `aws-config`; meanwhile #21/#19/#20 can reasonably be dismissed as low-risk, not-reachable transitive deps.

## Verification

- `cargo check -p vitaminc-kms` builds clean.
- Diff is 3 lines in `Cargo.lock` (version + checksum).
