### PR TITLE
refactor(aead)!: thread AAD through the decrypt path to mirror encrypt

### DIFF
--- a/packages/aead/README.md
+++ b/packages/aead/README.md
@@ -232,9 +232,15 @@ impl Encrypt for User {
 }
 
 impl<'c> Decrypt<'c> for User {
-    fn decrypt<D: Decipher<'c>>(decipher: D) -> D::Ok<Self> {
+    fn decrypt_with_aad<'a, D, A>(decipher: D, aad: A) -> D::Ok<Self>
+    where
+        D: Decipher<'c>,
+        A: IntoAad<'a>,
+    {
         // A visitor describes what to do with each shape the cipher might
-        // produce. Here we only accept maps.
+        // produce. Here we only accept maps. The `aad` mirrors the encrypt
+        // side and is threaded to the decipher so each value is authenticated
+        // against it.
         struct UserVisitor;
         impl<'c> DecipherVisitor<'c> for UserVisitor {
             type Value = User;
@@ -255,7 +261,7 @@ impl<'c> Decrypt<'c> for User {
                 })
             }
         }
-        decipher.decrypt_map(UserVisitor)
+        decipher.decrypt_map(UserVisitor, aad)
     }
 }
 ```

--- a/packages/aead/src/decipher/impls.rs
+++ b/packages/aead/src/decipher/impls.rs
@@ -1,11 +1,15 @@
 use super::{Decipher, DecipherVisitor, Decrypt, MapAccess, SeqAccess};
-use crate::Unspecified;
+use crate::{IntoAad, Unspecified};
 use std::collections::HashMap;
 use vitaminc_protected::{Controlled, Protected};
 use zeroize::Zeroize;
 
 impl<'c> Decrypt<'c> for Vec<u8> {
-    fn decrypt<D: Decipher<'c>>(decipher: D) -> D::Ok<Self> {
+    fn decrypt_with_aad<'a, D, A>(decipher: D, aad: A) -> D::Ok<Self>
+    where
+        D: Decipher<'c>,
+        A: IntoAad<'a>,
+    {
         struct BytesVisitor;
         impl<'c> DecipherVisitor<'c> for BytesVisitor {
             type Value = Vec<u8>;
@@ -16,12 +20,16 @@ impl<'c> Decrypt<'c> for Vec<u8> {
                 Ok(data.risky_unwrap())
             }
         }
-        decipher.decrypt_bytes(BytesVisitor)
+        decipher.decrypt_bytes(BytesVisitor, aad)
     }
 }
 
 impl<'c> Decrypt<'c> for String {
-    fn decrypt<D: Decipher<'c>>(decipher: D) -> D::Ok<Self> {
+    fn decrypt_with_aad<'a, D, A>(decipher: D, aad: A) -> D::Ok<Self>
+    where
+        D: Decipher<'c>,
+        A: IntoAad<'a>,
+    {
         struct StringVisitor;
         impl<'c> DecipherVisitor<'c> for StringVisitor {
             type Value = String;
@@ -29,12 +37,16 @@ impl<'c> Decrypt<'c> for String {
                 String::from_utf8(data.risky_unwrap()).map_err(|_| Unspecified)
             }
         }
-        decipher.decrypt_bytes(StringVisitor)
+        decipher.decrypt_bytes(StringVisitor, aad)
     }
 }
 
 impl<'c, const N: usize> Decrypt<'c> for [u8; N] {
-    fn decrypt<D: Decipher<'c>>(decipher: D) -> D::Ok<Self> {
+    fn decrypt_with_aad<'a, D, A>(decipher: D, aad: A) -> D::Ok<Self>
+    where
+        D: Decipher<'c>,
+        A: IntoAad<'a>,
+    {
         struct ArrayVisitor<const N: usize>;
         impl<'c, const N: usize> DecipherVisitor<'c> for ArrayVisitor<N> {
             type Value = [u8; N];
@@ -42,12 +54,16 @@ impl<'c, const N: usize> Decrypt<'c> for [u8; N] {
                 data.risky_unwrap().try_into().map_err(|_| Unspecified)
             }
         }
-        decipher.decrypt_bytes(ArrayVisitor::<N>)
+        decipher.decrypt_bytes(ArrayVisitor::<N>, aad)
     }
 }
 
 impl<'c> Decrypt<'c> for u32 {
-    fn decrypt<D: Decipher<'c>>(decipher: D) -> D::Ok<Self> {
+    fn decrypt_with_aad<'a, D, A>(decipher: D, aad: A) -> D::Ok<Self>
+    where
+        D: Decipher<'c>,
+        A: IntoAad<'a>,
+    {
         struct U32Visitor;
         impl<'c> DecipherVisitor<'c> for U32Visitor {
             type Value = u32;
@@ -56,7 +72,7 @@ impl<'c> Decrypt<'c> for u32 {
                 Ok(u32::from_le_bytes(bytes))
             }
         }
-        decipher.decrypt_bytes(U32Visitor)
+        decipher.decrypt_bytes(U32Visitor, aad)
     }
 }
 
@@ -64,7 +80,11 @@ impl<'c, T> Decrypt<'c> for Vec<T>
 where
     T: Decrypt<'c> + 'c,
 {
-    fn decrypt<D: Decipher<'c>>(decipher: D) -> D::Ok<Self> {
+    fn decrypt_with_aad<'a, D, A>(decipher: D, aad: A) -> D::Ok<Self>
+    where
+        D: Decipher<'c>,
+        A: IntoAad<'a>,
+    {
         struct VecVisitor<T>(std::marker::PhantomData<T>);
         impl<'c, T> DecipherVisitor<'c> for VecVisitor<T>
         where
@@ -79,7 +99,7 @@ where
                 Ok(items)
             }
         }
-        decipher.decrypt_seq(VecVisitor(std::marker::PhantomData))
+        decipher.decrypt_seq(VecVisitor(std::marker::PhantomData), aad)
     }
 }
 
@@ -87,7 +107,11 @@ impl<'c, T> Decrypt<'c> for HashMap<String, T>
 where
     T: Decrypt<'c> + 'c,
 {
-    fn decrypt<D: Decipher<'c>>(decipher: D) -> D::Ok<Self> {
+    fn decrypt_with_aad<'a, D, A>(decipher: D, aad: A) -> D::Ok<Self>
+    where
+        D: Decipher<'c>,
+        A: IntoAad<'a>,
+    {
         struct HashMapVisitor<T>(std::marker::PhantomData<T>);
         impl<'c, T> DecipherVisitor<'c> for HashMapVisitor<T>
         where
@@ -102,7 +126,7 @@ where
                 Ok(entries)
             }
         }
-        decipher.decrypt_map(HashMapVisitor(std::marker::PhantomData))
+        decipher.decrypt_map(HashMapVisitor(std::marker::PhantomData), aad)
     }
 }
 
@@ -110,8 +134,15 @@ impl<'c, T> Decrypt<'c> for Protected<T>
 where
     T: Decrypt<'c> + Zeroize + 'c,
 {
-    fn decrypt<D: Decipher<'c>>(decipher: D) -> D::Ok<Self> {
-        D::map_ok(T::decrypt(decipher), Protected::init_from_inner)
+    fn decrypt_with_aad<'a, D, A>(decipher: D, aad: A) -> D::Ok<Self>
+    where
+        D: Decipher<'c>,
+        A: IntoAad<'a>,
+    {
+        D::map_ok(
+            T::decrypt_with_aad(decipher, aad),
+            Protected::init_from_inner,
+        )
     }
 }
 
@@ -119,7 +150,11 @@ impl<'c, T> Decrypt<'c> for Option<T>
 where
     T: Decrypt<'c> + 'c,
 {
-    fn decrypt<D: Decipher<'c>>(decipher: D) -> D::Ok<Self> {
-        decipher.decrypt_option::<T>()
+    fn decrypt_with_aad<'a, D, A>(decipher: D, aad: A) -> D::Ok<Self>
+    where
+        D: Decipher<'c>,
+        A: IntoAad<'a>,
+    {
+        decipher.decrypt_option::<T, _>(aad)
     }
 }

--- a/packages/aead/src/decipher/mod.rs
+++ b/packages/aead/src/decipher/mod.rs
@@ -4,7 +4,7 @@ use std::any::Any;
 
 use vitaminc_protected::Protected;
 
-use crate::Unspecified;
+use crate::{Aad, IntoAad, Unspecified};
 
 /// A trait for types that can decrypt data, driving a [`DecipherVisitor`] to produce values.
 ///
@@ -47,15 +47,30 @@ pub trait Decipher<'c>: Sized {
         U: Send + 'c,
         F: FnOnce(T) -> U;
 
-    /// Decrypt a single byte-oriented ciphertext, driving the visitor's
-    /// [`visit_bytes_vec`](DecipherVisitor::visit_bytes_vec).
-    fn decrypt_bytes<V: DecipherVisitor<'c> + Send + 'c>(self, visitor: V) -> Self::Ok<V::Value>;
-    /// Decrypt a sequence of ciphertexts, driving the visitor's
-    /// [`visit_seq`](DecipherVisitor::visit_seq).
-    fn decrypt_seq<V: DecipherVisitor<'c> + Send + 'c>(self, visitor: V) -> Self::Ok<V::Value>;
-    /// Decrypt a map of ciphertexts, driving the visitor's
-    /// [`visit_map`](DecipherVisitor::visit_map).
-    fn decrypt_map<V: DecipherVisitor<'c> + Send + 'c>(self, visitor: V) -> Self::Ok<V::Value>;
+    /// Decrypt a single byte-oriented ciphertext authenticated against `aad`,
+    /// driving the visitor's [`visit_bytes_vec`](DecipherVisitor::visit_bytes_vec).
+    ///
+    /// `aad` mirrors [`Cipher::encrypt_bytes_vec`](crate::Cipher::encrypt_bytes_vec): it must
+    /// match the associated data bound at encrypt time or decryption fails.
+    fn decrypt_bytes<'a, V, A>(self, visitor: V, aad: A) -> Self::Ok<V::Value>
+    where
+        V: DecipherVisitor<'c> + Send + 'c,
+        A: IntoAad<'a>;
+    /// Decrypt a sequence of ciphertexts authenticated against `aad`, driving the
+    /// visitor's [`visit_seq`](DecipherVisitor::visit_seq). `aad` is applied to every
+    /// element, mirroring how [`SeqCipher::encrypt_next`](crate::SeqCipher::encrypt_next)
+    /// binds it per element.
+    fn decrypt_seq<'a, V, A>(self, visitor: V, aad: A) -> Self::Ok<V::Value>
+    where
+        V: DecipherVisitor<'c> + Send + 'c,
+        A: IntoAad<'a>;
+    /// Decrypt a map of ciphertexts authenticated against `aad`, driving the visitor's
+    /// [`visit_map`](DecipherVisitor::visit_map). `aad` is applied to every value,
+    /// mirroring [`MapCipher::encrypt_value`](crate::MapCipher::encrypt_value).
+    fn decrypt_map<'a, V, A>(self, visitor: V, aad: A) -> Self::Ok<V::Value>
+    where
+        V: DecipherVisitor<'c> + Send + 'c,
+        A: IntoAad<'a>;
 
     /// Recover a value stored via [`Cipher::passthrough`](crate::Cipher::passthrough).
     /// Returns an error if the ciphertext is not a passthrough or the stored
@@ -67,12 +82,13 @@ pub trait Decipher<'c>: Sized {
     where
         T: Any + Send + 'static;
 
-    /// Decrypt an `Option<T>`. The decipher inspects the ciphertext shape:
-    /// a `None`-marker variant produces `Ok(None)` (after AAD verification);
-    /// any other shape is decrypted as `T` and wrapped in `Some`.
-    fn decrypt_option<T>(self) -> Self::Ok<Option<T>>
+    /// Decrypt an `Option<T>`, authenticating against `aad`. The decipher inspects the
+    /// ciphertext shape: a `None`-marker variant produces `Ok(None)` (after AAD
+    /// verification); any other shape is decrypted as `T` and wrapped in `Some`.
+    fn decrypt_option<'a, T, A>(self, aad: A) -> Self::Ok<Option<T>>
     where
-        T: Decrypt<'c> + 'c;
+        T: Decrypt<'c> + 'c,
+        A: IntoAad<'a>;
 }
 
 /// A visitor over the structural shape of a ciphertext, analogous to serde's
@@ -130,7 +146,21 @@ pub trait MapAccess<'c> {
 /// The counterpart to `Encrypt` — a type that knows how to decrypt itself using a `Decipher`.
 /// Analogous to serde's `Deserialize`.
 pub trait Decrypt<'c>: Sized + Send {
-    /// Decrypt `Self` from the given decipher, returning the decipher's
-    /// `Ok` container.
-    fn decrypt<D: Decipher<'c>>(decipher: D) -> D::Ok<Self>;
+    /// Decrypt `Self` from the given decipher with no associated data.
+    ///
+    /// Convenience wrapper around [`decrypt_with_aad`](Decrypt::decrypt_with_aad), mirroring
+    /// [`Encrypt::encrypt`](crate::Encrypt::encrypt).
+    fn decrypt<D: Decipher<'c>>(decipher: D) -> D::Ok<Self> {
+        Self::decrypt_with_aad(decipher, Aad::empty())
+    }
+
+    /// Decrypt `Self` from the given decipher, authenticating against `aad`.
+    ///
+    /// This is the method implementations provide; it mirrors
+    /// [`Encrypt::encrypt_with_aad`](crate::Encrypt::encrypt_with_aad). The `aad` must match
+    /// the associated data bound at encrypt time or decryption fails.
+    fn decrypt_with_aad<'a, D, A>(decipher: D, aad: A) -> D::Ok<Self>
+    where
+        D: Decipher<'c>,
+        A: IntoAad<'a>;
 }

--- a/packages/aead/src/decipher/mod.rs
+++ b/packages/aead/src/decipher/mod.rs
@@ -34,11 +34,16 @@ pub trait Decipher<'c>: Sized {
     /// Transform the inner value of an [`Ok`](Decipher::Ok) container.
     ///
     /// This enables `Decrypt` implementations for wrapper types (e.g., `Box<T>`, `Protected<T>`)
-    /// to decrypt the inner type and then wrap the result:
+    /// to decrypt the inner type and then wrap the result. Note the AAD is threaded into the
+    /// inner [`decrypt_with_aad`](Decrypt::decrypt_with_aad) — a wrapper must not drop it:
     ///
     /// ```ignore
