### PR TITLE
feat(aead): implement Encrypt/Decrypt for the Equatable controlled type

### DIFF
--- a/packages/aead/src/decipher/impls.rs
+++ b/packages/aead/src/decipher/impls.rs
@@ -1,7 +1,7 @@
 use super::{Decipher, DecipherVisitor, Decrypt, MapAccess, SeqAccess};
 use crate::{IntoAad, Unspecified};
 use std::collections::HashMap;
-use vitaminc_protected::{Controlled, Protected};
+use vitaminc_protected::{Controlled, Equatable, Protected};
 use zeroize::Zeroize;
 
 impl<'c> Decrypt<'c> for Vec<u8> {
@@ -142,6 +142,34 @@ where
         D::map_ok(
             T::decrypt_with_aad(decipher, aad),
             Protected::init_from_inner,
+        )
+    }
+}
+
+impl<'c, T> Decrypt<'c> for Equatable<T>
+where
+    // `Send` is required by the `Decrypt: Send` supertrait and is load-bearing,
+    // not over-tightening. Unlike the sibling `Protected` impl — which bounds
+    // `T: Decrypt`, transitively giving `T: Send` — this impl bounds the
+    // flattened `T::Inner: Decrypt`, which only proves `T::Inner: Send`. `T`
+    // itself is otherwise unconstrained (`Controlled` has no `Send` supertrait),
+    // so `T: Send` is not implied and must be stated for `map_ok`'s `U: Send`
+    // requirement (and the impl's own `Send`) to hold.
+    T: Controlled + Send + 'c,
+    T::Inner: Decrypt<'c> + 'c,
+{
+    fn decrypt_with_aad<'a, D, A>(decipher: D, aad: A) -> D::Ok<Self>
+    where
+        D: Decipher<'c>,
+        A: IntoAad<'a>,
+    {
+        // Decrypt the innermost value, then rebuild both wrapper layers
+        // (`Equatable<Protected<_>>`) via `init_from_inner` — the mirror of the
+        // `Encrypt` impl, which unwraps them. The AAD is threaded through to the
+        // inner decrypt so the binding matches what the `Encrypt` impl sealed.
+        D::map_ok(
+            <T::Inner as Decrypt<'c>>::decrypt_with_aad(decipher, aad),
+            Equatable::init_from_inner,
         )
     }
 }

--- a/packages/aead/src/encrypt/impls.rs
+++ b/packages/aead/src/encrypt/impls.rs
@@ -4,7 +4,7 @@ use crate::{
     Aad, IntoAad,
 };
 use std::collections::HashMap;
-use vitaminc_protected::{Controlled, Protected};
+use vitaminc_protected::{Controlled, Equatable, Protected};
 use zeroize::Zeroize;
 
 impl Encrypt for u32 {
@@ -104,6 +104,34 @@ where
         // boundary, so the bare-`T` stack window opened here is bounded by
         // the inner `Encrypt::encrypt_with_aad` call. Custom `Encrypt` impls
         // are responsible for their own discipline.
+        self.risky_unwrap().encrypt_with_aad(cipher, aad)
+    }
+}
+
+impl<T> Encrypt for Equatable<T>
+where
+    // Deliberately no `Zeroize` bound, unlike the sibling `Protected<T>` impl
+    // above (`T: Encrypt + Zeroize`): `Controlled` already governs the zeroize
+    // chain for `T`, and the inner value is re-wrapped in `Protected` by the leaf
+    // impl before it crosses the cipher boundary (see below), so an extra bound
+    // here would over-constrain callers without adding protection. The divergence
+    // is a conscious choice, not drift.
+    T: Controlled,
+    T::Inner: Encrypt,
+{
+    fn encrypt_with_aad<'a, C, A>(self, cipher: C, aad: A) -> Result<C::Ok, C::Error>
+    where
+        C: Cipher,
+        A: IntoAad<'a>,
+    {
+        // `Equatable` is an in-memory constant-time-equality wrapper; it adds
+        // nothing to the ciphertext — an `Equatable<Protected<T>>` ciphertext is
+        // interchangeable with a `Protected<T>` one, as the ciphertext does not
+        // attest the wrapper. Mirror the `Protected<T>` impl above: unwrap to the
+        // inner value and let the leaf `Encrypt` impl re-wrap it in `Protected`
+        // before crossing the cipher boundary, preserving the zeroize chain of
+        // custody. The `Equatable` layer is reconstructed structurally on decrypt
+        // (see the `Decrypt` impl).
         self.risky_unwrap().encrypt_with_aad(cipher, aad)
     }
 }

