### PR TITLE
ci: add cargo-mutants in-diff gate, config, and mise task

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,0 +1,34 @@
+# Configuration for cargo-mutants — mutation testing for the vitaminc workspace.
+#
+# Mutation testing rewrites small pieces of logic (flip a `<` to `<=`, replace a
+# body with `Default::default()`, etc.) and reruns the tests: a mutant that
+# survives is a line the suite does not actually pin down. In a crypto library
+# that is exactly the logic — comparisons, AAD handling, length checks — we most
+# want a test to catch before it ships.
+#
+# CI runs this `--in-diff` as a per-PR gate (.github/workflows/mutants.yml): only
+# the lines a PR changes are mutated, so the gate trips when a PR adds logic its
+# tests don't exercise. `mise run mutants` runs the whole workspace locally.
+# Both read the settings below, so they stay in sync.
+
+# Build and test with every feature on, so feature-gated code — the `hlist`
+# static-ciphertext API and the `_test-rust-crypto-backend` — is actually
+# compiled and exercised. Without this, a mutant in that code would "survive"
+# only because the gating feature was off, not because a test is missing.
+additional_cargo_args = ["--all-features"]
+
+# Skip the proc-macro derive crates: their logic runs at compile time, not in the
+# instrumented test binary, so cargo-mutants cannot meaningfully test mutants
+# there (they'd survive spuriously). This mirrors the cargo-crap `allow` list;
+# the derives are exercised in practice by the crates that use them.
+exclude_globs = [
+    "packages/protected-derive/**",
+    "packages/random-derives/**",
+]
+
+# Property tests (quickcheck) and AEAD round-trips run slower under mutation than
+# a clean build, so give each mutant generous headroom over the measured baseline
+# before declaring a timeout — a slow-but-correct mutant must not be misreported
+# as surviving (which would fail the gate spuriously).
+timeout_multiplier = 5.0
+minimum_test_timeout = 90

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -97,22 +97,31 @@ jobs:
       - name: Compute PR diff
         # cargo-mutants `--in-diff` mutates only lines added/changed by the PR.
         # Diff the checked-out tree against the base branch tip; fetch it first
-        # since the PR checkout doesn't include it.
+        # since the PR checkout doesn't include it. PR-only: a manual
+        # `workflow_dispatch` has no `github.base_ref` to diff against, so it runs
+        # the whole workspace instead (see the run step below).
+        if: github.event_name == 'pull_request'
         run: |
           git fetch --no-tags origin "${{ github.base_ref }}"
           git diff "origin/${{ github.base_ref }}" > pr.diff
           echo "Changed lines under mutation:"
           cat pr.diff
 
-      - name: Run cargo-mutants on the diff
+      - name: Run cargo-mutants
         id: mutants
         # Don't fail the job here: the gate step below is authoritative, and the
-        # sticky comment must be posted first. `--in-diff` + .cargo/mutants.toml
-        # (features/excludes/timeouts) keep this in sync with `mise run mutants`.
+        # sticky comment must be posted first. .cargo/mutants.toml
+        # (features/excludes/timeouts) keeps this in sync with `mise run mutants`.
+        # On a PR, scope to the diff; on a manual dispatch there is no diff, so
+        # sweep the whole workspace (slow, but that's the point of asking for it).
         continue-on-error: true
         run: |
           set +e
-          cargo mutants --no-shuffle -vV --in-diff pr.diff
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            cargo mutants --no-shuffle -vV --in-diff pr.diff
+          else
+            cargo mutants --no-shuffle -vV
+          fi
           echo "exit_code=$?" >> "$GITHUB_OUTPUT"
 
       - name: Build mutants report
@@ -131,7 +140,14 @@ jobs:
             echo '## 🧬 Mutation testing (cargo-mutants, `--in-diff`)'
             echo
             if [ ! -d "$out" ]; then