-    /// fn decrypt<D: Decipher<'c>>(decipher: D) -> D::Ok<Self> {
-    ///     D::map_ok(T::decrypt(decipher), Wrapper::new)
+    /// fn decrypt_with_aad<'a, D, A>(decipher: D, aad: A) -> D::Ok<Self>
+    /// where
+    ///     D: Decipher<'c>,
+    ///     A: IntoAad<'a>,
+    /// {
+    ///     D::map_ok(T::decrypt_with_aad(decipher, aad), Wrapper::new)
     /// }
     /// ```
     fn map_ok<T, U, F>(ok: Self::Ok<T>, f: F) -> Self::Ok<U>
@@ -132,6 +137,13 @@ pub trait SeqAccess<'c> {
     /// The error type returned by [`next_element`](SeqAccess::next_element).
     type Error;
     /// Returns the next decrypted element, or `None` when the sequence is exhausted.
+    ///
+    /// Implementations **must authenticate each element against the sequence's associated
+    /// data** — thread the AAD supplied to [`Decipher::decrypt_seq`] into the element's
+    /// [`Decrypt::decrypt_with_aad`]. This mirrors how
+    /// [`SeqCipher::encrypt_next`](crate::SeqCipher::encrypt_next) binds the AAD to each
+    /// element at encrypt time; an implementation that decrypts elements with empty AAD
+    /// produces a silently unauthenticated sequence.
     fn next_element<T: Decrypt<'c> + 'c>(&mut self) -> Result<Option<T>, Self::Error>;
 }
 
