### PR TITLE
ci: gate PRs on cargo-crap (CRAP metric)

### DIFF
--- a/.cargo-crap.toml
+++ b/.cargo-crap.toml
@@ -1,0 +1,39 @@
+# Configuration for `cargo crap` — the CRAP (Change Risk Anti-Patterns) metric.
+#
+# CRAP rewards complex code that is well tested and penalises complex code that
+# is not:
+#
+#     CRAP = CC^2 * (1 - coverage)^3 + CC      (CC = cyclomatic complexity)
+#
+# A simple or fully covered function scores roughly its complexity; a complex,
+# untested one scores into the hundreds. In a crypto library that is exactly the
+# logic we most want covered before it ships, so the metric surfaces it for us.
+#
+# Run it locally via `mise run crap` (generates coverage first, then scores).
+# Config discovery walks up from the working directory, so this single root file
+# applies anywhere in the workspace — and both `mise run crap` and the CI gate
+# (.github/workflows/crap.yml) read their threshold/exclude/allow rules from here.
+
+# CRAP score above which a function is flagged. The CI gate (`cargo crap
+# --fail-above`) fails when any function exceeds it. 30 is the long-standing
+# Crap4J default: a CC-10 function needs ~42% coverage, a CC-15 function ~59%,
+# to fall below it. The whole workspace currently tops out around 20, so this
+# leaves headroom while still catching a complex, under-tested function added
+# in a PR. Lower it over time to ratchet the bar up.
+threshold = 30
+
+# Functions with complexity but no coverage data are scored as 0% covered
+# (worst case) rather than silently skipped — uninstrumented code is risk too.
+missing = "pessimistic"
+
+# Files skipped at walk time, relative to each workspace member's root.
+# Defensive: integration tests aren't walked today, but this keeps them out of
+# the score if that changes.
+exclude = ["tests/**"]
+
+# Functions to analyse but hide from the report, matched against the full path.
+# The proc-macro crates can't be measured by cargo-llvm-cov — macro expansion
+# runs at compile time, not in the instrumented test binary — so they always
+# read as 0% covered and would be permanent false-positives. They are exercised
+# in practice by the crates that use the derives.
+allow = ["**/random-derives/**", "**/protected-derive/**"]

--- a/.github/workflows/crap.yml
+++ b/.github/workflows/crap.yml
@@ -1,0 +1,151 @@
+name: "CRAP"
+
+# Gates PRs on the CRAP (Change Risk Anti-Patterns) metric for the whole
+# workspace, and posts the scores as a sticky PR comment. CRAP = cyclomatic
+# complexity weighted by test coverage, so the gate trips when a PR adds (or
+# leaves) a complex, under-tested function — the kind of logic in a crypto
+# library we most want covered before it ships.
+#
+# The job fails when any function exceeds the threshold in .cargo-crap.toml
+# (currently 30; the workspace tops out around 20 today). To actually block
+# merges, mark this check ("🚦 CRAP gate") as required in the repo's
+# branch-protection settings. To soften it back to report-only, drop the
+# "Enforce CRAP threshold" step — the sticky comment keeps working either way.
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "packages/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".cargo-crap.toml"
+      - ".github/workflows/crap.yml"
+      # Negative patterns must stay last: keep the matches above but ignore
+      # pure-docs changes so a README-only PR doesn't run coverage.
+      - "!**.md"
+
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+# Needed to post/update the report comment on the PR.
+permissions:
+  contents: read
+  pull-requests: write
+
+# Cancel an in-flight report when the PR is pushed again — only the latest
+# matters.
+concurrency:
+  group: crap-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  crap:
+    runs-on: ubuntu-latest
+    name: "🚦 CRAP gate"
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-crap-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: setup rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          # llvm-tools-preview is required by cargo-llvm-cov to produce coverage.
+          components: llvm-tools-preview
+
+      - name: Start LocalStack
+        # Mirrors the test.yml gate: vitaminc-kms' tests call a KMS endpoint on
+        # localhost:4566, so coverage of that crate needs LocalStack running too.
+        uses: LocalStack/setup-localstack@v0.3.2
+        with:
+          image-tag: 'latest'
+          install-awslocal: 'true'
+        env:
+          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
+
+      - name: install cargo-binstall, cargo-llvm-cov and cargo-crap
+        # Install via cargo-binstall (prebuilt binaries — far faster than
+        # `cargo install` from source). cargo-binstall itself is pulled in with
+        # its official install script, the same curl-pipe pattern test.yml uses
+        # for wasm-pack, so we avoid depending on a third-party GitHub Action
+        # that the org actions allowlist may not permit.
+        # GITHUB_TOKEN lifts the anonymous GitHub API rate limit binstall would
+        # otherwise hit when resolving release assets.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl -L --proto '=https' --tlsv1.2 -sSf \
+            https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+          cargo binstall -y cargo-llvm-cov cargo-crap
+
+      - name: Generate coverage and build CRAP report
+        # Coverage uses default features to match the primary `cargo test` gate
+        # (the aws-lc-rs backend). `cargo crap` then renders the sticky-comment
+        # report. Threshold, exclude and allow rules all live in
+        # .cargo-crap.toml, so this step, the gate below, and `mise run crap`
+        # stay in sync. No `--fail-above` here: this run must always write the
+        # comment, even on a PR that the gate below will fail (a `--fail-above`
+        # run writes an empty output file when it trips).
+        run: |
+          cargo llvm-cov --workspace --lcov --output-path target/vitaminc-lcov.info
+          cargo crap \
+            --workspace \
+            --lcov target/vitaminc-lcov.info \
+            --format pr-comment \
+            --repo-url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" \
+            --commit-ref "${{ github.event.pull_request.head.sha || github.sha }}" \
+            --output target/crap-comment.md
+
+      - name: Post CRAP report as a sticky PR comment
+        # Posted before the gate below so the comment always shows what tripped
+        # it. Only PRs have a comment thread; on workflow_dispatch the report is
+        # still generated above and visible in the job logs.
+        # Best-effort: a comment-posting hiccup must not turn the gate red or
+        # stop the authoritative "Enforce CRAP threshold" step from running.
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('target/crap-comment.md', 'utf8');
+            // cargo crap's pr-comment output starts with this marker.
+            const marker = '<!-- cargo-crap-report -->';
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            // Paginate so the marker is found even on PRs with >100 comments,
+            // otherwise we'd post a duplicate sticky comment each run.
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number, per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+
+      - name: Enforce CRAP threshold
+        # The gate. Re-scores from the same LCOV (no recompile) and exits
+        # non-zero if any function exceeds the threshold in .cargo-crap.toml,
+        # listing the offenders in the log. Runs last so the sticky comment is
+        # already posted when it fails. Make this check required in branch
+        # protection to actually block merges on a regression.
+        run: |
+          cargo crap \
+            --workspace \
+            --lcov target/vitaminc-lcov.info \
+            --fail-above

