### PR TITLE
feat(aead): re-introduce ContextTag on the revised Cipher/Decipher traits

### DIFF
--- a/packages/aead/src/context.rs
+++ b/packages/aead/src/context.rs
@@ -1,0 +1,449 @@
+//! Context-tagged encryption.
+//!
+//! This module provides [`ContextTag`], a wrapper that binds additional authenticated data (AAD)
+//! to a plaintext value **at the type level**. When a `ContextTag` is encrypted, the embedded tag
+//! is automatically folded into the AAD alongside any extra AAD passed to
+//! [`encrypt_with_aad`](crate::Encrypt::encrypt_with_aad).
+//!
+//! The point of the wrapper is the type-level guarantee: a value wrapped in `ContextTag` *cannot*
+//! be encrypted without its context. The revised [`Cipher`]/[`Encrypt`] API already accepts tuple
+//! AAD (e.g. `value.encrypt_with_aad(cipher, (tag, extra))`), so the byte-level behaviour is
+//! nothing more than [`IntoAad`] composition — but tuple AAD is opt-in at every call site and easy
+//! to forget. `ContextTag` moves the obligation into the type system so the compiler enforces it.
+//!
+//! # Where AAD lives in the revised API
+//!
+//! Encryption threads AAD through [`Encrypt::encrypt_with_aad`](crate::Encrypt::encrypt_with_aad),
+//! so `ContextTag` participates by implementing [`Encrypt`]. Decryption is different: the revised
+//! [`Decrypt`]/[`Decipher`] traits do **not** thread AAD through the type being decrypted — the
+//! concrete cipher injects the AAD when it constructs the decipher (e.g.
+//! `cipher.decrypt_with_aad::<T, _>(ciphertext, aad)`). There is therefore nothing for a
+//! `ContextTag` *type* to enforce on the decrypt path; the recovered value is simply `T`.
+//!
+//! To keep the two sides symmetric without guessing the tuple layout, [`ContextTag::aad`] and
+//! [`ContextTag::aad_with`] build the exact AAD the wrapper bound at encrypt time, ready to hand to
+//! a concrete cipher's decrypt entry point.
+//!
+//! # AAD encoding
+//!
+//! When encrypting a `ContextTag`, the final AAD is formed by combining the extra AAD with the
+//! embedded tag as the tuple `(extra_aad, tag)`, which [`IntoAad`] PAE-encodes:
+//!
+//! ```text
+//! final_aad = PAE(extra_aad, tag)
+//! ```
+//!
+//! PAE (Pre-Authentication Encoding) prefixes each piece with its length, preventing
+//! canonicalisation attacks where different inputs could otherwise produce identical byte strings.
+//!
+//! With [`refine`](ContextTag::refine), the tag itself is a nested tuple that is recursively
+//! PAE-encoded:
+//!
+//! ```text
+//! ContextTag::new(data, "a").refine("b")
+//!   ──► tag = ("a", "b")
+//!   ──► final_aad = PAE(extra_aad, PAE("a", "b"))
+//! ```
+
+use crate::{Aad, Cipher, Encrypt, IntoAad};
+
+/// A wrapper that pairs a plaintext value with a context tag used as additional authenticated
+/// data (AAD).
+///
+/// `ContextTag` guarantees, at the type level, that `tag` is folded into the AAD whenever `inner`
+/// is encrypted. This is the recommended way to enforce that a value is always sealed against a
+/// specific context (a user id, table name, column name, …): because the tag is part of the type,
+/// the compiler will not let you forget it.
+///
+/// The tag can be any type that implements [`IntoAad<'static>`](IntoAad) — `&'static str`,
+/// `String`, `u64`, `Vec<u8>`, and tuples of these. (Non-`'static` borrowed tags such as a
+/// short-lived `&str` are intentionally excluded; promote them to an owned `String` or a
+/// `&'static str`.)
+///
+/// # Encrypting
+///
+/// `ContextTag` implements [`Encrypt`], so it is encrypted like any other value. The embedded tag
+/// is bound automatically:
+///
+/// ```rust,ignore
+/// use vitaminc_aead::{ContextTag, Encrypt};
+///
+/// // `cipher` implements `Cipher` for `&MyCipher` (see crate docs / `Aes256Cipher`).
+/// let tagged = ContextTag::new("secret message", "user:42");
+/// let ciphertext = tagged.encrypt(&cipher)?;
+/// # Ok::<(), vitaminc_aead::Unspecified>(())
+/// ```
+///
+/// # Decrypting
+///
+/// The revised decrypt path takes its AAD from the cipher, not the type, so you recover the plain
+/// `T` and supply the matching AAD via [`ContextTag::aad`] / [`ContextTag::aad_with`]:
+///
+/// ```rust,ignore
+/// use vitaminc_aead::ContextTag;
+///
+/// let plaintext: String =
+///     cipher.decrypt_with_aad(ciphertext, ContextTag::aad("user:42"))?;
+/// # Ok::<(), vitaminc_aead::Unspecified>(())
+/// ```
+pub struct ContextTag<Tag, T> {
+    inner: T,
+    tag: Tag,
+}
+
+impl<Tag, T> ContextTag<Tag, T> {
+    /// Creates a new `ContextTag` pairing `inner` with the given `tag`.
+    ///
+    /// The tag is folded into the AAD whenever `inner` is encrypted.
+    ///
+    /// ```rust
+    /// use vitaminc_aead::ContextTag;
+    ///
+    /// let tagged = ContextTag::new("hello", "my-tag");
+    /// # let _ = tagged;
+    /// ```
+    pub fn new(inner: T, tag: Tag) -> Self {
+        ContextTag { inner, tag }
+    }
+
+    /// Adds a second layer of context, producing a new `ContextTag` whose tag is the tuple
+    /// `(original_tag, tag)`.
+    ///
+    /// Useful for building hierarchical context such as `("table:users", "column:email")`. The
+    /// nested tag is PAE-encoded when converted to AAD bytes, so distinct hierarchies never
+    /// collide. `refine` can be chained to build deeper hierarchies.
+    ///
+    /// ```rust
+    /// use vitaminc_aead::ContextTag;
+    ///
+    /// let tagged = ContextTag::new("secret", "table:users").refine("column:email");
+    /// // The tag is now ("table:users", "column:email").
+    /// # let _ = tagged;
+    /// ```
+    pub fn refine<B>(self, tag: B) -> ContextTag<(Tag, B), T> {
+        ContextTag {
+            inner: self.inner,
+            tag: (self.tag, tag),
+        }
+    }
+
+    /// Consumes the wrapper, returning the inner value and its tag.
+    pub fn into_parts(self) -> (T, Tag) {
+        (self.inner, self.tag)
+    }
+}
+
+impl<Tag> ContextTag<Tag, ()> {
+    /// Builds the AAD to supply when **decrypting** a value that was sealed with
+    /// `ContextTag::new(value, tag).encrypt(cipher)` (i.e. with no extra AAD).
+    ///
+    /// This is the symmetric counterpart of the binding performed by [`Encrypt`]: it reproduces
+    /// the `(empty, tag)` layout so a concrete cipher's decrypt entry point authenticates against
+    /// exactly the same bytes.
+    ///
+    /// ```rust
+    /// use vitaminc_aead::{ContextTag, IntoAad};
+    ///
+    /// // The AAD recovered for decryption matches what `encrypt` bound at seal time.
+    /// let decrypt_aad = ContextTag::aad("user:42");
+    /// assert_eq!(
+    ///     decrypt_aad.into_aad().as_bytes(),
+    ///     ((), "user:42").into_aad().as_bytes(),
+    /// );
+    /// ```
+    pub fn aad(tag: Tag) -> (Aad<'static>, Tag) {
+        (Aad::empty(), tag)
+    }
+
+    /// Builds the AAD to supply when **decrypting** a value that was sealed with
+    /// `ContextTag::new(value, tag).encrypt_with_aad(cipher, extra_aad)`.
+    ///
+    /// Reproduces the `(extra_aad, tag)` layout bound at encrypt time.
+    ///
+    /// ```rust
+    /// use vitaminc_aead::{ContextTag, IntoAad};
+    ///
+    /// let decrypt_aad = ContextTag::aad_with("table:users", "row:99");
+    /// assert_eq!(
+    ///     decrypt_aad.into_aad().as_bytes(),
+    ///     ("row:99", "table:users").into_aad().as_bytes(),
+    /// );
+    /// ```
+    pub fn aad_with<A>(tag: Tag, extra_aad: A) -> (A, Tag) {
+        (extra_aad, tag)
+    }
+}
+
+impl<Tag, T> Encrypt for ContextTag<Tag, T>
+where
+    T: Encrypt,
+    // `Encrypt::encrypt_with_aad` chooses the AAD lifetime at the call site, but the tag is owned
+    // by the wrapper. Requiring `IntoAad<'static>` lets the tag be encoded into an owned (or
+    // `'static`-borrowed) `Aad` that we then re-borrow for the call's lifetime via covariance.
+    // Owned tags (`String`, `u64`, `Vec<u8>`, tuples thereof) and `&'static str` satisfy this;
+    // non-`'static` borrows do not — promote them to `String` or a `&'static str`.
+    Tag: IntoAad<'static>,
+{
+    /// Encrypts the inner value, folding the embedded tag into the AAD.
+    ///
+    /// The final AAD is `(extra_aad, tag)`, PAE-encoded by [`IntoAad`] into an unambiguous byte
+    /// representation that binds both pieces.
+    fn encrypt_with_aad<'a, C, A>(self, cipher: C, extra_aad: A) -> Result<C::Ok, C::Error>
+    where
+        C: Cipher,
+        A: IntoAad<'a>,
+    {
+        let ContextTag { inner, tag } = self;
+        // Encode the tag into an owned/`'static` `Aad`, then re-borrow it for the call's `'a`
+        // lifetime (`Aad` is covariant in its lifetime, so `'static: 'a` permits the narrowing).
+        let tag_aad: Aad<'static> = tag.into_aad();
+        let tag_aad: Aad<'a> = tag_aad;
+        inner.encrypt_with_aad(cipher, (extra_aad, tag_aad))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        cipher::{MapCipher, SeqCipher},
+        Unspecified,
+    };
+    use std::any::Any;
+    use std::cell::RefCell;
+    use vitaminc_protected::{Controlled, Protected};
+
+    /// A minimal [`Cipher`] that records the AAD bytes it is handed and echoes the plaintext back
+    /// as its "ciphertext". Only the byte path is exercised by the leaf `Encrypt` impls used in
+    /// these tests (`&str`, `String`, `[u8; N]`); the sequence/map sub-ciphers exist solely to
+    /// satisfy the trait and are never driven.
+    struct MockCipher {
+        captured_aad: RefCell<Vec<u8>>,
+    }
+
+    impl MockCipher {
+        fn new() -> Self {
+            MockCipher {
+                captured_aad: RefCell::new(Vec::new()),
+            }
+        }
+
+        fn captured_aad(&self) -> Vec<u8> {
+            self.captured_aad.borrow().clone()
+        }
+    }
+
+    struct UnusedSeq;
+    struct UnusedMap;
+
+    impl Cipher for &MockCipher {
+        type Ok = Vec<u8>;
+        type Error = Unspecified;
+        type SeqCipher = UnusedSeq;
+        type MapCipher = UnusedMap;
+
+        fn encrypt_bytes_vec<'a, A>(
+            self,
+            data: Protected<Vec<u8>>,
+            aad: A,
+        ) -> Result<Self::Ok, Self::Error>
+        where
+            A: IntoAad<'a>,
+        {
+            *self.captured_aad.borrow_mut() = aad.into_aad().as_bytes().to_vec();
+            Ok(data.risky_unwrap())
+        }
+
+        fn encrypt_seq(self, _size_hint: Option<usize>) -> Self::SeqCipher {
+            UnusedSeq
+        }
+
+        fn encrypt_map(self) -> Self::MapCipher {
+            UnusedMap
+        }
+
+        fn encrypt_none<'a, A>(self, aad: A) -> Result<Self::Ok, Self::Error>
+        where
+            A: IntoAad<'a>,
+        {
+            *self.captured_aad.borrow_mut() = aad.into_aad().as_bytes().to_vec();
+            Ok(Vec::new())
+        }
+
+        fn passthrough<U>(self, _value: U) -> Result<Self::Ok, Self::Error>
+        where
+            U: Any + Send + 'static,
+        {
+            Ok(Vec::new())
+        }
+    }
+
+    impl SeqCipher for UnusedSeq {
+        type Ok = Vec<u8>;
+        type Error = Unspecified;
+
+        fn encrypt_next<'a, T, A>(self, _data: T, _aad: A) -> Result<Self, Self::Error>
+        where
+            T: Encrypt,
+            A: IntoAad<'a>,
+        {
+            Ok(self)
+        }
+
+        fn passthrough_next<T>(self, _value: T) -> Result<Self, Self::Error>
+        where
+            T: Any + Send + 'static,
+        {
+            Ok(self)
+        }
+
+        fn end(self) -> Result<Self::Ok, Self::Error> {
+            Ok(Vec::new())
+        }
+    }
+
+    impl MapCipher for UnusedMap {
+        type Ok = Vec<u8>;
+        type Error = Unspecified;
+
+        fn encrypt_key(self, _key: &'static str) -> Result<Self, Self::Error> {
+            Ok(self)
+        }
+
+        fn encrypt_value<'a, T, A>(self, _value: T, _aad: A) -> Result<Self, Self::Error>
+        where
+            T: Encrypt,
+            A: IntoAad<'a>,
+        {
+            Ok(self)
+        }
+
+        fn passthrough_entry<T>(self, _key: &'static str, _value: T) -> Result<Self, Self::Error>
+        where
+            T: Any + Send + 'static,
+        {
+            Ok(self)
+        }
+
+        fn end(self) -> Result<Self::Ok, Self::Error> {
+            Ok(Vec::new())
+        }
+    }
+
+    #[test]
+    fn encrypts_inner_value_and_binds_tag() {
+        let plaintext = "hello world";
+        let cipher = MockCipher::new();
+
+        let ciphertext = ContextTag::new(plaintext, "tag_aad")
+            .encrypt_with_aad(&cipher, "extra")
+            .expect("encryption should succeed");
+
+        // The inner value is encrypted unchanged...
+        assert_eq!(ciphertext, plaintext.as_bytes());
+        // ...and the bound AAD is PAE(extra, tag).
+        let expected = Aad::pae(&[b"extra", b"tag_aad"]);
+        assert_eq!(cipher.captured_aad(), expected.as_bytes());
+    }
+
+    #[test]
+    fn encrypt_with_no_extra_aad_still_binds_tag() {
+        let cipher = MockCipher::new();
+
+        ContextTag::new("secret", "user:42")
+            .encrypt(&cipher)
+            .expect("encryption should succeed");
+
+        // `encrypt` supplies an empty extra AAD, so the bound AAD is PAE(empty, tag).
+        let expected = ((), "user:42").into_aad();
+        assert_eq!(cipher.captured_aad(), expected.as_bytes());
+    }
+
+    #[test]
+    fn refine_nests_the_tag() {
+        let cipher = MockCipher::new();
+
+        ContextTag::new("secret", "table:users")
+            .refine("column:email")
+            .encrypt_with_aad(&cipher, "extra")
+            .expect("encryption should succeed");
+
+        // extra + (table, column) => PAE(extra, PAE(table, column)).
+        let inner = Aad::pae(&[b"table:users", b"column:email"]);
+        let expected = Aad::pae(&[b"extra", inner.as_bytes()]);
+        assert_eq!(cipher.captured_aad(), expected.as_bytes());
+    }
+
+    #[test]
+    fn chained_refine_builds_left_nested_tuple() {
+        let cipher = MockCipher::new();
+
+        ContextTag::new("data", "a")
+            .refine("b")
+            .refine("c")
+            .encrypt(&cipher)
+            .expect("encryption should succeed");
+
+        // tag = (("a", "b"), "c"); no extra AAD.
+        let expected = ((), (("a", "b"), "c")).into_aad();
+        assert_eq!(cipher.captured_aad(), expected.as_bytes());
+    }
+
+    #[test]
+    fn owned_string_tag_is_accepted() {
+        let cipher = MockCipher::new();
+
+        ContextTag::new("secret", String::from("owned-tag"))
+            .encrypt(&cipher)
+            .expect("encryption should succeed");
+
+        let expected = ((), "owned-tag").into_aad();
+        assert_eq!(cipher.captured_aad(), expected.as_bytes());
+    }
+
+    #[test]
+    fn aad_helper_matches_encrypt_binding() {
+        // The AAD `ContextTag::aad` produces for decryption must equal what `encrypt` binds.
+        let cipher = MockCipher::new();
+        ContextTag::new("secret", "user:42")
+            .encrypt(&cipher)
+            .expect("encryption should succeed");
+
+        let decrypt_aad = ContextTag::aad("user:42").into_aad();
+        assert_eq!(cipher.captured_aad(), decrypt_aad.as_bytes());
+    }
+
+    #[test]
+    fn aad_with_helper_matches_encrypt_binding() {
+        let cipher = MockCipher::new();
+        ContextTag::new("secret", "table:users")
+            .encrypt_with_aad(&cipher, "row:99")
+            .expect("encryption should succeed");
+
+        let decrypt_aad = ContextTag::aad_with("table:users", "row:99").into_aad();
+        assert_eq!(cipher.captured_aad(), decrypt_aad.as_bytes());
+    }
+
+    #[test]
+    fn different_tags_produce_different_aad() {
+        let cipher_a = MockCipher::new();
+        let cipher_b = MockCipher::new();
+
+        ContextTag::new("secret", "user:42")
+            .encrypt(&cipher_a)
+            .expect("encryption should succeed");
+        ContextTag::new("secret", "user:99")
+            .encrypt(&cipher_b)
+            .expect("encryption should succeed");
+
+        assert_ne!(cipher_a.captured_aad(), cipher_b.captured_aad());
+    }
+
+    #[test]
+    fn into_parts_round_trips() {
+        let tagged = ContextTag::new("secret", "ctx");
+        let (inner, tag) = tagged.into_parts();
+        assert_eq!(inner, "secret");
+        assert_eq!(tag, "ctx");
+    }
+}