@@ -140,6 +152,11 @@ pub trait MapAccess<'c> {
     /// The error type returned by [`next_entry`](MapAccess::next_entry).
     type Error;
     /// Returns the next decrypted `(key, value)` entry, or `None` when the map is exhausted.
+    ///
+    /// As with [`SeqAccess::next_element`], implementations **must authenticate each value
+    /// against the map's associated data** — thread the AAD supplied to
+    /// [`Decipher::decrypt_map`] into the value's [`Decrypt::decrypt_with_aad`], mirroring
+    /// [`MapCipher::encrypt_value`](crate::MapCipher::encrypt_value).
     fn next_entry<T: Decrypt<'c> + 'c>(&mut self) -> Result<Option<(String, T)>, Self::Error>;
 }
 

--- a/packages/encrypt/src/cipher.rs
+++ b/packages/encrypt/src/cipher.rs
@@ -579,6 +579,27 @@ mod test {
     }
 
     #[quickcheck]
+    fn roundtrip_vec_with_aad(key: Key, plaintext: Vec<String>) -> bool {
+        // Positive counterpart to `decrypt_seq_fails_with_wrong_aad`: every element
+        // must authenticate when the *correct* AAD is re-supplied per element by
+        // `AesSeqAccess::next_element`. Exercises the borrowed-AAD seq path across
+        // arbitrary element counts (the empty vec has no element tags and trivially
+        // roundtrips). A wrong-AAD-fails test alone can't catch a regression where
+        // the per-element AAD is dropped or mis-borrowed so even the correct AAD
+        // fails — only this positive multi-element roundtrip does.
+        let aad = "seq-aad";
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+        let ciphertext = plaintext
+            .clone()
+            .encrypt_with_aad(&cipher, aad)
+            .expect("Encryption failed");
+        let decrypted: Vec<String> = cipher
+            .decrypt_with_aad(ciphertext, aad)
+            .expect("Decryption failed");
+        decrypted == plaintext
+    }
+
+    #[quickcheck]
     fn decrypt_fails_with_wrong_key(keys: DifferingKeyPair, plaintext: String) -> bool {
         // `DifferingKeyPair` guarantees the two keys are distinct, so this test
         // is deterministic — a key collision cannot make it spuriously fail.

--- a/packages/encrypt/src/cipher.rs
+++ b/packages/encrypt/src/cipher.rs
@@ -261,17 +261,30 @@ impl Aes256Cipher {
         // AAD is threaded through the `Decrypt`/`Decipher` call chain (mirroring how
         // `Encrypt::encrypt_with_aad` threads it on the encrypt side), not baked into the
         // decipher up front.
-        T::decrypt_with_aad(
-            AesDecipher {
-                cipher: self,
-                ciphertext,
-            },
-            aad,
-        )
+        T::decrypt_with_aad(self.decipher(ciphertext), aad)
+    }
+
+    /// Construct a [`Decipher`] over `ciphertext` bound to this cipher.
+    ///
+    /// This is the decrypt-side counterpart to passing `&cipher` (a [`Cipher`])
+    /// on the encrypt side: it hands callers a concrete [`Decipher`] they can
+    /// drive directly via [`Decrypt::decrypt_with_aad`], which is what generic
+    /// decrypt-side helpers (e.g. `ContextTag`) build on. The ergonomic
+    /// [`decrypt`](Aes256Cipher::decrypt) /
+    /// [`decrypt_with_aad`](Aes256Cipher::decrypt_with_aad) methods are thin
+    /// wrappers around it.
+    pub fn decipher(&self, ciphertext: AesCipherText) -> AesDecipher<'_> {
+        AesDecipher {
+            cipher: self,
+            ciphertext,
+        }
     }
 }
 