-              echo "No mutants were generated for this PR's changed lines."
+              # No output dir: either the run found nothing to mutate (exit 0) or
+              # it died before producing results (e.g. the baseline tests failed).
+              # Distinguish them so a failed run doesn't masquerade as a clean one.
+              if [ "${{ steps.mutants.outputs.exit_code }}" = "0" ]; then
+                echo "No mutants were generated for the changed lines."
+              else
+                echo "⚠️ cargo-mutants did not complete (exit ${{ steps.mutants.outputs.exit_code }}) before producing results — check the workflow run logs. The gate below will fail."
+              fi
               exit 0
             fi
             echo "| caught | missed | unviable | timeout |"
@@ -144,8 +160,10 @@ jobs:
               [ -s "$out/missed.txt" ] && cat "$out/missed.txt"
               [ -s "$out/timeout.txt" ] && { echo '# timed out (treated as surviving):'; cat "$out/timeout.txt"; }
               echo '```'
-            else
+            elif [ "${{ steps.mutants.outputs.exit_code }}" = "0" ]; then
               echo "✅ Every mutant in the changed lines was caught by a test."
+            else
+              echo "⚠️ cargo-mutants exited ${{ steps.mutants.outputs.exit_code }} with no surviving mutants recorded — the run may not have completed cleanly. Check the workflow run logs."
             fi
           } > mutants-comment.md
           cat mutants-comment.md

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -1,0 +1,194 @@
+name: "Mutants"
+
+# Gates PRs on mutation testing of the lines they change. cargo-mutants rewrites
+# small pieces of logic (flip `<` to `<=`, replace a body with
+# `Default::default()`, …) and reruns the tests; a mutant that survives is a line
+# the suite does not actually pin down. In a crypto library — comparisons, AAD
+# handling, length checks — that is exactly the logic we want a test to catch
+# before it ships.
+#
+# Scoped with `--in-diff` to the PR's own changes, so the gate trips only when a
+# PR adds (or moves) logic its tests don't exercise — a full-workspace run is far
+# too slow for a per-PR gate (~600 mutants). Run the whole workspace locally with
+# `mise run mutants`. Config (features, excludes, timeouts) lives in
+# .cargo/mutants.toml so this gate and the local task stay in sync.
+#
+# To soften back to report-only, drop the "Enforce — fail on surviving mutants"
+# step; the sticky comment keeps working either way. To block merges, mark this
+# check ("🧬 Mutants gate") as required in the repo's branch-protection settings.
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "packages/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".cargo/mutants.toml"
+      - ".github/workflows/mutants.yml"
+      # Negative patterns must stay last: keep the matches above but ignore
+      # pure-docs changes so a README-only PR doesn't run mutation testing.
+      - "!**.md"
+
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+# Needed to post/update the report comment on the PR.
+permissions:
+  contents: read
+  pull-requests: write
+
+# Cancel an in-flight run when the PR is pushed again — only the latest matters.
+concurrency:
+  group: mutants-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  mutants:
+    runs-on: ubuntu-latest
+    name: "🧬 Mutants gate"
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Full history so we can diff the PR against its base branch for
+          # `--in-diff`.
+          fetch-depth: 0
+
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-mutants-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: setup rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Start LocalStack
+        # The unmutated baseline runs the whole test suite, and vitaminc-kms'
+        # tests call a KMS endpoint on localhost:4566 — same as the test.yml and
+        # crap.yml gates.
+        uses: LocalStack/setup-localstack@v0.3.2
+        with:
+          image-tag: 'latest'
+          install-awslocal: 'true'
+        env:
+          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
+
+      - name: install cargo-binstall and cargo-mutants
+        # Install via cargo-binstall (prebuilt binaries — far faster than
+        # `cargo install` from source), the same curl-pipe pattern crap.yml uses,
+        # so we avoid a third-party Action the org allowlist may not permit.
+        # GITHUB_TOKEN lifts the anonymous API rate limit binstall would hit.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl -L --proto '=https' --tlsv1.2 -sSf \
+            https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+          cargo binstall -y cargo-mutants
+
+      - name: Compute PR diff
+        # cargo-mutants `--in-diff` mutates only lines added/changed by the PR.
+        # Diff the checked-out tree against the base branch tip; fetch it first
+        # since the PR checkout doesn't include it.
+        run: |
+          git fetch --no-tags origin "${{ github.base_ref }}"
+          git diff "origin/${{ github.base_ref }}" > pr.diff
+          echo "Changed lines under mutation:"
+          cat pr.diff
+
+      - name: Run cargo-mutants on the diff
+        id: mutants
+        # Don't fail the job here: the gate step below is authoritative, and the
+        # sticky comment must be posted first. `--in-diff` + .cargo/mutants.toml
+        # (features/excludes/timeouts) keep this in sync with `mise run mutants`.
+        continue-on-error: true
+        run: |
+          set +e
+          cargo mutants --no-shuffle -vV --in-diff pr.diff
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+
+      - name: Build mutants report
+        # Compose a sticky-comment body from the cargo-mutants output dir. Always
+        # runs so the comment reflects the run even when the gate below will fail.
+        if: always()
+        run: |
+          out=mutants.out
+          count() { if [ -f "$out/$1" ]; then grep -c . "$out/$1" || true; else echo 0; fi; }
+          caught=$(count caught.txt)
+          missed=$(count missed.txt)
+          unviable=$(count unviable.txt)
+          timeout=$(count timeout.txt)
+          {
+            echo '<!-- cargo-mutants-report -->'
+            echo '## 🧬 Mutation testing (cargo-mutants, `--in-diff`)'
+            echo
+            if [ ! -d "$out" ]; then
+              echo "No mutants were generated for this PR's changed lines."
+              exit 0
+            fi
+            echo "| caught | missed | unviable | timeout |"
+            echo "| -----: | -----: | -------: | ------: |"
+            echo "| $caught | $missed | $unviable | $timeout |"
+            echo
+            if [ "$missed" -gt 0 ] || [ "$timeout" -gt 0 ]; then
+              echo "### Surviving mutants — add a test that fails on each before merging"
+              echo '```'
+              [ -s "$out/missed.txt" ] && cat "$out/missed.txt"
+              [ -s "$out/timeout.txt" ] && { echo '# timed out (treated as surviving):'; cat "$out/timeout.txt"; }
+              echo '```'
+            else
+              echo "✅ Every mutant in the changed lines was caught by a test."
+            fi
+          } > mutants-comment.md
+          cat mutants-comment.md
+
+      - name: Post mutants report as a sticky PR comment
+        # Posted before the gate so the comment always shows what tripped it.
+        # Best-effort: a comment hiccup must not turn the gate red or stop the
+        # authoritative enforce step from running.
+        if: always() && github.event_name == 'pull_request'
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('mutants-comment.md', 'utf8');
+            const marker = '<!-- cargo-mutants-report -->';
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number, per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+
+      - name: Enforce — fail on surviving mutants
+        # The gate. A surviving ("missed") or timed-out mutant in the changed
+        # lines means a test does not pin that logic down; block the merge.
+        run: |
+          out=mutants.out
+          if [ -s "$out/missed.txt" ] || [ -s "$out/timeout.txt" ]; then
+            echo "::error::Surviving mutants in the PR diff — add tests that catch them (see the PR comment)."
+            [ -s "$out/missed.txt" ] && cat "$out/missed.txt"
+            [ -s "$out/timeout.txt" ] && cat "$out/timeout.txt"
+            exit 1
+          fi
+          # cargo-mutants failed before producing results (e.g. baseline tests
+          # failed) — surface that as a gate failure rather than a false pass.
+          if [ "${{ steps.mutants.outputs.exit_code }}" != "0" ] && [ ! -f "$out/outcomes.json" ]; then
+            echo "::error::cargo-mutants did not complete (exit ${{ steps.mutants.outputs.exit_code }}) — check the run logs."
+            exit 1
+          fi
+          echo "No surviving mutants in the PR diff."

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 /target
+# cargo-mutants output (mutation testing); see .cargo/mutants.toml
+/mutants.out
+/mutants.out.old
 .env
 .envrc
 .mise