--- a/packages/aead/src/context.rs
+++ b/packages/aead/src/context.rs
@@ -45,7 +45,7 @@
 //!   ──► final_aad = PAE(extra_aad, PAE("a", "b"))
 //! ```
 
-use crate::{Aad, Cipher, Encrypt, IntoAad};
+use crate::{Aad, Cipher, Decipher, Decrypt, Encrypt, IntoAad};
 
 /// A wrapper that pairs a plaintext value with a context tag used as additional authenticated
 /// data (AAD).
@@ -76,16 +76,21 @@ use crate::{Aad, Cipher, Encrypt, IntoAad};
 ///
 /// # Decrypting
 ///
-/// The revised decrypt path takes its AAD from the cipher, not the type, so you recover the plain
-/// `T` and supply the matching AAD via [`ContextTag::aad`] / [`ContextTag::aad_with`]:
+/// Mirror the encrypt side: rebuild the context with [`ContextTag::context`] (and the same
+/// [`refine`](ContextTag::refine) chain, if any), then recover the value with
+/// [`decrypt`](ContextTag::decrypt) / [`decrypt_with_aad`](ContextTag::decrypt_with_aad),
+/// driving a [`Decipher`] obtained from the concrete cipher:
 ///
 /// ```rust,ignore
 /// use vitaminc_aead::ContextTag;
 ///
 /// let plaintext: String =