-struct AesDecipher<'c> {
+/// A [`Decipher`] over a single [`AesCipherText`], produced by
+/// [`Aes256Cipher::decipher`]. Carries the cipher and ciphertext; the AAD is
+/// supplied per call by [`Decrypt::decrypt_with_aad`].
+pub struct AesDecipher<'c> {
     cipher: &'c Aes256Cipher,
     ciphertext: AesCipherText,
 }

--- a/packages/encrypt/src/cipher.rs
+++ b/packages/encrypt/src/cipher.rs
@@ -409,10 +409,7 @@ impl<'c> Decipher<'c> for AesDecipher<'c> {
             // treatment of `Option` and is intentional — every caller fixes a
             // concrete type at the call site. See `nested_option_shape_is_caller_decided`.
             other => {
-                let inner = AesDecipher {
-                    cipher: self.cipher,
-                    ciphertext: other,
-                };
+                let inner = self.cipher.decipher(other);
                 T::decrypt_with_aad(inner, aad).map(Some)
             }
         }
@@ -423,8 +420,9 @@ struct AesSeqAccess<'c, 'a> {
     cipher: &'c Aes256Cipher,
     items: std::vec::IntoIter<AesCipherText>,
     // Held as `Aad` (copy-on-write) rather than an owned `Vec<u8>` so a borrowed
-    // AAD stays borrowed; the per-element `clone` below is then cheap for the
-    // common `&str`/`&[u8]` case.
+    // AAD stays borrowed. `next_element` re-supplies it per element by *borrowing*
+    // these bytes, so there is no per-element allocation in either the borrowed
+    // (`&str`/`&[u8]`) or the owned (`Vec`/PAE) case.
     aad: Aad<'a>,
 }
 
