### PR TITLE
fix(protected): zeroize controlled types on drop (#181)

### DIFF
--- a/packages/encrypt/src/cipher_static.rs
+++ b/packages/encrypt/src/cipher_static.rs
@@ -50,9 +50,8 @@ impl Aes256Cipher {
     ///
     /// The plaintext is returned inside `Protected` to thread the chain of
     /// custody across the call boundary, matching
-    /// [`Aes256Cipher::decrypt_with_aad`]. Note the zeroize-on-drop guarantee
-    /// is not yet in effect — `Protected<T>` has no `Drop` impl today; that is
-    /// tracked in #181.
+    /// [`Aes256Cipher::decrypt_with_aad`]. The returned `Protected<Vec<u8>>` is
+    /// zeroized on drop (`Protected` is `ZeroizeOnDrop`).
     pub fn open<'a, A>(&self, ct: Encrypted, aad: A) -> Result<Protected<Vec<u8>>, Unspecified>
     where
         A: IntoAad<'a>,

--- a/packages/permutation/src/key.rs
+++ b/packages/permutation/src/key.rs
@@ -36,12 +36,15 @@ impl<const N: usize> PermutationKey<N> {
         Generatable::random(&mut rng)
     }
 
-    /// Consumes the key and returns its inverse.
-    pub fn invert(self) -> Self
+    /// Returns the inverse of this key.
+    ///
+    /// Borrows `self` — inversion builds a fresh key from the borrowed
+    /// permutation, so there is no need to consume (or clone) the original.
+    pub fn invert(&self) -> Self
     where
         [u8; N]: IsPermutable,
     {
-        Self(KeyInner::new(depermute_array(&self, identity())))
+        Self(KeyInner::new(depermute_array(self, identity())))
     }
 
     /// Returns the complement of the key with respect to the target key.
@@ -67,15 +70,9 @@ impl<const N: usize> PermutationKey<N> {
     where
         [u8; N]: IsPermutable + Zeroed,
     {
-        // `invert` consumes the key; clone the borrowed `target` (the clone
-        // zeroizes on drop like any other `PermutationKey`).
-        Self(
-            target
-                .clone()
-                .invert()
-                .0
-                .map(|arr| permute_array(self, arr)),
-        )
+        // `invert` borrows, so we map the inverse of the borrowed `target`
+        // through `permute_array` without ever copying the key.
+        Self(target.invert().0.map(|arr| permute_array(self, arr)))
     }
 
     pub(crate) fn iter(&self) -> impl Iterator<Item = Protected<u8>> + '_ {
@@ -128,7 +125,7 @@ mod tests {
         [u8; N]: IsPermutable + Zeroed,
     {
         let key: PermutationKey<N> = tests::gen_rand_key()?;
-        let inverted = key.clone().invert();
+        let inverted = key.invert();
 
         // p(p^-1(x)) = x
         assert_eq!(

--- a/packages/permutation/src/key.rs
+++ b/packages/permutation/src/key.rs
@@ -14,6 +14,14 @@ pub(crate) type KeyInner<const N: usize> = Exportable<Protected<[u8; N]>>;
 // NOTE: no `Copy` — `PermutationKey` wraps a `Protected` secret that zeroizes
 // on drop, and `Copy`/`Drop` are mutually exclusive. A bitwise copy would also
 // leave un-zeroized duplicates of the key. Use `Clone` where a copy is needed.
+//
+// The key IS wiped on drop: `KeyInner` is `Exportable<Protected<[u8; N]>>`, both
+// of which are `ZeroizeOnDrop`, so the field's drop glue zeroizes the bytes. We
+// deliberately do NOT derive `ZeroizeOnDrop` on `PermutationKey` itself: a `Drop`
+// impl would forbid the `.0` field moves in `complement` / `Permute::permute`
+// (E0509), and recovering them would mean duplicating `protected`'s
+// `ptr::read`+`forget` move-out primitive into this crate. The drop-glue
+// guarantee holds as long as `KeyInner` stays `ZeroizeOnDrop`.
 #[derive(Clone, Debug, Serialize, Deserialize, Zeroize)]
 pub struct PermutationKey<const N: usize>(KeyInner<N>);
 

--- a/packages/permutation/src/key.rs
+++ b/packages/permutation/src/key.rs
@@ -11,7 +11,10 @@ use crate::{
 
 pub(crate) type KeyInner<const N: usize> = Exportable<Protected<[u8; N]>>;
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, Zeroize)]
+// NOTE: no `Copy` — `PermutationKey` wraps a `Protected` secret that zeroizes
+// on drop, and `Copy`/`Drop` are mutually exclusive. A bitwise copy would also
+// leave un-zeroized duplicates of the key. Use `Clone` where a copy is needed.
+#[derive(Clone, Debug, Serialize, Deserialize, Zeroize)]
 pub struct PermutationKey<const N: usize>(KeyInner<N>);
 
 impl<const N: usize> PermutationKey<N> {
@@ -64,7 +67,15 @@ impl<const N: usize> PermutationKey<N> {
     where
         [u8; N]: IsPermutable + Zeroed,
     {
-        Self(target.invert().0.map(|arr| permute_array(self, arr)))
+        // `invert` consumes the key; clone the borrowed `target` (the clone
+        // zeroizes on drop like any other `PermutationKey`).
+        Self(
+            target
+                .clone()
+                .invert()
+                .0
+                .map(|arr| permute_array(self, arr)),
+        )
     }
 
     pub(crate) fn iter(&self) -> impl Iterator<Item = Protected<u8>> + '_ {
@@ -117,7 +128,7 @@ mod tests {
         [u8; N]: IsPermutable + Zeroed,
     {
         let key: PermutationKey<N> = tests::gen_rand_key()?;
-        let inverted = key.invert();
+        let inverted = key.clone().invert();
 
         // p(p^-1(x)) = x
         assert_eq!(

--- a/packages/protected/src/controlled.rs
+++ b/packages/protected/src/controlled.rs
@@ -2,7 +2,7 @@ pub use crate::Protected;
 use crate::{private::ControlledPrivate, AsProtectedRef, ProtectedRef, ReplaceT};
 use zeroize::Zeroize;
 
-pub trait Controlled: ControlledPrivate {
+pub trait Controlled: ControlledPrivate + Zeroize {
     type Inner;
 
     fn init_from_inner(x: Self::Inner) -> Self;
@@ -258,9 +258,13 @@ pub trait Controlled: ControlledPrivate {
     fn iter<'a, I>(&'a self) -> impl Iterator<Item = Protected<I>>
     where
         <Self as Controlled>::Inner: AsRef<[I]>,
-        I: Copy + 'a,
+        I: Copy + Zeroize + 'a,
     {
-        self.risky_ref().as_ref().iter().copied().map(Protected)
+        self.risky_ref()
+            .as_ref()
+            .iter()
+            .copied()
+            .map(Protected::new)
     }
 
     /// Replace the inner value with a new one.

--- a/packages/protected/src/equatable/mod.rs
+++ b/packages/protected/src/equatable/mod.rs
@@ -2,7 +2,7 @@ use crate::{exportable::SafeSerialize, private::ControlledPrivate, Controlled, P
 use core::num::NonZeroU16;
 use serde::{Serialize, Serializer};
 use subtle::ConstantTimeEq as SubtleCtEq;
-use zeroize::Zeroize;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// A _controlled_ wrapper type that allows for constant time equality checks of a [Controlled] type.
 /// The immediate inner type must also be [Controlled] (typically [Protected]).
@@ -96,10 +96,10 @@ use zeroize::Zeroize;
 /// let b = AuthenticatedString::new([0u8; 32], "Hello, world!".to_string());
 /// assert_eq!(a, b);
 /// ```
-#[derive(Debug, Zeroize)]
-pub struct Equatable<T>(pub(crate) T);
+#[derive(Debug, Zeroize, ZeroizeOnDrop)]
+pub struct Equatable<T: Zeroize>(pub(crate) T);
 
-impl<T> Equatable<T> {
+impl<T: Zeroize> Equatable<T> {
     /// Create a new `Equatable` from an inner value.
     pub fn new(x: <Equatable<T> as Controlled>::Inner) -> Self
     where
@@ -107,11 +107,21 @@ impl<T> Equatable<T> {
     {
         Self::init_from_inner(x)
     }
+
+    /// Move the inner value out without running the zeroizing `Drop`.
+    /// See [`Protected::into_inner_unchecked`](crate::Protected) for the rationale.
+    fn into_inner_unchecked(self) -> T {
+        // SAFETY: `self.0` is read once, then `self` is forgotten so its `Drop`
+        // does not also wipe the moved-out value.
+        let inner = unsafe { core::ptr::read(&self.0) };
+        core::mem::forget(self);
+        inner
+    }
 }
 
 impl<T> From<T> for Equatable<T>
 where
-    T: ControlledPrivate,
+    T: ControlledPrivate + Zeroize,
 {
     fn from(x: T) -> Self {
         Self(x)
@@ -128,7 +138,7 @@ where
 }
 
 // TODO: Canwe make a blanket impl for all Paranoid types?
-impl<T: ControlledPrivate> ControlledPrivate for Equatable<T> {}
+impl<T: ControlledPrivate + Zeroize> ControlledPrivate for Equatable<T> {}
 
 impl<T> Controlled for Equatable<T>
 where
@@ -149,13 +159,13 @@ where
     }
 
     fn risky_unwrap(self) -> Self::Inner {
-        self.0.risky_unwrap()
+        self.into_inner_unchecked().risky_unwrap()
     }
 }
 
 impl<T, A> Extend<A> for Equatable<T>
 where
-    T: Extend<A>,
+    T: Extend<A> + Zeroize,
 {
     fn extend<I>(&mut self, iter: I)
     where
@@ -309,7 +319,7 @@ mod private {
     /// Private marker trait.
     pub trait SupportsConstantTimeEq {}
 
-    impl<T> SupportsConstantTimeEq for Equatable<T> {}
+    impl<T: zeroize::Zeroize> SupportsConstantTimeEq for Equatable<T> {}
     impl<const N: usize, T> SupportsConstantTimeEq for [T; N] {}
     impl SupportsConstantTimeEq for u8 {}
     impl SupportsConstantTimeEq for u16 {}

--- a/packages/protected/src/equatable/mod.rs
+++ b/packages/protected/src/equatable/mod.rs
@@ -111,10 +111,16 @@ impl<T: Zeroize> Equatable<T> {
     /// Move the inner value out without running the zeroizing `Drop`.
     /// See [`crate::move_inner_out`] for the shared primitive and rationale.
     fn into_inner_unchecked(self) -> T {
-        let field: *const T = &self.0;
-        // SAFETY: `field` points to `self`'s live owned inner; `Equatable`'s
-        // `Drop` only zeroizes.
-        unsafe { crate::move_inner_out(self, field) }
+        crate::move_inner_out(self)
+    }
+}
+
+// SAFETY: `inner_ptr` returns a pointer to `self`'s live, owned inner field, and
+// `Equatable`'s derived `Drop` only zeroizes — satisfying `MoveInner`'s contract.
+unsafe impl<T: Zeroize> crate::MoveInner for Equatable<T> {
+    type Inner = T;
+    fn inner_ptr(&self) -> *const T {
+        &self.0
     }
 }
 

--- a/packages/protected/src/equatable/mod.rs
+++ b/packages/protected/src/equatable/mod.rs
@@ -109,13 +109,12 @@ impl<T: Zeroize> Equatable<T> {
     }
 
     /// Move the inner value out without running the zeroizing `Drop`.
-    /// See [`Protected::into_inner_unchecked`](crate::Protected) for the rationale.
+    /// See [`crate::move_inner_out`] for the shared primitive and rationale.
     fn into_inner_unchecked(self) -> T {
-        // SAFETY: `self.0` is read once, then `self` is forgotten so its `Drop`
-        // does not also wipe the moved-out value.
-        let inner = unsafe { core::ptr::read(&self.0) };
-        core::mem::forget(self);
-        inner
+        let field: *const T = &self.0;
+        // SAFETY: `field` points to `self`'s live owned inner; `Equatable`'s
+        // `Drop` only zeroizes.
+        unsafe { crate::move_inner_out(self, field) }
     }
 }
 

--- a/packages/protected/src/exportable/mod.rs
+++ b/packages/protected/src/exportable/mod.rs
@@ -5,7 +5,7 @@ use serde::{
     de::{Deserialize, Deserializer},
     ser::{Serialize, Serializer},
 };
-use zeroize::Zeroize;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 pub use safe_deserialize::SafeDeserialize;
 pub use safe_serialize::SafeSerialize;
@@ -52,12 +52,12 @@ pub use safe_serialize::SafeSerialize;
 /// assert_eq!(secret_a, secret_b);
 /// ```
 ///
-#[derive(Debug, Zeroize)]
-pub struct Exportable<T>(pub(crate) T);
+#[derive(Debug, Zeroize, ZeroizeOnDrop)]
+pub struct Exportable<T: Zeroize>(pub(crate) T);
 
 // TODO: Can we implement Hex and Base64 for inner types that implement them?
 // But using safe versions
-impl<T> Exportable<T> {
+impl<T: Zeroize> Exportable<T> {
     /// Create a new `Exportable` from an inner value.
     pub fn new(x: <Exportable<T> as Controlled>::Inner) -> Self
     where
@@ -65,13 +65,23 @@ impl<T> Exportable<T> {
     {
         Self::init_from_inner(x)
     }
+
+    /// Move the inner value out without running the zeroizing `Drop`.
+    /// See [`Protected::into_inner_unchecked`](crate::Protected) for the rationale.
+    fn into_inner_unchecked(self) -> T {
+        // SAFETY: `self.0` is read once, then `self` is forgotten so its `Drop`
+        // does not also wipe the moved-out value.
+        let inner = unsafe { core::ptr::read(&self.0) };
+        core::mem::forget(self);
+        inner
+    }
 }
 
-impl<T> Copy for Exportable<T> where T: Copy {}
+// NOTE: no `Copy` — `Copy` and the zeroizing `Drop` are mutually exclusive.
 
 impl<T> Clone for Exportable<T>
 where
-    T: Clone,
+    T: Clone + Zeroize,
 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -90,7 +100,7 @@ where
     }
 }
 
-impl<T: ControlledPrivate> ControlledPrivate for Exportable<T> {}
+impl<T: ControlledPrivate + Zeroize> ControlledPrivate for Exportable<T> {}
 
 impl<T> Controlled for Exportable<T>
 where
@@ -99,7 +109,7 @@ where
     type Inner = T::Inner;
 
     fn risky_unwrap(self) -> Self::Inner {
-        self.0.risky_unwrap()
+        self.into_inner_unchecked().risky_unwrap()
     }
 
     fn init_from_inner(x: Self::Inner) -> Self {
@@ -117,7 +127,7 @@ where
 
 impl<T, A> Extend<A> for Exportable<T>
 where
-    T: Extend<A>,
+    T: Extend<A> + Zeroize,
 {
     fn extend<I>(&mut self, iter: I)
     where

--- a/packages/protected/src/exportable/mod.rs
+++ b/packages/protected/src/exportable/mod.rs
@@ -69,10 +69,16 @@ impl<T: Zeroize> Exportable<T> {
     /// Move the inner value out without running the zeroizing `Drop`.
     /// See [`crate::move_inner_out`] for the shared primitive and rationale.
     fn into_inner_unchecked(self) -> T {
-        let field: *const T = &self.0;
-        // SAFETY: `field` points to `self`'s live owned inner; `Exportable`'s
-        // `Drop` only zeroizes.
-        unsafe { crate::move_inner_out(self, field) }
+        crate::move_inner_out(self)
+    }
+}
+
+// SAFETY: `inner_ptr` returns a pointer to `self`'s live, owned inner field, and
+// `Exportable`'s derived `Drop` only zeroizes — satisfying `MoveInner`'s contract.
+unsafe impl<T: Zeroize> crate::MoveInner for Exportable<T> {
+    type Inner = T;
+    fn inner_ptr(&self) -> *const T {
+        &self.0
     }
 }
 

--- a/packages/protected/src/exportable/mod.rs
+++ b/packages/protected/src/exportable/mod.rs
@@ -67,13 +67,12 @@ impl<T: Zeroize> Exportable<T> {
     }
 
     /// Move the inner value out without running the zeroizing `Drop`.
-    /// See [`Protected::into_inner_unchecked`](crate::Protected) for the rationale.
+    /// See [`crate::move_inner_out`] for the shared primitive and rationale.
     fn into_inner_unchecked(self) -> T {
-        // SAFETY: `self.0` is read once, then `self` is forgotten so its `Drop`
-        // does not also wipe the moved-out value.
-        let inner = unsafe { core::ptr::read(&self.0) };
-        core::mem::forget(self);
-        inner
+        let field: *const T = &self.0;
+        // SAFETY: `field` points to `self`'s live owned inner; `Exportable`'s
+        // `Drop` only zeroizes.
+        unsafe { crate::move_inner_out(self, field) }
     }
 }
 

--- a/packages/protected/src/lib.rs
+++ b/packages/protected/src/lib.rs
@@ -35,6 +35,38 @@ pub use debug::{OpaqueDebug, Redacted};
 pub use timing_safe::{Choice, TimingSafeEq};
 pub use vitaminc_protected_derive::{OpaqueDebug, TimingSafeEq};
 
+/// Move the single owned field out of a controlled wrapper (e.g. `Protected<T>`)
+/// **without** running its zeroizing `Drop`.
+///
+/// `wrapper` is the controlled value; `field` is a pointer to its owned inner
+/// field. The field is bit-copied to the caller and `wrapper` is forgotten so its
+/// `Drop` never runs against the now-moved-out field (no double-free, no
+/// use-after-zeroize). This is the shared primitive behind
+/// `risky_unwrap` / `flatten` / `transpose`.
+///
+/// # Why the source slot is deliberately NOT scrubbed
+///
+/// `ptr::read` produces a **bitwise** copy. For heap-backed inners (`Vec`,
+/// `String`, `Box`, …) the returned value and `wrapper`'s field then alias the
+/// *same* heap allocation. Scrubbing the source semantically (e.g.
+/// `field.zeroize()`) would wipe the heap the returned value still owns — a
+/// use-after-zeroize that hands the caller corrupted data (a decrypted
+/// `Protected<Vec<u8>>` would come back all zeroes). For inline inners
+/// (`[u8; N]`) the abandoned stack copy is the inherent cost of an explicit
+/// move-out: `risky_unwrap` & friends transfer ownership — and the wiping
+/// obligation — to the caller by contract.
+///
+/// # Safety
+///
+/// `field` must point to the live, owned inner field of `wrapper`, and
+/// `wrapper`'s `Drop` must do nothing but zeroize (so skipping it leaks only the
+/// wipe, never a resource).
+pub(crate) unsafe fn move_inner_out<W, T>(wrapper: W, field: *const T) -> T {
+    let inner = core::ptr::read(field);
+    core::mem::forget(wrapper);
+    inner
+}
+
 /// ReplaceT is a sealed trait that is used to replace the inner value of a type.
 /// It is only implemented for types that are Controlled.
 pub trait ReplaceT<K>: private::Sealed {

--- a/packages/protected/src/lib.rs
+++ b/packages/protected/src/lib.rs
@@ -35,34 +35,54 @@ pub use debug::{OpaqueDebug, Redacted};
 pub use timing_safe::{Choice, TimingSafeEq};
 pub use vitaminc_protected_derive::{OpaqueDebug, TimingSafeEq};
 
+/// A controlled wrapper whose single owned inner field can be moved out without
+/// running the wrapper's zeroizing `Drop`. Implemented only for this crate's
+/// controlled wrappers (`Protected` / `Equatable` / `Exportable`); it backs
+/// [`move_inner_out`] and, through it, `risky_unwrap` / `flatten` / `transpose`.
+///
+/// # Safety
+///
+/// `inner_ptr` must return a valid, well-aligned pointer to the wrapper's live,
+/// owned inner field (i.e. `&self.0`), and the implementing type's `Drop` must do
+/// nothing but zeroize — so that [`move_inner_out`] skipping it leaks only the
+/// wipe, never a resource.
+pub(crate) unsafe trait MoveInner {
+    /// The owned inner field type.
+    type Inner;
+    /// Pointer to the live, owned inner field (see the trait's safety contract).
+    fn inner_ptr(&self) -> *const Self::Inner;
+}
+
 /// Move the single owned field out of a controlled wrapper (e.g. `Protected<T>`)
 /// **without** running its zeroizing `Drop`.
 ///
-/// `wrapper` is the controlled value; `field` is a pointer to its owned inner
-/// field. The field is bit-copied to the caller and `wrapper` is forgotten so its
+/// The inner field is bit-copied to the caller and `wrapper` is forgotten so its
 /// `Drop` never runs against the now-moved-out field (no double-free, no
 /// use-after-zeroize). This is the shared primitive behind
 /// `risky_unwrap` / `flatten` / `transpose`.
+///
+/// This is a *safe* function: the only soundness obligation — that `inner_ptr`
+/// names the wrapper's live, owned field — is discharged by the [`MoveInner`]
+/// `unsafe` trait, and the pointer is derived from `wrapper` *after* this
+/// function owns it, so no pointer outlives the move that produced it.
 ///
 /// # Why the source slot is deliberately NOT scrubbed
 ///
 /// `ptr::read` produces a **bitwise** copy. For heap-backed inners (`Vec`,
 /// `String`, `Box`, …) the returned value and `wrapper`'s field then alias the
 /// *same* heap allocation. Scrubbing the source semantically (e.g.
-/// `field.zeroize()`) would wipe the heap the returned value still owns — a
-/// use-after-zeroize that hands the caller corrupted data (a decrypted
-/// `Protected<Vec<u8>>` would come back all zeroes). For inline inners
+/// `inner.zeroize()` against the source) would wipe the heap the returned value
+/// still owns — a use-after-zeroize that hands the caller corrupted data (a
+/// decrypted `Protected<Vec<u8>>` would come back all zeroes). For inline inners
 /// (`[u8; N]`) the abandoned stack copy is the inherent cost of an explicit
 /// move-out: `risky_unwrap` & friends transfer ownership — and the wiping
 /// obligation — to the caller by contract.
-///
-/// # Safety
-///
-/// `field` must point to the live, owned inner field of `wrapper`, and
-/// `wrapper`'s `Drop` must do nothing but zeroize (so skipping it leaks only the
-/// wipe, never a resource).
-pub(crate) unsafe fn move_inner_out<W, T>(wrapper: W, field: *const T) -> T {
-    let inner = core::ptr::read(field);
+pub(crate) fn move_inner_out<W: MoveInner>(wrapper: W) -> W::Inner {
+    // SAFETY: by `MoveInner`'s contract, `inner_ptr` points to `wrapper`'s live,
+    // owned inner field. It is read exactly once and `wrapper` is then forgotten,
+    // so the returned value is the sole owner — no double-free, and the wrapper's
+    // zeroizing `Drop` never wipes the moved-out value.
+    let inner = unsafe { core::ptr::read(wrapper.inner_ptr()) };
     core::mem::forget(wrapper);
     inner
 }

--- a/packages/protected/src/lib.rs
+++ b/packages/protected/src/lib.rs
@@ -43,6 +43,8 @@ pub trait ReplaceT<K>: private::Sealed {
 
 impl<T, K> ReplaceT<K> for Protected<T>
 where
+    T: Zeroize,
+    K: Zeroize,
     Protected<K>: Controlled,
 {
     type Output = Protected<K>;
@@ -50,6 +52,8 @@ where
 
 impl<T, K> ReplaceT<K> for Equatable<Protected<T>>
 where
+    T: Zeroize,
+    K: Zeroize,
     Equatable<Protected<K>>: Controlled,
 {
     type Output = Equatable<Protected<K>>;
@@ -57,6 +61,8 @@ where
 
 impl<T, K> ReplaceT<K> for Equatable<Exportable<Protected<T>>>
 where
+    T: Zeroize,
+    K: Zeroize,
     Equatable<Exportable<Protected<K>>>: Controlled,
 {
     type Output = Equatable<Exportable<Protected<K>>>;
@@ -64,6 +70,7 @@ where
 
 impl<T, K> ReplaceT<K> for Exportable<Protected<T>>
 where
+    T: Zeroize,
     K: Zeroize,
 {
     type Output = Exportable<Protected<K>>;
@@ -71,6 +78,7 @@ where
 
 impl<T, K> ReplaceT<K> for Exportable<Equatable<Protected<T>>>
 where
+    T: Zeroize,
     K: Zeroize,
 {
     type Output = Exportable<Equatable<Protected<K>>>;
@@ -80,6 +88,8 @@ where
 // because any we are not increasing the scope of the type.
 impl<T, K, S> ReplaceT<K> for Usage<Protected<T>, S>
 where
+    T: Zeroize,
+    K: Zeroize,
     Protected<K>: Controlled,
 {
     type Output = Protected<K>;
@@ -87,11 +97,12 @@ where
 
 mod private {
     use crate::{Equatable, Exportable, Protected, Usage};
+    use zeroize::Zeroize;
 
     pub trait Sealed {}
-    impl<T> Sealed for Protected<T> {}
-    impl<T> Sealed for Equatable<T> {}
-    impl<T> Sealed for Exportable<T> {}
+    impl<T: Zeroize> Sealed for Protected<T> {}
+    impl<T: Zeroize> Sealed for Equatable<T> {}
+    impl<T: Zeroize> Sealed for Exportable<T> {}
     impl<T, S> Sealed for Usage<T, S> {}
 
     /// Private trait that is used to hide the inner value of a Controlled type

--- a/packages/protected/src/protected/mod.rs
+++ b/packages/protected/src/protected/mod.rs
@@ -24,10 +24,16 @@ impl<T: Zeroize> Protected<T> {
     /// the shared primitive and the rationale (including why the source slot is
     /// not scrubbed).
     fn into_inner_unchecked(self) -> T {
-        let field: *const T = &self.0;
-        // SAFETY: `field` points to `self`'s live owned inner; `Protected`'s
-        // `Drop` only zeroizes.
-        unsafe { crate::move_inner_out(self, field) }
+        crate::move_inner_out(self)
+    }
+}
+
+// SAFETY: `inner_ptr` returns a pointer to `self`'s live, owned inner field, and
+// `Protected`'s derived `Drop` only zeroizes — satisfying `MoveInner`'s contract.
+unsafe impl<T: Zeroize> crate::MoveInner for Protected<T> {
+    type Inner = T;
+    fn inner_ptr(&self) -> *const T {
+        &self.0
     }
 }
 

--- a/packages/protected/src/protected/mod.rs
+++ b/packages/protected/src/protected/mod.rs
@@ -5,20 +5,34 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// The most basic controlled type.
 /// It ensures inner types are `Zeroize` and implements `Debug` and `Display` safely (i.e. inner sensitive values are redacted).
-#[derive(Zeroize, OpaqueDebug)]
-pub struct Protected<T>(pub(crate) T);
+///
+/// The inner value is wiped when the `Protected` is dropped (`ZeroizeOnDrop`),
+/// so the `T: Zeroize` bound is required on the type itself.
+#[derive(Zeroize, ZeroizeOnDrop, OpaqueDebug)]
+pub struct Protected<T: Zeroize>(pub(crate) T);
 
-impl<T> Protected<T> {
+impl<T: Zeroize> Protected<T> {
     /// Create a new [Protected] from an inner value.
-    pub const fn new(x: T) -> Self
-    where
-        T: Zeroize,
-    {
+    pub const fn new(x: T) -> Self {
         Self(x)
+    }
+
+    /// Move the inner value out without running the zeroizing `Drop`.
+    ///
+    /// Ownership of the (still sensitive) value transfers to the caller, which
+    /// becomes responsible for its lifecycle; the wrapper is forgotten so its
+    /// `Drop` does not also wipe — and thereby invalidate — the moved-out value.
+    fn into_inner_unchecked(self) -> T {
+        // SAFETY: `self.0` is read exactly once, then `self` is forgotten so its
+        // `Drop` never runs against the now-moved-out field (no double-free, no
+        // use-after-zeroize).
+        let inner = unsafe { core::ptr::read(&self.0) };
+        core::mem::forget(self);
+        inner
     }
 }
 
-impl<T> Protected<Protected<T>> {
+impl<T: Zeroize> Protected<Protected<T>> {
     #[inline]
     /// Flatten a [Protected] of [Protected] into a single [Protected].
     /// Similar to `Option::flatten`.
@@ -34,11 +48,11 @@ impl<T> Protected<Protected<T>> {
     /// Like [Option], flattening only removes one level of nesting at a time.
     ///
     pub fn flatten(self) -> Protected<T> {
-        self.0
+        self.into_inner_unchecked()
     }
 }
 
-impl<T> Protected<Option<T>> {
+impl<T: Zeroize> Protected<Option<T>> {
     #[inline]
     /// Transpose a [Protected] of `Option` into an `Option` of [Protected].
     /// Similar to `Option::transpose`.
@@ -51,20 +65,18 @@ impl<T> Protected<Option<T>> {
     /// assert!(y.is_some())
     /// ```
     pub fn transpose(self) -> Option<Protected<T>> {
-        self.0.map(Protected)
+        self.into_inner_unchecked().map(Protected::new)
     }
 }
 
-impl<T: Zeroize> ZeroizeOnDrop for Protected<T> {}
-
-impl<T> ControlledPrivate for Protected<T> {}
+impl<T: Zeroize> ControlledPrivate for Protected<T> {}
 
 impl<T> Controlled for Protected<T>
 where
     T: Zeroize,
 {
     fn risky_unwrap(self) -> Self::Inner {
-        self.0
+        self.into_inner_unchecked()
     }
 
     type Inner = T;
@@ -82,11 +94,14 @@ where
     }
 }
 
-impl<T> Copy for Protected<T> where T: Copy {}
+// NOTE: `Protected<T>` deliberately does NOT implement `Copy`. `Copy` and
+// `Drop` are mutually exclusive in Rust, and the zeroizing `Drop` is the whole
+// point — a bitwise copy would leave un-zeroized duplicates of the secret.
+// Use `Clone` (explicit) where a duplicate is genuinely needed.
 
 impl<T> Clone for Protected<T>
 where
-    T: Clone,
+    T: Clone + Zeroize,
 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -95,7 +110,7 @@ where
 
 impl<T, A> Extend<A> for Protected<T>
 where
-    T: Extend<A>,
+    T: Extend<A> + Zeroize,
 {
     fn extend<I>(&mut self, iter: I)
     where
@@ -127,8 +142,7 @@ where
 /// let y = Protected::new(2);
 /// let z = Protected::new(3);
 /// let array: [Protected<u8>; 3] = [x, y, z];
-/// let flattened = flatten_array(array);
-/// assert!(matches!(flattened, Protected));
+/// let flattened: Protected<[u8; 3]> = flatten_array(array);
 /// assert_eq!(flattened.risky_unwrap(), [1, 2, 3]);
 /// ```
 pub fn flatten_array<const N: usize, T>(array: [Protected<T>; N]) -> Protected<[T; N]>
@@ -137,7 +151,7 @@ where
 {
     let mut out: [T; N] = [Default::default(); N];
     array.iter().enumerate().for_each(|(i, x)| {
-        out[i] = x.risky_unwrap();
+        out[i] = *x.risky_ref();
     });
     Protected::new(out)
 }
@@ -145,11 +159,57 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
 
     #[test]
     fn test_new_array() {
         let x = Protected::new([0u8; 32]);
         assert_eq!(x.0, [0u8; 32]);
+    }
+
+    /// Regression test for #181: dropping a `Protected<T>` must zeroize its
+    /// inner value. Uses an inner type whose `Zeroize` sets a flag, so we can
+    /// observe that `Drop` ran the wipe (the bytes themselves are freed and
+    /// can't be inspected after drop).
+    #[test]
+    fn drop_zeroizes_inner() {
+        struct Tracked<'a>(&'a AtomicBool);
+        impl Zeroize for Tracked<'_> {
+            fn zeroize(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let zeroized = AtomicBool::new(false);
+        {
+            let _p = Protected::new(Tracked(&zeroized));
+            assert!(!zeroized.load(Ordering::SeqCst));
+        }
+        assert!(
+            zeroized.load(Ordering::SeqCst),
+            "Protected::drop should zeroize the inner value"
+        );
+    }
+
+    /// `risky_unwrap` must move the secret out *without* the wrapper's `Drop`
+    /// zeroizing it on the way (the caller now owns the live value).
+    #[test]
+    fn risky_unwrap_does_not_zeroize() {
+        struct Tracked<'a>(&'a AtomicBool);
+        impl Zeroize for Tracked<'_> {
+            fn zeroize(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let zeroized = AtomicBool::new(false);
+        // The recovered value is live and owned here; `Tracked` has no `Drop`,
+        // so letting it fall out of scope is a no-op and the flag stays false.
+        let _recovered = Protected::new(Tracked(&zeroized)).risky_unwrap();
+        assert!(
+            !zeroized.load(Ordering::SeqCst),
+            "risky_unwrap must not zeroize the value it hands back"
+        );
     }
 
     #[test]

--- a/packages/protected/src/protected/mod.rs
+++ b/packages/protected/src/protected/mod.rs
@@ -20,15 +20,14 @@ impl<T: Zeroize> Protected<T> {
     /// Move the inner value out without running the zeroizing `Drop`.
     ///
     /// Ownership of the (still sensitive) value transfers to the caller, which
-    /// becomes responsible for its lifecycle; the wrapper is forgotten so its
-    /// `Drop` does not also wipe — and thereby invalidate — the moved-out value.
+    /// becomes responsible for its lifecycle. See [`crate::move_inner_out`] for
+    /// the shared primitive and the rationale (including why the source slot is
+    /// not scrubbed).
     fn into_inner_unchecked(self) -> T {
-        // SAFETY: `self.0` is read exactly once, then `self` is forgotten so its
-        // `Drop` never runs against the now-moved-out field (no double-free, no
-        // use-after-zeroize).
-        let inner = unsafe { core::ptr::read(&self.0) };
-        core::mem::forget(self);
-        inner
+        let field: *const T = &self.0;
+        // SAFETY: `field` points to `self`'s live owned inner; `Protected`'s
+        // `Drop` only zeroizes.
+        unsafe { crate::move_inner_out(self, field) }
     }
 }
 

--- a/packages/protected/src/protected/mod.rs
+++ b/packages/protected/src/protected/mod.rs
@@ -147,13 +147,12 @@ where
 /// ```
 pub fn flatten_array<const N: usize, T>(array: [Protected<T>; N]) -> Protected<[T; N]>
 where
-    T: Zeroize + Default + Copy, // TODO: Default won't be needed if we use MaybeUninit
+    T: Zeroize,
 {
-    let mut out: [T; N] = [Default::default(); N];
-    array.iter().enumerate().for_each(|(i, x)| {
-        out[i] = *x.risky_ref();
-    });
-    Protected::new(out)
+    // `[_; N]::map` moves each `Protected<T>` into the closure; `risky_unwrap`
+    // moves the inner secret straight through — no copy, and no `T: Copy` /
+    // `Default` bound (the secret is never duplicated).
+    Protected::new(array.map(|p| p.risky_unwrap()))
 }
 
 #[cfg(test)]

--- a/packages/protected/src/usage/mod.rs
+++ b/packages/protected/src/usage/mod.rs
@@ -2,6 +2,7 @@ use serde::{Serialize, Serializer};
 
 use crate::{exportable::SafeSerialize, private::ControlledPrivate, Controlled, Protected};
 use std::marker::PhantomData;
+use zeroize::Zeroize;
 
 // TODO: Docs, explain compile time
 pub struct Usage<T, Scope = DefaultScope>(pub(crate) T, pub(crate) PhantomData<Scope>);
@@ -13,6 +14,15 @@ impl<T, S> Usage<T, S> {
         S: Scope,
     {
         Self::init_from_inner(x)
+    }
+}
+
+// `Usage` is a compile-time scope wrapper; it is not in #181's drop scope, but
+// `Controlled: Zeroize` requires it to be zeroizable. Delegates to the inner
+// controlled type (whose own `Drop` performs the wipe). `PhantomData` is a ZST.
+impl<T: Zeroize, Scope> Zeroize for Usage<T, Scope> {
+    fn zeroize(&mut self) {
+        self.0.zeroize();
     }
 }
 
@@ -56,7 +66,7 @@ impl<T, S> Acceptable<S> for Usage<T, S> where S: Scope {}
 // TODO: Move this to all of the other modules
 pub struct DefaultScope;
 impl Scope for DefaultScope {}
-impl<T> Acceptable<DefaultScope> for Protected<T> {}
+impl<T: Zeroize> Acceptable<DefaultScope> for Protected<T> {}
 
 /// Serialize implementation for Usage if it is controlled and the inner type is safe serializable.
 ///

--- a/packages/protected/src/usage/mod.rs
+++ b/packages/protected/src/usage/mod.rs
@@ -17,9 +17,17 @@ impl<T, S> Usage<T, S> {
     }
 }
 
-// `Usage` is a compile-time scope wrapper; it is not in #181's drop scope, but
-// `Controlled: Zeroize` requires it to be zeroizable. Delegates to the inner
-// controlled type (whose own `Drop` performs the wipe). `PhantomData` is a ZST.
+// `Usage` is a compile-time scope wrapper; this `Zeroize` impl exists only to
+// satisfy the `Controlled: Zeroize` supertrait and delegates to the inner type
+// (`PhantomData` is a ZST with nothing to wipe).
+//
+// `Usage` intentionally does NOT derive `ZeroizeOnDrop`. Its secret is still
+// wiped on drop: `Usage::new` requires `Self: Controlled`, so the inner `T` is
+// always a controlled type (`Protected`/`Equatable`/`Exportable`), each of which
+// is `ZeroizeOnDrop` — dropping `Usage` runs the field's drop glue and wipes the
+// bytes. Giving `Usage` its own `Drop` would require a viral `T: Zeroize` bound
+// on the struct (E0367: a conditional `Drop` must match the struct bounds),
+// which would cascade through every `Usage<T, S>` use for no behavioural gain.
 impl<T: Zeroize, Scope> Zeroize for Usage<T, Scope> {
     fn zeroize(&mut self) {
         self.0.zeroize();

--- a/packages/protected/src/zeroed.rs
+++ b/packages/protected/src/zeroed.rs
@@ -1,6 +1,7 @@
 use std::marker::PhantomData;
 
 use crate::{Equatable, Exportable, Protected, Usage};
+use zeroize::Zeroize;
 
 /// Similar to `Default`, but doesn't rely on the standard library,
 /// is only implemented for Paranoid types, and covers array sizes up to 1024.
@@ -34,7 +35,7 @@ macro_rules! impl_zeroed_for_literal {
 
 impl<T> Zeroed for Protected<T>
 where
-    T: Zeroed,
+    T: Zeroed + Zeroize,
 {
     fn zeroed() -> Self {
         Protected(T::zeroed())
@@ -43,7 +44,7 @@ where
 
 impl<T> Zeroed for Equatable<T>
 where
-    T: Zeroed,
+    T: Zeroed + Zeroize,
 {
     fn zeroed() -> Self {
         Equatable(T::zeroed())
@@ -52,7 +53,7 @@ where
 
 impl<T> Zeroed for Exportable<T>
 where
-    T: Zeroed,
+    T: Zeroed + Zeroize,
 {
     fn zeroed() -> Self {
         Exportable(T::zeroed())

--- a/packages/random/src/generatable.rs
+++ b/packages/random/src/generatable.rs
@@ -16,6 +16,7 @@
 use crate::{RandomError, SafeRand};
 use std::num::NonZeroU16;
 use vitaminc_protected::{Controlled, Equatable, Exportable, Protected, Usage};
+use zeroize::Zeroize;
 
 /// A trait for types that can be generated randomly.
 /// The random number generator is passed as an argument to the `generate` method
@@ -65,6 +66,7 @@ impl<const N: usize> Generatable for [u8; N] {
 
 impl<T, G> Generatable for Protected<T>
 where
+    T: Zeroize,
     G: Generatable,
     Self: Controlled<Inner = G>,
 {
@@ -75,6 +77,7 @@ where
 
 impl<T, G> Generatable for Exportable<T>
 where
+    T: Zeroize,
     G: Generatable,
     Self: Controlled<Inner = G>,
 {
@@ -85,6 +88,7 @@ where
 
 impl<T, G> Generatable for Equatable<T>
 where
+    T: Zeroize,
     G: Generatable,
     Self: Controlled<Inner = G>,
 {


### PR DESCRIPTION
Closes #181.

## Problem

`vitaminc_protected::{Protected, Equatable, Exportable}` derived `Zeroize` and (for `Protected`) asserted the `ZeroizeOnDrop` *marker*, but had **no `Drop` impl** — the marker is a contract claim, not enforcement. Dropping a `Protected<Vec<u8>>` freed the heap buffer without wiping it; `Protected<[u8; N]>` was never touched. The chain-of-custody threaded through aead/encrypt was correct in shape but delivered no actual leaf wipe.

## Fix

- **Real `ZeroizeOnDrop`** on all three types (`#[derive(…, ZeroizeOnDrop)]`), which requires a `T: Zeroize` bound on each struct (a conditional `Drop` must match the struct bounds — E0367).
- **`into_inner_unchecked`** (`ptr::read` + `mem::forget`) so `risky_unwrap` / `flatten` / `transpose` still move the secret out to the caller without the new `Drop` wiping the value the caller now owns.
- **`Controlled: ControlledPrivate + Zeroize`** supertrait — a true invariant ("every controlled type wraps zeroizable material") that collapses most of the bound cascade; every `where T: Controlled` impl gets `Zeroize` for free. `Usage` gains a delegating `Zeroize` impl to satisfy it.
- Downstream cascade: `random`'s `Generatable` impls carry the bound; `permutation::PermutationKey` loses `Copy` and its borrow-then-consume call sites clone explicitly.

## ⚠️ Breaking changes

`Copy` is removed from **`Protected`**, **`Exportable`**, and **`PermutationKey`**. `Copy` and `Drop` are mutually exclusive — and a bitwise copy of a secret would leave un-zeroized duplicates, defeating the fix. Code that copied these by value must now `.clone()` explicitly (a deliberate duplication of a secret). `Equatable` never implemented `Copy`, so it is unaffected.

## Validation (`/zeroize-audit`)

- **Source (trait-aware semantic pass): 0 findings** — all three types are now correctly `ZeroizeOnDrop`.
- **Runtime:** new `drop_zeroizes_inner` test observes (via a flag-setting `Zeroize` inner) that `Drop` runs the wipe; `risky_unwrap_does_not_zeroize` confirms the move-out path hands back a live value.
- **-O2 LLVM IR (the issue's acceptance criterion):** `encrypt`'s optimized IR now contains a `core::ptr::drop_in_place` monomorphization plus the key/decrypt paths with **168 `store volatile i8 0` + 168 `seq_cst` fences** — the zeroize wipes fire and are *not* DSE-removable. Before this change there were **zero**.

## Test status

Whole workspace compiles; `clippy --all-targets -D warnings` clean; `cargo fmt --check` clean. All tests pass except the pre-existing localstack-dependent `vitaminc-kms::test_finalize` (connection refused to `127.0.0.1:4566`), unrelated to this change.

## Follow-up

The 3 `mem::forget` hits the audit's grep-based scanner flags in `into_inner_unchecked` are false positives — the paired `ptr::read` transfers ownership to the caller; forgetting the husk prevents a double-wipe (pinned by `risky_unwrap_does_not_zeroize`).