--- a/mise.toml
+++ b/mise.toml
@@ -1,9 +1,27 @@
 [tools]
 rust = "stable"
+# Coverage → CRAP (Change Risk Anti-Patterns) tooling. `cargo llvm-cov` produces
+# the LCOV file that `cargo crap` scores; see the `crap` task below. Both ship
+# prebuilt binaries, so `mise install` binstalls them quickly.
+"cargo:cargo-llvm-cov" = "latest"
+"cargo:cargo-crap" = "latest"
 
 [tasks.clippy]
 description = "Clippy lints (including tests and all features)"
 run = "cargo clippy --no-deps --tests --all-features -- -D warnings"
+
+[tasks.crap]
+description = "Gate on the CRAP (Change Risk Anti-Patterns) metric across the workspace — fails on complex, under-tested functions"
+run = [
+  # llvm-tools-preview is required by cargo-llvm-cov; adding it is idempotent.
+  "rustup component add llvm-tools-preview",
+  # Default features, matching the primary `cargo test` gate (aws-lc-rs backend).
+  # Needs LocalStack running for the vitaminc-kms tests, same as `cargo test`.
+  "cargo llvm-cov --workspace --lcov --output-path {{ config_root }}/target/vitaminc-lcov.info",
+  # Score against the threshold + exclude/allow rules in .cargo-crap.toml.
+  # `--fail-above` mirrors the CI gate, so a green local run means a green CI run.
+  "cargo crap --workspace --lcov {{ config_root }}/target/vitaminc-lcov.info --fail-above",
+]
 
 [tasks.docs]
 dir = "{{ config_root }}/packages/vitaminc"


### PR DESCRIPTION
## Summary

Adds a workspace-wide **CRAP (Change Risk Anti-Patterns)** gate. CRAP weights cyclomatic complexity by test coverage — `CRAP = CC² · (1 − coverage)³ + CC` — so a complex, untested function scores into the hundreds while a simple or well-covered one scores ~its complexity. It surfaces exactly the kind of risky, under-tested logic a crypto library most wants covered before it ships.

Mirrors **cipherstash-suite#2037**, adapted to vitaminc (all-Rust workspace, this repo's CI idioms) and — since the workspace is already in good shape — turned into a **gate** rather than report-only.

## Current baseline

The whole workspace tops out at **CRAP 20** (`CipherKey::open`, CC 4), comfortably under the threshold of 30. **296 functions analysed, 0 over threshold.** Gating now has headroom while still catching a complex, under-tested function added in a future PR.

## Changes

- **`.github/workflows/crap.yml`** — on PRs touching Rust code: generates LCOV with `cargo llvm-cov`, posts the scores as a **sticky PR comment**, then enforces the threshold with `cargo crap --fail-above` (the job fails on a violation, listing the offenders). Uses vitaminc's existing CI idioms: `dtolnay/rust-toolchain` + `llvm-tools-preview`, `actions/cache`, the same `LocalStack` step `test.yml` uses (the `vitaminc-kms` tests hit `localhost:4566`), and `cargo-binstall` via curl-pipe (no new third-party action). The comment is posted *before* the gate so it always shows what tripped it.
- **`.cargo-crap.toml`** (workspace root) — `threshold = 30`, `missing = "pessimistic"`, plus the `exclude`/`allow` rules as a single source of truth shared by CI and the local task. `allow` suppresses the two **proc-macro crates** (`random-derives`, `protected-derive`): `cargo-llvm-cov` can't instrument macro expansion, so they always read as 0% covered and would be permanent false-positives (they're exercised in practice by the crates that use the derives).
- **`mise.toml`** — `mise run crap` reproduces the gate locally (needs LocalStack running, same as `cargo test`).

## Notes

- **Non-blocking until required:** the job failing only blocks merges once `🚦 CRAP gate` is a required status check in branch protection (being set up alongside this PR).
- To soften back to report-only, drop the *Enforce CRAP threshold* step — the sticky comment keeps working either way. To ratchet the bar up later, lower `threshold` in `.cargo-crap.toml`.

https://claude.ai/code/session_015jJwUcMbyjuttxTLh4vh6q