@@ -436,10 +434,7 @@ impl<'c, 'a> SeqAccess<'c> for AesSeqAccess<'c, 'a> {
             Some(ct) => ct,
             None => return Ok(None),
         };
-        let decipher = AesDecipher {
-            cipher: self.cipher,
-            ciphertext: ct,
-        };
+        let decipher = self.cipher.decipher(ct);
         // Each element was sealed with the same AAD; re-supply it per element by
         // *borrowing* the stored bytes — no per-element allocation, even when the
         // AAD is owned. Mirrors `SeqCipher::encrypt_next` binding AAD per element.
@@ -461,10 +456,7 @@ impl<'c, 'a> MapAccess<'c> for AesMapAccess<'c, 'a> {
             Some(entry) => entry,
             None => return Ok(None),
         };
-        let decipher = AesDecipher {
-            cipher: self.cipher,
-            ciphertext: ct,
-        };
+        let decipher = self.cipher.decipher(ct);
         // Borrow the stored AAD bytes per entry — see `AesSeqAccess::next_element`.
         let value = T::decrypt_with_aad(decipher, self.aad.as_bytes())?;
         Ok(Some((key, value)))
@@ -556,6 +548,25 @@ mod test {
             .expect("Encryption failed");
         cipher
             .decrypt_with_aad::<String, _>(ciphertext, "wrong-aad")
+            .is_err()
+    }
+
+    #[quickcheck]
+    fn decrypt_seq_fails_with_wrong_aad(key: Key, plaintext: Vec<String>) -> bool {
+        // The Sequence path re-supplies the same AAD to every element, so a wrong
+        // AAD must fail the per-element authentication rather than silently
+        // decrypting (see `AesSeqAccess::next_element`). An empty sequence has no
+        // element tags to reject — the container shape itself is not
+        // AEAD-authenticated on either side — so skip it.
+        if plaintext.is_empty() {
+            return true;
+        }
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+        let ciphertext = plaintext
+            .encrypt_with_aad(&cipher, "correct-aad")
+            .expect("Encryption failed");
+        cipher
+            .decrypt_with_aad::<Vec<String>, _>(ciphertext, "wrong-aad")
             .is_err()
     }
 
@@ -752,7 +763,7 @@ mod test {
     where
         T: Any + Send + 'static,
     {
-        let decipher = AesDecipher { cipher, ciphertext };
+        let decipher = cipher.decipher(ciphertext);
         decipher.decrypt_passthrough::<T>()
     }
 

--- a/packages/encrypt/src/cipher.rs
+++ b/packages/encrypt/src/cipher.rs
@@ -258,19 +258,22 @@ impl Aes256Cipher {
         T: Decrypt<'c> + 'c,
         A: IntoAad<'a>,
     {
-        let aad = aad.into_aad();
-        T::decrypt(AesDecipher {
-            cipher: self,
-            ciphertext,
-            aad: aad.as_bytes().to_vec(),
-        })
+        // AAD is threaded through the `Decrypt`/`Decipher` call chain (mirroring how
+        // `Encrypt::encrypt_with_aad` threads it on the encrypt side), not baked into the
+        // decipher up front.
+        T::decrypt_with_aad(
+            AesDecipher {
+                cipher: self,
+                ciphertext,
+            },
+            aad,
+        )
     }
 }
 
 struct AesDecipher<'c> {
     cipher: &'c Aes256Cipher,
     ciphertext: AesCipherText,
-    aad: Vec<u8>,
 }
 
 impl AesDecipher<'_> {