--- a/mise.toml
+++ b/mise.toml
@@ -5,6 +5,10 @@ rust = "stable"
 # prebuilt binaries, so `mise install` binstalls them quickly.
 "cargo:cargo-llvm-cov" = "latest"
 "cargo:cargo-crap" = "latest"
+# Mutation testing. `cargo mutants` rewrites small pieces of logic and reruns the
+# tests; a surviving mutant is a line the suite doesn't pin down. Config lives in
+# .cargo/mutants.toml; see the `mutants` task below. Ships a prebuilt binary.
+"cargo:cargo-mutants" = "latest"
 
 [tasks.clippy]
 description = "Clippy lints (including tests and all features)"
@@ -21,6 +25,17 @@ run = [
   # Score against the threshold + exclude/allow rules in .cargo-crap.toml.
   # `--fail-above` mirrors the CI gate, so a green local run means a green CI run.
   "cargo crap --workspace --lcov {{ config_root }}/target/vitaminc-lcov.info --fail-above",
+]
+
+[tasks.mutants]
+description = "Mutation testing (cargo-mutants) across the workspace — surfaces logic the tests don't actually pin down"
+run = [
+  # Whole-workspace mutation run, reading features/excludes/timeouts from
+  # .cargo/mutants.toml. Like `cargo test` / `mise run crap`, the baseline runs
+  # the vitaminc-kms tests, so it needs LocalStack running. CI instead runs this
+  # `--in-diff` as a fast per-PR gate (.github/workflows/mutants.yml), mutating
+  # only the lines a PR changes.
+  "cargo mutants",
 ]
 
 [tasks.docs]