--- a/packages/encrypt/src/cipher.rs
+++ b/packages/encrypt/src/cipher.rs
@@ -678,6 +678,115 @@ mod test {
     }
 
     #[quickcheck]
+    fn roundtrip_equatable_string(key: Key, plaintext: String) -> bool {
+        use vitaminc_protected::{Controlled, Equatable, Protected};
+
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+        let value: Equatable<Protected<String>> = Equatable::new(plaintext.clone());
+        let ciphertext = value.encrypt(&cipher).expect("Encryption failed");
+        let decrypted: Equatable<Protected<String>> =
+            cipher.decrypt(ciphertext).expect("Decryption failed");
+        decrypted.risky_unwrap() == plaintext
+    }
+
+    #[quickcheck]
+    fn roundtrip_equatable_u32(key: Key, plaintext: u32) -> bool {
+        use vitaminc_protected::{Controlled, Equatable, Protected};
+
+        // `u32` routes through the fixed-size `encrypt_bytes_array` path, so this
+        // exercises the `Equatable` wrapper over that branch — not just the
+        // byte-vec path covered by `roundtrip_equatable_string`.
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+        let value: Equatable<Protected<u32>> = Equatable::new(plaintext);
+        let ciphertext = value.encrypt(&cipher).expect("Encryption failed");
+        let decrypted: Equatable<Protected<u32>> =
+            cipher.decrypt(ciphertext).expect("Decryption failed");
+        decrypted.risky_unwrap() == plaintext
+    }
+
+    #[quickcheck]
+    fn roundtrip_equatable_with_aad(key: Key, plaintext: String) -> bool {
+        use vitaminc_protected::{Controlled, Equatable, Protected};
+
+        // Positive correct-AAD roundtrip *through* the `Equatable` layer — the
+        // wrong-AAD test only proves rejection, never that the right AAD recovers
+        // the value. Also asserts the rebuilt wrapper's own constant-time
+        // `PartialEq` (the reason `Decrypt` reconstructs `Equatable` via
+        // `init_from_inner` rather than handing back a bare `Protected`).
+        let aad = "equatable-aad";
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+        let value: Equatable<Protected<String>> = Equatable::new(plaintext.clone());
+        let ciphertext = value
+            .encrypt_with_aad(&cipher, aad)
+            .expect("Encryption failed");
+        let decrypted: Equatable<Protected<String>> = cipher
+            .decrypt_with_aad(ciphertext, aad)
+            .expect("Decryption failed");
+        let expected: Equatable<Protected<String>> = Equatable::new(plaintext.clone());
+        decrypted == expected && decrypted.risky_unwrap() == plaintext
+    }
+
+    #[quickcheck]
+    fn decrypt_equatable_fails_with_wrong_aad(key: Key, plaintext: String) -> bool {
+        use vitaminc_protected::{Equatable, Protected};
+
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+        let value: Equatable<Protected<String>> = Equatable::new(plaintext);
+        let ciphertext = value
+            .encrypt_with_aad(&cipher, "correct-aad")
+            .expect("Encryption failed");
+        cipher
+            .decrypt_with_aad::<Equatable<Protected<String>>, _>(ciphertext, "wrong-aad")
+            .is_err()
+    }
+
+    #[quickcheck]
+    fn decrypt_equatable_fails_with_wrong_key(keys: DifferingKeyPair, plaintext: String) -> bool {
+        use vitaminc_protected::{Equatable, Protected};
+
+        // Completes the tamper matrix with the key axis (sibling `String` path has
+        // both wrong-AAD and wrong-key). `DifferingKeyPair` guarantees the two keys
+        // are distinct, so a key collision cannot make this spuriously pass.
+        let DifferingKeyPair(key_a, key_b) = keys;
+        let cipher_a = Aes256Cipher::new(&key_a).expect("Failed to create cipher A");
+        let cipher_b = Aes256Cipher::new(&key_b).expect("Failed to create cipher B");
+        let value: Equatable<Protected<String>> = Equatable::new(plaintext);
+        let ciphertext = value.encrypt(&cipher_a).expect("Encryption failed");
+        cipher_b
+            .decrypt::<Equatable<Protected<String>>>(ciphertext)
+            .is_err()
+    }
+
+    #[quickcheck]
+    fn equatable_ciphertext_is_wrapper_agnostic(key: Key, plaintext: String) -> bool {
+        use vitaminc_protected::{Controlled, Equatable, Protected};
+
+        // `Equatable` adds nothing to the ciphertext, so the two are interchangeable:
+        // a value sealed as `Equatable<Protected<String>>` decrypts cleanly as the
+        // bare inner `Protected<String>`, and a bare `String` ciphertext reads back
+        // through the `Equatable` layer. Pins the wrapper-agnostic invariant — a
+        // future change that tagged the wrapper into the ciphertext would break this.
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+
+        let eq_ciphertext = Equatable::<Protected<String>>::new(plaintext.clone())
+            .encrypt(&cipher)
+            .expect("Encryption failed");
+        let as_protected: Protected<String> = cipher
+            .decrypt(eq_ciphertext)
+            .expect("decrypt as Protected failed");
+
+        let bare_ciphertext = plaintext
+            .clone()
+            .encrypt(&cipher)
+            .expect("Encryption failed");
+        let as_equatable: Equatable<Protected<String>> = cipher
+            .decrypt(bare_ciphertext)
+            .expect("decrypt as Equatable failed");
+
+        as_protected.risky_unwrap() == plaintext && as_equatable.risky_unwrap() == plaintext
+    }
+
+    #[quickcheck]
     fn roundtrip_option_some_string(key: Key, plaintext: String) -> bool {
         let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
         let value = Some(plaintext.clone());


### PR DESCRIPTION
## Summary

Implements `aead`'s `Encrypt`/`Decrypt` traits for `Equatable<T>`, so an `Equatable`-wrapped secret can flow through the encryption pipeline the way `Protected<T>` already can — no more manually unwrapping before encrypting and re-wrapping after decrypting.

Closes #221.

## Background

This supersedes the original issue #36 (closed *not planned*) and the stale PR #37. That PR couldn't be revived: it targeted the pre-restructure `aead/src/encrypt.rs` / `decrypt.rs` single files and the old `Encrypt { type Encrypted }` / `Decrypt` trait shapes, all since replaced by the current driver-style `Encrypt` and GAT-based `Decipher`/`Decrypt<'c>` design. This is a fresh implementation against the current structure.

## Changes

Mirrors the existing `Protected<T>` impls, accounting for `Equatable<T>` being a `Controlled` wrapper over an inner `T: Controlled` (`Inner = T::Inner`):

- **`Encrypt for Equatable<T>`** (`encrypt/impls.rs`) — `where T: Controlled, T::Inner: Encrypt`. Unwraps to the inner value and forwards; leaf impls re-wrap in `Protected` before crossing the cipher boundary, preserving the zeroize chain of custody.
- **`Decrypt<'c> for Equatable<T>`** (`decipher/impls.rs`) — `where T: Controlled + Send + 'c, T::Inner: Decrypt<'c> + 'c`. Decrypts the innermost value, then rebuilds both wrapper layers via `Controlled::init_from_inner`.

`Equatable` is an in-memory constant-time-equality wrapper and adds nothing to the ciphertext, so its layer is reconstructed structurally on decrypt — there's no on-the-wire representation distinguishing it from `Protected`.

## Testing

- `roundtrip_equatable_string` — round-trips `Equatable<Protected<String>>` (the byte-vec path).
- `roundtrip_equatable_u32` — round-trips `Equatable<Protected<u32>>`, exercising the fixed-size `encrypt_bytes_array` path under the wrapper.
- `decrypt_equatable_fails_with_wrong_aad` — negative-AAD case for the wrapper.
- All pass on **both** the aws-lc and rust-crypto backends; `clippy -D warnings` and `cargo fmt --check` clean.

## Review fixes (post-open)

Addressed code-review feedback:

- **Tightened the `Decrypt` bound** from `Self: Send` to the more precise `T: Send`. `Self: Send` was the loosest patch that satisfied the `Decrypt: Send` supertrait; constraining the wrapper directly (the way `Protected<T>` derives `Send` from its inner) removes a latent *encryptable-but-not-decryptable* asymmetry for any `Controlled` type with a `Send` inner but non-`Send` outer.
- **Expanded test coverage** beyond the single `Equatable<Protected<String>>` case: added the fixed-size-inner (`u32`) round-trip and the wrong-AAD negative test described above.

A possible follow-up (not done here): the `Encrypt`/`Decrypt` bodies are generic over `Controlled` and will be copy-pasted for the other wrappers (`Exportable`, `Usage`). A declarative macro over the wrapper list would collapse the duplication — the `equatable/mod.rs` "blanket impl for all Paranoid types?" TODO already marks the spot.

https://claude.ai/code/session_018swQ3Fa1GrWdpTQp1Dmj1s