@@ -303,23 +306,32 @@ impl<'c> Decipher<'c> for AesDecipher<'c> {
         ok.map(f)
     }
 
-    fn decrypt_bytes<V: DecipherVisitor<'c> + Send + 'c>(self, visitor: V) -> Self::Ok<V::Value> {
+    fn decrypt_bytes<'a, V, A>(self, visitor: V, aad: A) -> Self::Ok<V::Value>
+    where
+        V: DecipherVisitor<'c> + Send + 'c,
+        A: IntoAad<'a>,
+    {
         match self.ciphertext {
             AesCipherText::Single(ct) => {
-                let bytes = Self::decrypt_local_ciphertext(self.cipher, ct, &self.aad)?;
+                let aad = aad.into_aad();
+                let bytes = Self::decrypt_local_ciphertext(self.cipher, ct, aad.as_bytes())?;
                 visitor.visit_bytes_vec(bytes)
             }
             _ => Err(Unspecified),
         }
     }
 
-    fn decrypt_seq<V: DecipherVisitor<'c> + Send + 'c>(self, visitor: V) -> Self::Ok<V::Value> {
+    fn decrypt_seq<'a, V, A>(self, visitor: V, aad: A) -> Self::Ok<V::Value>
+    where
+        V: DecipherVisitor<'c> + Send + 'c,
+        A: IntoAad<'a>,
+    {
         match self.ciphertext {
             AesCipherText::Sequence(items) => {
                 let seq_access = AesSeqAccess {
                     cipher: self.cipher,
                     items: items.into_iter(),
-                    aad: self.aad,
+                    aad: aad.into_aad().as_bytes().to_vec(),
                 };
                 visitor.visit_seq(seq_access)
             }
@@ -327,13 +339,17 @@ impl<'c> Decipher<'c> for AesDecipher<'c> {
         }
     }
 
-    fn decrypt_map<V: DecipherVisitor<'c> + Send + 'c>(self, visitor: V) -> Self::Ok<V::Value> {
+    fn decrypt_map<'a, V, A>(self, visitor: V, aad: A) -> Self::Ok<V::Value>
+    where
+        V: DecipherVisitor<'c> + Send + 'c,
+        A: IntoAad<'a>,
+    {
         match self.ciphertext {
             AesCipherText::Map(entries) => {
                 let map_access = AesMapAccess {
                     cipher: self.cipher,
                     entries: entries.into_iter(),
-                    aad: self.aad,
+                    aad: aad.into_aad().as_bytes().to_vec(),
                 };
                 visitor.visit_map(map_access)
             }
@@ -353,14 +369,16 @@ impl<'c> Decipher<'c> for AesDecipher<'c> {
         }
     }
 
-    fn decrypt_option<T>(self) -> Self::Ok<Option<T>>
+    fn decrypt_option<'a, T, A>(self, aad: A) -> Self::Ok<Option<T>>
     where
         T: Decrypt<'c> + 'c,
+        A: IntoAad<'a>,
     {
         match self.ciphertext {
             AesCipherText::None(ct) => {
                 // Verify the AAD-bound tag over the empty plaintext.
-                Self::decrypt_local_ciphertext(self.cipher, ct, &self.aad)?;
+                let aad = aad.into_aad();
+                Self::decrypt_local_ciphertext(self.cipher, ct, aad.as_bytes())?;
                 Ok(None)
             }
             // Passthrough must never be decoded as an Option payload.
@@ -381,9 +399,8 @@ impl<'c> Decipher<'c> for AesDecipher<'c> {
                 let inner = AesDecipher {
                     cipher: self.cipher,
                     ciphertext: other,
-                    aad: self.aad,
                 };
-                T::decrypt(inner).map(Some)
+                T::decrypt_with_aad(inner, aad).map(Some)
             }
         }
     }
@@ -406,9 +423,10 @@ impl<'c> SeqAccess<'c> for AesSeqAccess<'c> {
         let decipher = AesDecipher {
             cipher: self.cipher,
             ciphertext: ct,
-            aad: self.aad.clone(),
         };
-        T::decrypt(decipher).map(Some)
+        // Each element was sealed with the same AAD; re-supply it per element
+        // (mirrors `SeqCipher::encrypt_next` cloning the AAD into each element).
+        T::decrypt_with_aad(decipher, self.aad.clone()).map(Some)
     }
 }
 
@@ -429,9 +447,8 @@ impl<'c> MapAccess<'c> for AesMapAccess<'c> {
         let decipher = AesDecipher {
             cipher: self.cipher,
             ciphertext: ct,
-            aad: self.aad.clone(),
         };