-///     cipher.decrypt_with_aad(ciphertext, ContextTag::aad("user:42"))?;
+///     ContextTag::context("user:42").decrypt(cipher.decipher(ciphertext))?;
 /// # Ok::<(), vitaminc_aead::Unspecified>(())
 /// ```
+///
+/// For lower-level control you can instead build the raw AAD with [`ContextTag::aad`] /
+/// [`ContextTag::aad_with`] and pass it to a cipher's own decrypt entry point.
 pub struct ContextTag<Tag, T> {
     inner: T,
     tag: Tag,
@@ -174,6 +179,64 @@ impl<Tag> ContextTag<Tag, ()> {
     /// ```
     pub fn aad_with<A>(extra_aad: A, tag: Tag) -> (A, Tag) {
         (extra_aad, tag)
+    }
+
+    /// Begins a decrypt-side context carrying `tag` (and no value yet).
+    ///
+    /// This is the decrypt mirror of [`ContextTag::new`]: build (and
+    /// [`refine`](ContextTag::refine)) the tag exactly as you did at encrypt time,
+    /// then call [`decrypt`](ContextTag::decrypt) /
+    /// [`decrypt_with_aad`](ContextTag::decrypt_with_aad) to recover the value —
+    /// so the tag (and any nested refinement) is reconstructed by the same code
+    /// path that bound it, never re-typed by hand.
+    ///
+    /// ```rust
+    /// use vitaminc_aead::ContextTag;
+    ///
+    /// // mirrors `ContextTag::new(value, "table:users").refine("column:email")`
+    /// let ctx = ContextTag::context("table:users").refine("column:email");
+    /// # let _ = ctx;
+    /// ```
+    pub fn context(tag: Tag) -> Self {
+        ContextTag { inner: (), tag }
+    }
+}
+
+impl<Tag> ContextTag<Tag, ()>
+where
+    Tag: IntoAad<'static>,
+{
+    /// Decrypts a value sealed against this context, authenticating against the
+    /// embedded tag (no extra AAD). The decrypt mirror of
+    /// [`ContextTag::encrypt`](Encrypt::encrypt).
+    ///
+    /// Obtain `decipher` from a concrete cipher (e.g. `cipher.decipher(ciphertext)`).
+    pub fn decrypt<'c, T, D>(self, decipher: D) -> D::Ok<T>
+    where
+        D: Decipher<'c>,
+        T: Decrypt<'c> + 'c,
+    {
+        self.decrypt_with_aad(decipher, Aad::empty())
+    }
+
+    /// Decrypts a value sealed against this context plus `extra_aad`, mirroring
+    /// [`ContextTag::encrypt_with_aad`](Encrypt::encrypt_with_aad).
+    ///
+    /// The tag lives in the receiver and `extra_aad` is the lone argument, so the
+    /// two cannot be swapped; the bound AAD is `(extra_aad, tag)` — byte-identical
+    /// to what the [`Encrypt`] impl folds in at seal time. Obtain `decipher` from
+    /// a concrete cipher (e.g. `cipher.decipher(ciphertext)`).
+    pub fn decrypt_with_aad<'c, 'a, T, D, A>(self, decipher: D, extra_aad: A) -> D::Ok<T>
+    where
+        D: Decipher<'c>,
+        T: Decrypt<'c> + 'c,
+        A: IntoAad<'a>,
+    {
+        // Encode the tag into an owned/`'static` `Aad`, then re-borrow it for the
+        // call's `'a` lifetime (covariance), exactly as the `Encrypt` impl does.
+        let tag_aad: Aad<'static> = self.tag.into_aad();
+        let tag_aad: Aad<'a> = tag_aad;
+        T::decrypt_with_aad(decipher, (extra_aad, tag_aad))
     }
 }
 

--- a/packages/aead/src/context.rs
+++ b/packages/aead/src/context.rs
@@ -158,18 +158,21 @@ impl<Tag> ContextTag<Tag, ()> {
     /// Builds the AAD to supply when **decrypting** a value that was sealed with
     /// `ContextTag::new(value, tag).encrypt_with_aad(cipher, extra_aad)`.
     ///
-    /// Reproduces the `(extra_aad, tag)` layout bound at encrypt time.
+    /// Reproduces the `(extra_aad, tag)` layout bound at encrypt time. The argument order
+    /// mirrors [`encrypt_with_aad`](crate::Encrypt::encrypt_with_aad): the extra AAD comes
+    /// first, then the tag — so the two call sites line up and read in the same order as the
+    /// bound tuple.
     ///
     /// ```rust
     /// use vitaminc_aead::{ContextTag, IntoAad};
     ///
-    /// let decrypt_aad = ContextTag::aad_with("table:users", "row:99");
+    /// let decrypt_aad = ContextTag::aad_with("row:99", "table:users");
     /// assert_eq!(
     ///     decrypt_aad.into_aad().as_bytes(),
     ///     ("row:99", "table:users").into_aad().as_bytes(),
     /// );
     /// ```
-    pub fn aad_with<A>(tag: Tag, extra_aad: A) -> (A, Tag) {
+    pub fn aad_with<A>(extra_aad: A, tag: Tag) -> (A, Tag) {
         (extra_aad, tag)
     }
 }
@@ -420,7 +423,7 @@ mod tests {
             .encrypt_with_aad(&cipher, "row:99")
             .expect("encryption should succeed");
 
-        let decrypt_aad = ContextTag::aad_with("table:users", "row:99").into_aad();
+        let decrypt_aad = ContextTag::aad_with("row:99", "table:users").into_aad();
         assert_eq!(cipher.captured_aad(), decrypt_aad.as_bytes());
     }
 

--- a/packages/aead/src/context.rs
+++ b/packages/aead/src/context.rs
@@ -14,15 +14,19 @@
 //! # Where AAD lives in the revised API
 //!
 //! Encryption threads AAD through [`Encrypt::encrypt_with_aad`](crate::Encrypt::encrypt_with_aad),
-//! so `ContextTag` participates by implementing [`Encrypt`]. Decryption is different: the revised
-//! [`Decrypt`]/[`Decipher`] traits do **not** thread AAD through the type being decrypted — the
-//! concrete cipher injects the AAD when it constructs the decipher (e.g.
-//! `cipher.decrypt_with_aad::<T, _>(ciphertext, aad)`). There is therefore nothing for a
-//! `ContextTag` *type* to enforce on the decrypt path; the recovered value is simply `T`.
+//! so `ContextTag` participates by implementing [`Encrypt`]. Decryption is symmetric: the
+//! [`Decrypt`]/[`Decipher`] traits thread AAD through the type being decrypted via
+//! [`Decrypt::decrypt_with_aad`](crate::Decrypt::decrypt_with_aad), so `ContextTag` mirrors its
+//! `Encrypt` impl with [`ContextTag::decrypt`] / [`ContextTag::decrypt_with_aad`].
 //!
-//! To keep the two sides symmetric without guessing the tuple layout, [`ContextTag::aad`] and
-//! [`ContextTag::aad_with`] build the exact AAD the wrapper bound at encrypt time, ready to hand to
-//! a concrete cipher's decrypt entry point.
+//! Rebuild the decrypt context with [`ContextTag::context`] (and the same
+//! [`refine`](ContextTag::refine) chain used at encrypt time), then drive a [`Decipher`] obtained
+//! from the concrete cipher — e.g. `ContextTag::context(tag).decrypt(cipher.decipher(ciphertext))`.
+//! Because the tag (and any refinement) is reconstructed by the same code path that bound it, it is
+//! never re-typed by hand.
+//!
+//! For lower-level use directly against a cipher's own decrypt entry point, [`ContextTag::aad`] /
+//! [`ContextTag::aad_with`] build the raw AAD tuple the wrapper bound at encrypt time.
 //!
 //! # AAD encoding
 //!
@@ -46,6 +50,23 @@
 //! ```
 
 use crate::{Aad, Cipher, Decipher, Decrypt, Encrypt, IntoAad};
+
+/// Folds a context `tag` and `extra_aad` into the AAD layout bound by `ContextTag`.
+///
+/// This is the **single source** of the encrypt/decrypt AAD layout: both the [`Encrypt`] impl and
+/// [`ContextTag::decrypt_with_aad`] go through it, so the two sides cannot drift out of sync (a
+/// divergence would silently break authentication). The tag is encoded into an owned/`'static`
+/// `Aad` and re-borrowed for the call's `'a` lifetime (`Aad` is covariant in its lifetime, so
+/// `'static: 'a` permits the narrowing); the result is `(extra_aad, tag)`, which [`IntoAad`]
+/// PAE-encodes.
+fn fold_tag_aad<'a, Tag, A>(tag: Tag, extra_aad: A) -> (A, Aad<'a>)
+where
+    Tag: IntoAad<'static>,
+{
+    let tag_aad: Aad<'static> = tag.into_aad();
+    let tag_aad: Aad<'a> = tag_aad;
+    (extra_aad, tag_aad)
+}
 
 /// A wrapper that pairs a plaintext value with a context tag used as additional authenticated
 /// data (AAD).
@@ -139,12 +160,16 @@ impl<Tag, T> ContextTag<Tag, T> {
 }
 
 impl<Tag> ContextTag<Tag, ()> {
-    /// Builds the AAD to supply when **decrypting** a value that was sealed with
+    /// Low-level: builds the raw AAD tuple for **decrypting** a value sealed with
     /// `ContextTag::new(value, tag).encrypt(cipher)` (i.e. with no extra AAD).
     ///
-    /// This is the symmetric counterpart of the binding performed by [`Encrypt`]: it reproduces
-    /// the `(empty, tag)` layout so a concrete cipher's decrypt entry point authenticates against
-    /// exactly the same bytes.
+    /// Prefer [`ContextTag::context`] + [`decrypt`](ContextTag::decrypt) where a
+    /// [`Decipher`] is available — it folds the AAD for you and reconstructs nested
+    /// [`refine`](ContextTag::refine) tags via the same path used at encrypt time. Reach for `aad`
+    /// only to drive a cipher's own decrypt entry point directly.
+    ///
+    /// This reproduces the `(empty, tag)` layout the [`Encrypt`] impl binds, so a concrete cipher's
+    /// decrypt entry point authenticates against exactly the same bytes.
     ///
     /// ```rust
     /// use vitaminc_aead::{ContextTag, IntoAad};
@@ -160,13 +185,16 @@ impl<Tag> ContextTag<Tag, ()> {
         (Aad::empty(), tag)
     }
 
-    /// Builds the AAD to supply when **decrypting** a value that was sealed with
+    /// Low-level: builds the raw AAD tuple for **decrypting** a value sealed with
     /// `ContextTag::new(value, tag).encrypt_with_aad(cipher, extra_aad)`.
     ///
-    /// Reproduces the `(extra_aad, tag)` layout bound at encrypt time. The argument order
-    /// mirrors [`encrypt_with_aad`](crate::Encrypt::encrypt_with_aad): the extra AAD comes
-    /// first, then the tag — so the two call sites line up and read in the same order as the
-    /// bound tuple.
+    /// Prefer [`ContextTag::context`] + [`decrypt_with_aad`](ContextTag::decrypt_with_aad), which
+    /// puts the tag in the receiver so it can't be transposed with `extra_aad`. This builder takes
+    /// **both** as positional, same-typed args (`extra_aad` first, then `tag`) — swapping them
+    /// silently produces the wrong AAD, so reach for it only to drive a cipher's own decrypt entry
+    /// point directly.
+    ///
+    /// Reproduces the `(extra_aad, tag)` layout bound at encrypt time.
     ///
     /// ```rust
     /// use vitaminc_aead::{ContextTag, IntoAad};
@@ -232,11 +260,7 @@ where
         T: Decrypt<'c> + 'c,
         A: IntoAad<'a>,
     {
-        // Encode the tag into an owned/`'static` `Aad`, then re-borrow it for the
-        // call's `'a` lifetime (covariance), exactly as the `Encrypt` impl does.
-        let tag_aad: Aad<'static> = self.tag.into_aad();
-        let tag_aad: Aad<'a> = tag_aad;
-        T::decrypt_with_aad(decipher, (extra_aad, tag_aad))
+        T::decrypt_with_aad(decipher, fold_tag_aad(self.tag, extra_aad))
     }
 }
 
@@ -260,11 +284,7 @@ where
         A: IntoAad<'a>,
     {
         let ContextTag { inner, tag } = self;
-        // Encode the tag into an owned/`'static` `Aad`, then re-borrow it for the call's `'a`
-        // lifetime (`Aad` is covariant in its lifetime, so `'static: 'a` permits the narrowing).
-        let tag_aad: Aad<'static> = tag.into_aad();
-        let tag_aad: Aad<'a> = tag_aad;
-        inner.encrypt_with_aad(cipher, (extra_aad, tag_aad))
+        inner.encrypt_with_aad(cipher, fold_tag_aad(tag, extra_aad))
     }
 }
 