### PR DESCRIPTION
## What

Wires **cargo-mutants** (mutation testing) into the workspace as a permanent gate, mirroring how we set up cargo-crap (#205):

- **`.github/workflows/mutants.yml`** — a per-PR gate (`🧬 Mutants gate`) that runs `cargo mutants --in-diff` over **only the lines a PR changes**, posts a sticky comment with the results, and **fails when a changed line has a surviving (or timed-out) mutant**. A full-workspace run (~600 mutants) is far too slow for a per-PR gate, so `--in-diff` keeps it fast and relevant. Reuses crap.yml's LocalStack + cargo-binstall idioms (the unmutated baseline runs the `vitaminc-kms` tests, which need LocalStack).
- **`.cargo/mutants.toml`** — shared config: `--all-features` (so feature-gated code like `hlist` / `_test-rust-crypto-backend` is actually exercised, not falsely "missed"), excludes the proc-macro derive crates (their logic runs at compile time, not in the instrumented test binary), and generous timeouts for the property/round-trip tests.
- **`mise.toml`** — adds the `cargo:cargo-mutants` tool and a `mutants` task for a full local run.
- **`.gitignore`** — ignores the `mutants.out` output dir.

## Why

Mutation testing rewrites small pieces of logic (flip `<` to `<=`, replace a body with `Default::default()`, …) and reruns the tests; a surviving mutant is a line the suite doesn't actually pin down — exactly the comparisons, AAD handling, and length checks a crypto library most wants covered before it ships. We did the one-off mutation **inventory** earlier and fixed the Tier-1 gaps it surfaced (merged via #212); this PR wires the tool in so those gains don't regress and new PRs are held to the same bar.

## How it behaves

- **In-diff only:** mutates just the PR's added/changed lines, so the gate trips only when a PR introduces logic its own tests don't catch.
- **Gate:** fails the check on any surviving/timed-out mutant in the diff; unviable mutants (mutations that don't compile) are not failures.
- **Sticky comment:** posts a caught/missed/unviable/timeout table plus the list of surviving mutants to fix.

## Validation

Ran `cargo mutants --in-diff` locally end-to-end against a sample diff: it generates mutants only for the changed lines, the baseline + mutant runs complete, and the gate/comment logic produces the right pass/fail. Confirmed `--all-features` is threaded into the cargo invocations (so feature-gated code isn't falsely reported as surviving). Workflow YAML and TOML validated.

## To make it blocking

Mark **`🧬 Mutants gate`** as a required status check in the repo ruleset (same as the CRAP gate).

https://claude.ai/code/session_015jJwUcMbyjuttxTLh4vh6q