-        let value = T::decrypt(decipher)?;
+        let value = T::decrypt_with_aad(decipher, self.aad.clone())?;
         Ok(Some((key, value)))
     }
 }
@@ -717,11 +734,7 @@ mod test {
     where
         T: Any + Send + 'static,
     {
-        let decipher = AesDecipher {
-            cipher,
-            ciphertext,
-            aad: Vec::new(),
-        };
+        let decipher = AesDecipher { cipher, ciphertext };
         decipher.decrypt_passthrough::<T>()
     }
 

--- a/packages/encrypt/src/cipher.rs
+++ b/packages/encrypt/src/cipher.rs
@@ -2,7 +2,7 @@ use crate::backend::{CipherKey, NONCE_LEN};
 use crate::Key;
 use std::any::Any;
 use vitaminc_aead::{
-    Cipher, CipherTextBuilder, Decipher, DecipherVisitor, Decrypt, Encrypt, IntoAad,
+    Aad, Cipher, CipherTextBuilder, Decipher, DecipherVisitor, Decrypt, Encrypt, IntoAad,
     LocalCipherText, MapAccess, MapCipher, NonceGenerator, RandomNonceGenerator, SeqAccess,
     SeqCipher, Unspecified,
 };
@@ -331,7 +331,7 @@ impl<'c> Decipher<'c> for AesDecipher<'c> {
                 let seq_access = AesSeqAccess {
                     cipher: self.cipher,
                     items: items.into_iter(),
-                    aad: aad.into_aad().as_bytes().to_vec(),
+                    aad: aad.into_aad(),
                 };
                 visitor.visit_seq(seq_access)
             }
@@ -349,7 +349,7 @@ impl<'c> Decipher<'c> for AesDecipher<'c> {
                 let map_access = AesMapAccess {
                     cipher: self.cipher,
                     entries: entries.into_iter(),
-                    aad: aad.into_aad().as_bytes().to_vec(),
+                    aad: aad.into_aad(),
                 };
                 visitor.visit_map(map_access)
             }
@@ -406,13 +406,16 @@ impl<'c> Decipher<'c> for AesDecipher<'c> {
     }
 }
 
-struct AesSeqAccess<'c> {
+struct AesSeqAccess<'c, 'a> {
     cipher: &'c Aes256Cipher,
     items: std::vec::IntoIter<AesCipherText>,
-    aad: Vec<u8>,
+    // Held as `Aad` (copy-on-write) rather than an owned `Vec<u8>` so a borrowed
+    // AAD stays borrowed; the per-element `clone` below is then cheap for the
+    // common `&str`/`&[u8]` case.
+    aad: Aad<'a>,
 }
 
-impl<'c> SeqAccess<'c> for AesSeqAccess<'c> {
+impl<'c, 'a> SeqAccess<'c> for AesSeqAccess<'c, 'a> {
     type Error = Unspecified;
 
     fn next_element<T: Decrypt<'c> + 'c>(&mut self) -> Result<Option<T>, Self::Error> {
@@ -430,13 +433,13 @@ impl<'c> SeqAccess<'c> for AesSeqAccess<'c> {
     }
 }
 
-struct AesMapAccess<'c> {
+struct AesMapAccess<'c, 'a> {
     cipher: &'c Aes256Cipher,
     entries: std::vec::IntoIter<(String, AesCipherText)>,
-    aad: Vec<u8>,
+    aad: Aad<'a>,
 }
 
-impl<'c> MapAccess<'c> for AesMapAccess<'c> {
+impl<'c, 'a> MapAccess<'c> for AesMapAccess<'c, 'a> {
     type Error = Unspecified;
 
     fn next_entry<T: Decrypt<'c> + 'c>(&mut self) -> Result<Option<(String, T)>, Self::Error> {

--- a/packages/encrypt/src/cipher.rs
+++ b/packages/encrypt/src/cipher.rs
@@ -427,9 +427,10 @@ impl<'c, 'a> SeqAccess<'c> for AesSeqAccess<'c, 'a> {
             cipher: self.cipher,
             ciphertext: ct,
         };
-        // Each element was sealed with the same AAD; re-supply it per element
-        // (mirrors `SeqCipher::encrypt_next` cloning the AAD into each element).
-        T::decrypt_with_aad(decipher, self.aad.clone()).map(Some)
+        // Each element was sealed with the same AAD; re-supply it per element by
+        // *borrowing* the stored bytes — no per-element allocation, even when the
+        // AAD is owned. Mirrors `SeqCipher::encrypt_next` binding AAD per element.
+        T::decrypt_with_aad(decipher, self.aad.as_bytes()).map(Some)
     }
 }
 
@@ -451,7 +452,8 @@ impl<'c, 'a> MapAccess<'c> for AesMapAccess<'c, 'a> {
             cipher: self.cipher,
             ciphertext: ct,
         };