@@ -273,10 +293,11 @@ mod tests {
     use super::*;
     use crate::{
         cipher::{MapCipher, SeqCipher},
-        Unspecified,
+        DecipherVisitor, Unspecified,
     };
     use std::any::Any;
     use std::cell::RefCell;
+    use std::rc::Rc;
     use vitaminc_protected::{Controlled, Protected};
 
     /// A minimal [`Cipher`] that records the AAD bytes it is handed and echoes the plaintext back
@@ -511,5 +532,126 @@ mod tests {
         let (inner, tag) = tagged.into_parts();
         assert_eq!(inner, "secret");
         assert_eq!(tag, "ctx");
+    }
+
+    /// A minimal [`Decipher`] that records the AAD bytes it is handed via `decrypt_bytes` and
+    /// yields nothing. Lets the decrypt-side `ContextTag` helper's folded AAD be pinned
+    /// byte-for-byte against an independent expected layout (and against the encrypt binding).
+    struct CapturingDecipher {
+        captured_aad: Rc<RefCell<Vec<u8>>>,
+    }
+
+    impl<'c> Decipher<'c> for CapturingDecipher {
+        type Ok<T>
+            = Option<T>
+        where
+            T: Send + 'c;
+
+        fn map_ok<T, U, F>(ok: Self::Ok<T>, f: F) -> Self::Ok<U>
+        where
+            T: Send + 'c,
+            U: Send + 'c,
+            F: FnOnce(T) -> U,
+        {
+            ok.map(f)
+        }
+
+        fn decrypt_bytes<'a, V, A>(self, _visitor: V, aad: A) -> Self::Ok<V::Value>
+        where
+            V: DecipherVisitor<'c> + Send + 'c,
+            A: IntoAad<'a>,
+        {
+            *self.captured_aad.borrow_mut() = aad.into_aad().as_bytes().to_vec();
+            None
+        }
+
+        fn decrypt_seq<'a, V, A>(self, _visitor: V, _aad: A) -> Self::Ok<V::Value>
+        where
+            V: DecipherVisitor<'c> + Send + 'c,
+            A: IntoAad<'a>,
+        {
+            None
+        }
+
+        fn decrypt_map<'a, V, A>(self, _visitor: V, _aad: A) -> Self::Ok<V::Value>
+        where
+            V: DecipherVisitor<'c> + Send + 'c,
+            A: IntoAad<'a>,
+        {
+            None
+        }
+
+        fn decrypt_passthrough<T>(self) -> Self::Ok<T>
+        where
+            T: Any + Send + 'static,
+        {
+            None
+        }
+
+        fn decrypt_option<'a, T, A>(self, _aad: A) -> Self::Ok<Option<T>>
+        where
+            T: Decrypt<'c> + 'c,
+            A: IntoAad<'a>,
+        {
+            None
+        }
+    }
+
+    fn captured_helper_aad<F>(build: F) -> Vec<u8>
+    where
+        F: FnOnce(CapturingDecipher) -> Option<String>,
+    {
+        let captured = Rc::new(RefCell::new(Vec::new()));
+        let _ = build(CapturingDecipher {
+            captured_aad: Rc::clone(&captured),
+        });
+        let bytes = captured.borrow().clone();
+        bytes
+    }
+
+    // The decrypt helper must fold byte-identical AAD to what the `Encrypt` impl binds. These pin
+    // the helper against an *independent* expected layout (not the shared `fold_tag_aad`), so a
+    // reorder of the fold would be caught even though both sides share it.
+
+    #[test]
+    fn decrypt_helper_folds_empty_extra_plus_tag() {
+        let captured =
+            captured_helper_aad(|d| ContextTag::context("user:42").decrypt::<String, _>(d));
+        assert_eq!(captured, ((), "user:42").into_aad().as_bytes());
+    }
+
+    #[test]
+    fn decrypt_helper_folds_extra_then_tag() {
+        let captured = captured_helper_aad(|d| {
+            ContextTag::context("table:users").decrypt_with_aad::<String, _, _>(d, "row:99")
+        });
+        assert_eq!(captured, ("row:99", "table:users").into_aad().as_bytes());
+    }
+
+    #[test]
+    fn decrypt_helper_refine_folds_nested_tag() {
+        let captured = captured_helper_aad(|d| {
+            ContextTag::context("table:users")
+                .refine("column:email")
+                .decrypt::<String, _>(d)
+        });
+        assert_eq!(
+            captured,
+            ((), ("table:users", "column:email")).into_aad().as_bytes()
+        );
+    }
+
+    #[test]
+    fn decrypt_helper_matches_encrypt_binding() {
+        // Cross-check: the helper's fold equals what the `Encrypt` impl actually binds.
+        let cipher = MockCipher::new();
+        ContextTag::new("secret", "table:users")
+            .encrypt_with_aad(&cipher, "row:99")
+            .expect("encryption should succeed");
+
+        let captured = captured_helper_aad(|d| {
+            ContextTag::context("table:users").decrypt_with_aad::<String, _, _>(d, "row:99")
+        });
+        assert_eq!(captured, cipher.captured_aad());
     }
 }