-        let value = T::decrypt_with_aad(decipher, self.aad.clone())?;
+        // Borrow the stored AAD bytes per entry — see `AesSeqAccess::next_element`.
+        let value = T::decrypt_with_aad(decipher, self.aad.as_bytes())?;
         Ok(Some((key, value)))
     }
 }

--- a/packages/encrypt/src/cipher.rs
+++ b/packages/encrypt/src/cipher.rs
@@ -468,7 +468,15 @@ impl<'c, 'a> MapAccess<'c> for AesMapAccess<'c, 'a> {
 // tests already cover both backends on native via the
 // `_test-rust-crypto-backend` feature; the wasm32 codegen path is gated by the
 // KAT in `crate::backend::tests`.
-#[cfg(all(test, not(target_arch = "wasm32")))]
+//
+// Written as two stacked `cfg` attributes rather than `cfg(all(test, …))` so
+// cargo-mutants sees the literal `cfg(test)` and skips this whole test module —
+// it doesn't look for `test` nested inside `all(...)`, and the `#[quickcheck]`
+// fns aren't `#[test]` at the syntax level, so it would otherwise mutate them
+// (e.g. replace a property body with `true`, which trivially "survives").
+// Stacked `cfg` attributes are AND-ed, so this compiles identically.
+#[cfg(test)]
+#[cfg(not(target_arch = "wasm32"))]
 #[allow(clippy::unwrap_used)]
 mod test {
     use super::*;

--- a/packages/encrypt/src/cipher_static.rs
+++ b/packages/encrypt/src/cipher_static.rs
@@ -113,7 +113,10 @@ where
         .read()
 }
 
-#[cfg(all(test, not(target_arch = "wasm32")))]
+// Split cfgs (not `all(test, …)`) so cargo-mutants recognises the test module
+// and skips it — see the comment on `cipher::test`.
+#[cfg(test)]
+#[cfg(not(target_arch = "wasm32"))]
 #[allow(clippy::unwrap_used)]
 mod test {
     use super::*;

--- a/packages/encrypt/src/key.rs
+++ b/packages/encrypt/src/key.rs
@@ -46,7 +46,9 @@ impl Encrypt for Key {
 
 // Quickcheck `Arbitrary` impls for the property tests in `cipher::test` —
 // gated to non-wasm32 alongside their consumers (see comment in `cipher.rs`).
-#[cfg(all(test, not(target_arch = "wasm32")))]
+// Split cfgs (not `all(test, …)`) so cargo-mutants recognises the test module.
+#[cfg(test)]
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) mod tests {
     use super::*;
     use quickcheck::Arbitrary;

--- a/packages/encrypt/src/lib.rs
+++ b/packages/encrypt/src/lib.rs
@@ -6,7 +6,7 @@ mod cipher;
 mod cipher_static;
 mod key;
 
-pub use cipher::{Aes256Cipher, AesCipherText};
+pub use cipher::{Aes256Cipher, AesCipherText, AesDecipher};
 pub use key::Key;
 
 // Re-exports


### PR DESCRIPTION
## What & why

Makes the **decrypt path symmetric with the encrypt path**. Today AAD is baked into the concrete `AesDecipher` at construction, while encryption threads it per-call through `Cipher`/`Encrypt`. That asymmetry meant there was no generic decrypt entry point and blocked a clean `ContextTag::decrypt_with_aad` helper.

AAD is now threaded per-call:

- `Decipher::decrypt_bytes`/`decrypt_seq`/`decrypt_map`/`decrypt_option` take an `aad: A` parameter.
- New **`Decrypt::decrypt_with_aad`** — the dual of `Encrypt::encrypt_with_aad`; `Decrypt::decrypt` now defaults to it with `Aad::empty()`.
- `Aes256Cipher::decrypt_with_aad` delegates to `T::decrypt_with_aad` (the `AesDecipher` no longer carries an `aad` field); `AesSeqAccess`/`AesMapAccess` re-supply their stored AAD per element.

## Deliberately kept

The **visitor pattern** (`DecipherVisitor` / `SeqAccess` / `MapAccess`), the **`Ok<T>` GAT**, and the **infallible `map_ok`** are retained — they are the correct pull-side duals of the encrypt-side builder, not incidental indirection. Per-element AAD rides on the `Decipher` methods so `SeqAccess`/`MapAccess` signatures are untouched.

## Breaking change

Breaking to the `Decipher`/`Decrypt` traits. These are unreleased (v0.2.0-pre), so there are no external consumers. The public `cipher.decrypt(ct)` / `cipher.decrypt_with_aad(ct, aad)` entry points are unchanged.

## Verification

- `cargo test -p vitaminc-aead -p vitaminc-encrypt` — 29 + 52 unit, all doctests, all ~40 roundtrip/negative cipher tests (incl. wrong-AAD, wrong-shape, option-tag-auth) pass.
- `cargo build --workspace`, `cargo test -p vitaminc-aead --all-features` (hlist), `cargo fmt --check` all pass.

## Follow-up

Unblocks a `ContextTag::decrypt_with_aad` helper built on `Decrypt::decrypt_with_aad` (separate PR).