--- a/packages/aead/src/context.rs
+++ b/packages/aead/src/context.rs
@@ -474,6 +474,21 @@ mod tests {
     }
 
     #[test]
+    fn unit_tag_still_binds_nonempty_aad() {
+        let cipher = MockCipher::new();
+
+        ContextTag::new("secret", ())
+            .encrypt(&cipher)
+            .expect("encryption should succeed");
+
+        // Pins the documented boundary: a `()` tag binds PAE(empty, empty), which
+        // is *not* empty AAD — so `cipher.decrypt(ct)` (empty AAD) must fail. A
+        // regression that folded a `()` tag to empty AAD would silently break it.
+        assert_eq!(cipher.captured_aad(), ((), ()).into_aad().as_bytes());
+        assert_ne!(cipher.captured_aad(), Aad::empty().as_bytes());
+    }
+
+    #[test]
     fn refine_nests_the_tag() {
         let cipher = MockCipher::new();
 
@@ -504,6 +519,29 @@ mod tests {
     }
 
     #[test]
+    fn nested_context_tag_folds_aad_twice() {
+        let cipher = MockCipher::new();
+
+        // The documented footgun: wrapping a `ContextTag` *inside another* rather
+        // than layering with `refine`.
+        ContextTag::new(ContextTag::new("secret", "b"), "a")
+            .encrypt(&cipher)
+            .expect("encryption should succeed");
+
+        // Nesting folds the AAD twice into ((extra, "a"), "b") — extra = () here...
+        assert_eq!(
+            cipher.captured_aad(),
+            (((), "a"), "b").into_aad().as_bytes()
+        );
+        // ...which is distinct from the symmetric refine layout ((), ("a", "b"))
+        // that `context("a").refine("b")` decrypts against — hence the footgun.
+        assert_ne!(
+            cipher.captured_aad(),
+            ((), ("a", "b")).into_aad().as_bytes()
+        );
+    }
+
+    #[test]
     fn owned_string_tag_is_accepted() {
         let cipher = MockCipher::new();
 
@@ -512,6 +550,19 @@ mod tests {
             .expect("encryption should succeed");
 
         let expected = ((), "owned-tag").into_aad();
+        assert_eq!(cipher.captured_aad(), expected.as_bytes());
+    }
+
+    #[test]
+    fn vec_u8_tag_is_accepted() {
+        let cipher = MockCipher::new();
+
+        // `Vec<u8>` is a documented tag type; exercise it like the &str/String cases.
+        ContextTag::new("secret", vec![0xde_u8, 0xad, 0xbe, 0xef])
+            .encrypt(&cipher)
+            .expect("encryption should succeed");
+
+        let expected = ((), vec![0xde_u8, 0xad, 0xbe, 0xef]).into_aad();
         assert_eq!(cipher.captured_aad(), expected.as_bytes());
     }
 

--- a/packages/aead/src/context.rs
+++ b/packages/aead/src/context.rs
@@ -53,12 +53,17 @@ use crate::{Aad, Cipher, Decipher, Decrypt, Encrypt, IntoAad};
 
 /// Folds a context `tag` and `extra_aad` into the AAD layout bound by `ContextTag`.
 ///
-/// This is the **single source** of the encrypt/decrypt AAD layout: both the [`Encrypt`] impl and
-/// [`ContextTag::decrypt_with_aad`] go through it, so the two sides cannot drift out of sync (a
-/// divergence would silently break authentication). The tag is encoded into an owned/`'static`
-/// `Aad` and re-borrowed for the call's `'a` lifetime (`Aad` is covariant in its lifetime, so
-/// `'static: 'a` permits the narrowing); the result is `(extra_aad, tag)`, which [`IntoAad`]
-/// PAE-encodes.
+/// This is the layout shared by the two *type-driven* paths: both the [`Encrypt`] impl and
+/// [`ContextTag::decrypt_with_aad`] go through it, so those two sides cannot drift out of sync (a
+/// divergence would silently break authentication). The low-level [`ContextTag::aad`] /
+/// [`ContextTag::aad_with`] builders reproduce the same `(extra_aad, tag)` layout *by hand* (they
+/// must return the unencoded tag for a cipher's own decrypt entry point to re-encode), so they are
+/// a parallel construction kept in lockstep only by the `*_helper_matches_encrypt_binding` tests —
+/// if you change the layout here, update those builders too.
+///
+/// The tag is encoded into an owned/`'static` `Aad` and re-borrowed for the call's `'a` lifetime
+/// (`Aad` is covariant in its lifetime, so `'static: 'a` permits the narrowing); the result is
+/// `(extra_aad, tag)`, which [`IntoAad`] PAE-encodes.
 fn fold_tag_aad<'a, Tag, A>(tag: Tag, extra_aad: A) -> (A, Aad<'a>)
 where
     Tag: IntoAad<'static>,
@@ -112,6 +117,28 @@ where
 ///
 /// For lower-level control you can instead build the raw AAD with [`ContextTag::aad`] /
 /// [`ContextTag::aad_with`] and pass it to a cipher's own decrypt entry point.
+///
+/// # Limitations
+///
+/// `ContextTag` is designed to wrap the **outermost** value being encrypted. A few corollaries are
+/// worth knowing — none is a soundness issue, but each produces ciphertext that the obvious decrypt
+/// call will reject:
+///
+/// - **Use [`refine`](ContextTag::refine), not nesting, to layer context.** Wrapping a `ContextTag`
+///   *inside another* `ContextTag` (`ContextTag::new(ContextTag::new(v, "b"), "a")`) folds the AAD
+///   twice into `((extra, "a"), "b")`, which the symmetric [`context`](ContextTag::context) +
+///   `refine` decrypt path *cannot* reconstruct (it produces `(extra, ("a", "b"))`). Always layer
+///   hierarchy with `ContextTag::new(v, "a").refine("b")`.
+/// - **`ContextTag` has no [`Decrypt`] impl**, only an [`Encrypt`] impl. It therefore composes on
+///   the encrypt side (you *can* build `Vec<ContextTag<…>>` and encrypt it) but a `ContextTag`
+///   nested inside another structure has no symmetric decrypt path — decrypt only at the top level
+///   via [`context`](ContextTag::context) / [`aad`](ContextTag::aad). Don't bury a `ContextTag`
+///   inside a collection or struct you intend to read back.
+/// - **A unit tag `()` still binds a (non-empty) tag.** `ContextTag::new(v, ())` seals against
+///   `PAE(empty, empty)`, not empty AAD, so `cipher.decrypt(ct)` (empty AAD) will fail. If you want
+///   no context, encrypt the bare value; if you want a context, give a real tag.
+/// - **Tags must be [`IntoAad<'static>`](IntoAad)** (owned or `&'static`), so a short-lived `&str`
+///   must be promoted to `String` / `&'static str` — see the tag-type note above.
 pub struct ContextTag<Tag, T> {
     inner: T,
     tag: Tag,

--- a/packages/aead/src/lib.rs
+++ b/packages/aead/src/lib.rs
@@ -3,6 +3,7 @@
 mod aad;
 mod cipher;
 mod ciphertext;
+mod context;
 mod decipher;
 mod encrypt;
 #[cfg(feature = "hlist")]
@@ -15,6 +16,8 @@ pub use aad::{Aad, IntoAad};
 pub use cipher::{Cipher, MapCipher, SeqCipher, Unspecified};
 #[doc(inline)]
 pub use ciphertext::{CipherTextBuilder, LocalCipherText};
+#[doc(inline)]
+pub use context::ContextTag;
 #[doc(inline)]
 pub use decipher::{Decipher, DecipherVisitor, Decrypt, MapAccess, SeqAccess};
 #[doc(inline)]

--- a/packages/encrypt/tests/context_tag.rs
+++ b/packages/encrypt/tests/context_tag.rs
@@ -1,0 +1,115 @@
+//! End-to-end tests for `ContextTag` against the real AES-256-GCM cipher.
+//!
+//! The `vitaminc-aead` unit tests prove that `ContextTag` binds the right AAD bytes at encrypt
+//! time using a mock cipher. These tests close the loop with a concrete AEAD: a value sealed
+//! through `ContextTag` must decrypt only when the same context is supplied via
+//! `ContextTag::aad` / `ContextTag::aad_with`, and must fail otherwise.
+
+use vitaminc_aead::{ContextTag, Encrypt};
+use vitaminc_encrypt::{Aes256Cipher, Key};
+
+fn cipher() -> Aes256Cipher {
+    Aes256Cipher::new(&Key::from([42u8; 32])).expect("failed to create cipher")
+}
+
+#[test]
+fn roundtrip_with_context_tag() {
+    let cipher = cipher();
+
+    let ciphertext = ContextTag::new("secret message", "user:42")
+        .encrypt(&cipher)
+        .expect("encryption failed");
+
+    let plaintext: String = cipher
+        .decrypt_with_aad(ciphertext, ContextTag::aad("user:42"))
+        .expect("decryption failed");
+
+    assert_eq!(plaintext, "secret message");
+}
+
+#[test]
+fn roundtrip_with_context_tag_and_extra_aad() {
+    let cipher = cipher();
+
+    let ciphertext = ContextTag::new("secret", "table:users")
+        .encrypt_with_aad(&cipher, "row:99")
+        .expect("encryption failed");
+
+    let plaintext: String = cipher
+        .decrypt_with_aad(ciphertext, ContextTag::aad_with("table:users", "row:99"))
+        .expect("decryption failed");
+
+    assert_eq!(plaintext, "secret");
+}
+
+#[test]
+fn decrypt_fails_with_wrong_context() {
+    let cipher = cipher();
+
+    let ciphertext = ContextTag::new("secret", "user:42")
+        .encrypt(&cipher)
+        .expect("encryption failed");
+
+    let result: Result<String, _> = cipher.decrypt_with_aad(ciphertext, ContextTag::aad("user:99"));
+    assert!(result.is_err(), "wrong context must not decrypt");
+}
+
+#[test]
+fn decrypt_fails_when_context_omitted() {
+    let cipher = cipher();
+
+    let ciphertext = ContextTag::new("secret", "user:42")
+        .encrypt(&cipher)
+        .expect("encryption failed");
+
+    // Decrypting with no AAD at all must fail — the tag was authenticated.
+    let result: Result<String, _> = cipher.decrypt(ciphertext);
+    assert!(result.is_err(), "omitting the context must not decrypt");
+}
+
+#[test]
+fn roundtrip_with_refined_context() {
+    let cipher = cipher();
+
+    let ciphertext = ContextTag::new("secret", "table:users")
+        .refine("column:email")
+        .encrypt(&cipher)
+        .expect("encryption failed");
+
+    // The refined tag is the nested tuple ("table:users", "column:email").
+    let plaintext: String = cipher
+        .decrypt_with_aad(ciphertext, ContextTag::aad(("table:users", "column:email")))
+        .expect("decryption failed");
+
+    assert_eq!(plaintext, "secret");
+}
+
+#[test]
+fn refined_context_fails_with_unrefined_aad() {
+    let cipher = cipher();
+
+    let ciphertext = ContextTag::new("secret", "table:users")
+        .refine("column:email")
+        .encrypt(&cipher)
+        .expect("encryption failed");
+
+    // Supplying only the outer tag must not authenticate.
+    let result: Result<String, _> =
+        cipher.decrypt_with_aad(ciphertext, ContextTag::aad("table:users"));
+    assert!(result.is_err());
+}
+
+#[test]
+fn context_tag_binds_owned_and_integer_tags() {
+    let cipher = cipher();
+
+    let ciphertext = ContextTag::new("secret", 7u64)
+        .encrypt_with_aad(&cipher, String::from("session"))
+        .expect("encryption failed");
+
+    let plaintext: String = cipher
+        .decrypt_with_aad(ciphertext, ContextTag::aad_with(7u64, String::from("session")))
+        .expect("decryption failed");
+
+    assert_eq!(plaintext, "secret");
+}

--- a/packages/encrypt/tests/context_tag.rs
+++ b/packages/encrypt/tests/context_tag.rs
@@ -69,6 +69,19 @@ fn decrypt_fails_when_context_omitted() {
 }
 
 #[test]
+fn decrypt_fails_with_wrong_key() {
+    let ciphertext = ContextTag::new("secret", "user:42")
+        .encrypt(&cipher())
+        .expect("encryption failed");
+
+    // Same (correct) context, different key: GCM authentication must still reject
+    // it. Completes the tamper matrix with the key axis alongside the AAD axes.
+    let other = Aes256Cipher::new(&Key::from([7u8; 32])).expect("failed to create cipher");
+    let result: Result<String, _> = other.decrypt_with_aad(ciphertext, ContextTag::aad("user:42"));
+    assert!(result.is_err(), "wrong key must not decrypt");
+}
+
+#[test]
 fn roundtrip_with_refined_context() {
     let cipher = cipher();
 
@@ -98,6 +111,23 @@ fn refined_context_fails_with_unrefined_aad() {
     let result: Result<String, _> =
         cipher.decrypt_with_aad(ciphertext, ContextTag::aad("table:users"));
     assert!(result.is_err());
+}
+
+#[test]
+fn refined_context_fails_with_wrong_inner_aad() {
+    let cipher = cipher();
+
+    let ciphertext = ContextTag::new("secret", "table:users")
+        .refine("column:email")
+        .encrypt(&cipher)
+        .expect("encryption failed");
+
+    // Correct outer tag and correct tuple *shape*, but a wrong inner value —
+    // distinct from `refined_context_fails_with_unrefined_aad`, which omits the
+    // inner entirely. Guards against the refined tag authenticating on shape alone.
+    let result: Result<String, _> =
+        cipher.decrypt_with_aad(ciphertext, ContextTag::aad(("table:users", "column:WRONG")));
+    assert!(result.is_err(), "wrong inner refine value must not decrypt");
 }
 
 #[test]

--- a/packages/encrypt/tests/context_tag.rs
+++ b/packages/encrypt/tests/context_tag.rs
@@ -36,7 +36,7 @@ fn roundtrip_with_context_tag_and_extra_aad() {
         .expect("encryption failed");
 
     let plaintext: String = cipher
-        .decrypt_with_aad(ciphertext, ContextTag::aad_with("table:users", "row:99"))
+        .decrypt_with_aad(ciphertext, ContextTag::aad_with("row:99", "table:users"))
         .expect("decryption failed");
 
     assert_eq!(plaintext, "secret");
@@ -110,7 +110,7 @@ fn context_tag_binds_owned_and_integer_tags() {
     let plaintext: String = cipher
         .decrypt_with_aad(
             ciphertext,
-            ContextTag::aad_with(7u64, String::from("session")),
+            ContextTag::aad_with(String::from("session"), 7u64),
         )
         .expect("decryption failed");
 

--- a/packages/encrypt/tests/context_tag.rs
+++ b/packages/encrypt/tests/context_tag.rs
@@ -182,3 +182,23 @@ fn context_helper_wrong_tag_fails() {
         ContextTag::context("user:99").decrypt(cipher.decipher(ciphertext));
     assert!(result.is_err(), "wrong context must not decrypt");
 }
+
+#[test]
+fn context_helper_roundtrips_composite_value() {
+    let cipher = cipher();
+
+    // A composite inner type (Vec): the (extra, tag) AAD must be distributed to every
+    // element identically on encrypt and decrypt for this to round-trip.
+    let items = vec![String::from("a"), String::from("b"), String::from("c")];
+    let ciphertext = ContextTag::new(items.clone(), "table:users")
+        .refine("column:tags")
+        .encrypt_with_aad(&cipher, "row:99")
+        .expect("encryption failed");
+
+    let plaintext: Vec<String> = ContextTag::context("table:users")
+        .refine("column:tags")
+        .decrypt_with_aad(cipher.decipher(ciphertext), "row:99")
+        .expect("decryption failed");
+
+    assert_eq!(plaintext, items);
+}

--- a/packages/encrypt/tests/context_tag.rs
+++ b/packages/encrypt/tests/context_tag.rs
@@ -2,8 +2,9 @@
 //!
 //! The `vitaminc-aead` unit tests prove that `ContextTag` binds the right AAD bytes at encrypt
 //! time using a mock cipher. These tests close the loop with a concrete AEAD: a value sealed
-//! through `ContextTag` must decrypt only when the same context is supplied via
-//! `ContextTag::aad` / `ContextTag::aad_with`, and must fail otherwise.
+//! through `ContextTag` must decrypt only when the same context is supplied — via the
+//! `ContextTag::context(..).decrypt[_with_aad]` helper or the lower-level
+//! `ContextTag::aad` / `ContextTag::aad_with` builders — and must fail otherwise.
 
 use vitaminc_aead::{ContextTag, Encrypt};
 use vitaminc_encrypt::{Aes256Cipher, Key};
@@ -115,4 +116,69 @@ fn context_tag_binds_owned_and_integer_tags() {
         .expect("decryption failed");
 
     assert_eq!(plaintext, "secret");
+}
+
+// --- The `ContextTag::context(..).decrypt[_with_aad]` helper (symmetric with the
+// --- encrypt side, driving a `Decipher` from `cipher.decipher(ciphertext)`). ---
+
+#[test]
+fn context_helper_roundtrip() {
+    let cipher = cipher();
+
+    let ciphertext = ContextTag::new("secret message", "user:42")
+        .encrypt(&cipher)
+        .expect("encryption failed");
+
+    let plaintext: String = ContextTag::context("user:42")
+        .decrypt(cipher.decipher(ciphertext))
+        .expect("decryption failed");
+
+    assert_eq!(plaintext, "secret message");
+}
+
+#[test]
+fn context_helper_roundtrip_with_extra_aad() {
+    let cipher = cipher();
+
+    let ciphertext = ContextTag::new("secret", "table:users")
+        .encrypt_with_aad(&cipher, "row:99")
+        .expect("encryption failed");
+
+    let plaintext: String = ContextTag::context("table:users")
+        .decrypt_with_aad(cipher.decipher(ciphertext), "row:99")
+        .expect("decryption failed");
+
+    assert_eq!(plaintext, "secret");
+}
+
+#[test]
+fn context_helper_refine_rebuilds_nested_tag() {
+    let cipher = cipher();
+
+    let ciphertext = ContextTag::new("secret", "table:users")
+        .refine("column:email")
+        .encrypt(&cipher)
+        .expect("encryption failed");
+
+    // The decrypt context is built with the SAME refine chain — no hand-written
+    // nested tuple to get wrong.
+    let plaintext: String = ContextTag::context("table:users")
+        .refine("column:email")
+        .decrypt(cipher.decipher(ciphertext))
+        .expect("decryption failed");
+
+    assert_eq!(plaintext, "secret");
+}
+
+#[test]
+fn context_helper_wrong_tag_fails() {
+    let cipher = cipher();
+
+    let ciphertext = ContextTag::new("secret", "user:42")
+        .encrypt(&cipher)
+        .expect("encryption failed");
+
+    let result: Result<String, _> =
+        ContextTag::context("user:99").decrypt(cipher.decipher(ciphertext));
+    assert!(result.is_err(), "wrong context must not decrypt");
 }

--- a/packages/encrypt/tests/context_tag.rs
+++ b/packages/encrypt/tests/context_tag.rs
@@ -202,3 +202,92 @@ fn context_helper_roundtrips_composite_value() {
 
     assert_eq!(plaintext, items);
 }
+
+// --- Negative / coverage tests: the extra AAD, the chained-refine nesting, the
+// --- `aad_with` arg order, composite values, and non-string tags must each be
+// --- authenticated — a wrong/partial context must fail to decrypt. ---
+
+#[test]
+fn decrypt_fails_with_wrong_extra_aad() {
+    let cipher = cipher();
+
+    let ciphertext = ContextTag::new("secret", "table:users")
+        .encrypt_with_aad(&cipher, "row:99")
+        .expect("encryption failed");
+
+    // Correct tag but wrong *extra* AAD: the extra is authenticated too, so this
+    // must fail. Guards against the fold ever dropping `extra_aad`.
+    let result: Result<String, _> =
+        ContextTag::context("table:users").decrypt_with_aad(cipher.decipher(ciphertext), "row:00");
+    assert!(result.is_err(), "wrong extra AAD must not decrypt");
+}
+
+#[test]
+fn context_helper_double_refine_roundtrips() {
+    let cipher = cipher();
+
+    // Two refines => left-nested tag (("a", "b"), "c"). Pins that the e2e decrypt
+    // path reconstructs the same nesting (the unit tests only assert the bytes).
+    let ciphertext = ContextTag::new("secret", "a")
+        .refine("b")
+        .refine("c")
+        .encrypt(&cipher)
+        .expect("encryption failed");
+
+    let plaintext: String = ContextTag::context("a")
+        .refine("b")
+        .refine("c")
+        .decrypt(cipher.decipher(ciphertext))
+        .expect("decryption failed");
+
+    assert_eq!(plaintext, "secret");
+}
+
+#[test]
+fn aad_with_swapped_args_fails_to_decrypt() {
+    let cipher = cipher();
+
+    // Sealed as (extra="row:99", tag="table:users").
+    let ciphertext = ContextTag::new("secret", "table:users")
+        .encrypt_with_aad(&cipher, "row:99")
+        .expect("encryption failed");
+
+    // `aad_with(extra, tag)` — swapping the two same-typed args silently builds the
+    // wrong AAD. This pins that the documented footgun actually fails to decrypt
+    // (i.e. the order genuinely matters at the byte level).
+    let result: Result<String, _> =
+        cipher.decrypt_with_aad(ciphertext, ContextTag::aad_with("table:users", "row:99"));
+    assert!(result.is_err(), "swapped aad_with args must not decrypt");
+}
+
+#[test]
+fn composite_value_fails_with_wrong_context() {
+    let cipher = cipher();
+
+    // Multi-element value: every element is bound to the context. A wrong tag must
+    // fail — guards against per-element AAD threading silently dropping on any element.
+    let items = vec![String::from("a"), String::from("b"), String::from("c")];
+    let ciphertext = ContextTag::new(items, "table:users")
+        .encrypt_with_aad(&cipher, "row:99")
+        .expect("encryption failed");
+
+    let result: Result<Vec<String>, _> =
+        ContextTag::context("table:WRONG").decrypt_with_aad(cipher.decipher(ciphertext), "row:99");
+    assert!(
+        result.is_err(),
+        "wrong context must not decrypt a composite value"
+    );
+}
+
+#[test]
+fn integer_tag_fails_with_wrong_context() {
+    let cipher = cipher();
+
+    // Wrong-context coverage for a non-string (`u64`) tag.
+    let ciphertext = ContextTag::new("secret", 7u64)
+        .encrypt(&cipher)
+        .expect("encryption failed");
+
+    let result: Result<String, _> = ContextTag::context(8u64).decrypt(cipher.decipher(ciphertext));
+    assert!(result.is_err(), "wrong integer context must not decrypt");
+}

--- a/packages/encrypt/tests/context_tag.rs
+++ b/packages/encrypt/tests/context_tag.rs
@@ -108,7 +108,10 @@ fn context_tag_binds_owned_and_integer_tags() {
         .expect("encryption failed");
 
     let plaintext: String = cipher
-        .decrypt_with_aad(ciphertext, ContextTag::aad_with(7u64, String::from("session")))
+        .decrypt_with_aad(
+            ciphertext,
+            ContextTag::aad_with(7u64, String::from("session")),
+        )
         .expect("decryption failed");
 
     assert_eq!(plaintext, "secret");


### PR DESCRIPTION
PR #148 redesigned the Cipher/Encrypt/Decipher/Decrypt traits and dropped the
old ContextTag, which referenced the pre-redesign API. Re-introduce it as an
encrypt-side wrapper so the type system, not the call site, guarantees a value's
context tag is always bound as AAD — the one piece of behaviour raw tuple AAD
cannot enforce.

In the revised API, AAD is threaded through Encrypt at seal time but injected
into the Decipher by the concrete cipher at open time, so ContextTag implements
Encrypt and folds (extra_aad, tag) into the AAD, while ContextTag::aad /
aad_with rebuild the matching AAD for the cipher's decrypt entry point. refine
nests tags into a PAE-encoded tuple for hierarchical context.

The Encrypt impl bounds the tag on IntoAad<'static> (owned tags and &'static
str) and re-borrows the encoded Aad for the call lifetime via covariance,
sidestepping the HRTB that an Encrypt-level lifetime used to carry.

Covered by mock-cipher unit tests in vitaminc-aead and an end-to-end AES-256-GCM
roundtrip suite in vitaminc-encrypt (wrong/omitted/refined context all fail).