### PR TITLE
feat(aead)!: authenticate map keys and accept runtime-derived keys

### DIFF
--- a/packages/aead/README.md
+++ b/packages/aead/README.md
@@ -97,7 +97,10 @@ impl<'c> SeqCipher for MySeqCipher<'c> {
         T: Any + Send + 'static,
     { unimplemented!() }
 
-    fn end(self) -> Result<Self::Ok, Self::Error> { unimplemented!() }
+    fn end<'a, A>(self, _aad: A) -> Result<Self::Ok, Self::Error>
+    where
+        A: IntoAad<'a>,
+    { unimplemented!() }
 }
 
 impl<'c> MapCipher for MyMapCipher<'c> {
@@ -123,7 +126,10 @@ impl<'c> MapCipher for MyMapCipher<'c> {
         T: Any + Send + 'static,
     { unimplemented!() }
 
-    fn end(self) -> Result<Self::Ok, Self::Error> { unimplemented!() }
+    fn end<'a, A>(self, _aad: A) -> Result<Self::Ok, Self::Error>
+    where
+        A: IntoAad<'a>,
+    { unimplemented!() }
 }
 ```
 
@@ -227,13 +233,14 @@ impl Encrypt for User {
         C: Cipher,
         A: IntoAad<'a>,
     {
+        let aad = aad.into_aad();
         // Encrypt the user as a map of named fields, encrypting only the
         // password hash. id and email are not stored here for brevity —
         // a real implementation would also encrypt or pass them through.
         cipher
             .encrypt_map()
-            .encrypt_entry("password_hash", self.password_hash, aad)?
-            .end()
+            .encrypt_entry("password_hash", self.password_hash, aad.clone())?
+            .end(aad)
     }
 }
 

--- a/packages/aead/README.md
+++ b/packages/aead/README.md
@@ -104,16 +104,22 @@ impl<'c> MapCipher for MyMapCipher<'c> {
     type Ok = MyCipherText;
     type Error = Unspecified;
 
-    fn encrypt_key(self, _key: &'static str) -> Result<Self, Self::Error> { unimplemented!() }
+    fn encrypt_key<K>(self, _key: K) -> Result<Self, Self::Error>
+    where
+        K: Into<std::borrow::Cow<'static, str>>,
+    { unimplemented!() }
 
+    // Must seal the value against `Aad::for_map_entry(aad, key)` — see the
+    // `MapCipher` docs on key authentication.
     fn encrypt_value<'a, T, A>(self, _value: T, _aad: A) -> Result<Self, Self::Error>
     where
         T: vitaminc_aead::Encrypt,
         A: IntoAad<'a>,
     { unimplemented!() }
 
-    fn passthrough_entry<T>(self, _key: &'static str, _value: T) -> Result<Self, Self::Error>
+    fn passthrough_entry<K, T>(self, _key: K, _value: T) -> Result<Self, Self::Error>
     where
+        K: Into<std::borrow::Cow<'static, str>>,
         T: Any + Send + 'static,
     { unimplemented!() }
 
@@ -160,7 +166,7 @@ let plaintext: String = cipher.decrypt_with_aad(ciphertext, "context data")?;
 
 `String`, `Vec<u8>`, `[u8; N]`, `u32`, `Vec<T: Decrypt>`, `HashMap<String, T: Decrypt>`, and `Protected<T: Decrypt>` all implement `Decrypt` out of the box.
 
-> **Note on maps:** `HashMap` decryption yields `HashMap<String, T>`, but map *encryption* requires statically known keys — only `HashMap<&'static str, T>` implements `Encrypt`. Map keys are passed to [`MapCipher::encrypt_key`], which takes a `&'static str`. A `HashMap<String, T>` with runtime-derived keys can therefore be decrypted but not encrypted directly.
+> **Note on maps:** both `HashMap<&'static str, T>` and `HashMap<String, T>` implement `Encrypt` (keys are anything `Into<Cow<'static, str>>`), and decryption yields `HashMap<String, T>`. Map keys travel in the clear but are bound into each value's AAD via [`Aad::for_map_entry`], so swapping or renaming keys inside a stored ciphertext causes decryption to fail.
 
 ### Additional Authenticated Data (AAD)
 

--- a/packages/aead/README.md
+++ b/packages/aead/README.md
@@ -59,12 +59,20 @@ impl<'c> Cipher for &'c MyCipher {
         unimplemented!("seal `data` with AAD and return a ciphertext")
     }
 
-    fn encrypt_seq(self, size_hint: Option<usize>) -> Self::SeqCipher {
-        unimplemented!("return a SeqCipher initialised with `size_hint` capacity")
+    // The AAD is captured here, once, and covers every element and the
+    // empty marker — the sub-cipher methods take none of their own.
+    fn encrypt_seq<'a, A>(self, size_hint: Option<usize>, aad: A) -> Self::SeqCipher
+    where
+        A: IntoAad<'a>,
+    {
+        unimplemented!("return a SeqCipher holding `aad`, sized by `size_hint`")
     }
 
-    fn encrypt_map(self) -> Self::MapCipher {
-        unimplemented!("return a MapCipher")
+    fn encrypt_map<'a, A>(self, aad: A) -> Self::MapCipher
+    where
+        A: IntoAad<'a>,
+    {
+        unimplemented!("return a MapCipher holding `aad`")
     }
 
     fn encrypt_none<'a, A>(self, _aad: A) -> Result<Self::Ok, Self::Error>
@@ -86,10 +94,9 @@ impl<'c> SeqCipher for MySeqCipher<'c> {
     type Ok = MyCipherText;
     type Error = Unspecified;
 
-    fn encrypt_next<'a, T, A>(self, _data: T, _aad: A) -> Result<Self, Self::Error>
+    fn encrypt_next<T>(self, _data: T) -> Result<Self, Self::Error>
     where
         T: vitaminc_aead::Encrypt,
-        A: IntoAad<'a>,
     { unimplemented!() }
 
     fn passthrough_next<T>(self, _value: T) -> Result<Self, Self::Error>
@@ -97,10 +104,7 @@ impl<'c> SeqCipher for MySeqCipher<'c> {
         T: Any + Send + 'static,
     { unimplemented!() }
 
-    fn end<'a, A>(self, _aad: A) -> Result<Self::Ok, Self::Error>
-    where
-        A: IntoAad<'a>,
-    { unimplemented!() }
+    fn end(self) -> Result<Self::Ok, Self::Error> { unimplemented!() }
 }
 
 impl<'c> MapCipher for MyMapCipher<'c> {
@@ -112,12 +116,12 @@ impl<'c> MapCipher for MyMapCipher<'c> {
         K: Into<std::borrow::Cow<'static, str>>,
     { unimplemented!() }
 
-    // Must seal the value against `Aad::for_map_entry(aad, key)` — see the
-    // `MapCipher` docs on key authentication.
-    fn encrypt_value<'a, T, A>(self, _value: T, _aad: A) -> Result<Self, Self::Error>
+    // Must seal the value against `Aad::for_map_entry(aad, key)` of the AAD
+    // this MapCipher was constructed with — see the `MapCipher` docs on key
+    // authentication.
+    fn encrypt_value<T>(self, _value: T) -> Result<Self, Self::Error>
     where
         T: vitaminc_aead::Encrypt,
-        A: IntoAad<'a>,
     { unimplemented!() }
 
     fn passthrough_entry<K, T>(self, _key: K, _value: T) -> Result<Self, Self::Error>
@@ -126,10 +130,7 @@ impl<'c> MapCipher for MyMapCipher<'c> {
         T: Any + Send + 'static,
     { unimplemented!() }
 
-    fn end<'a, A>(self, _aad: A) -> Result<Self::Ok, Self::Error>
-    where
-        A: IntoAad<'a>,
-    { unimplemented!() }
+    fn end(self) -> Result<Self::Ok, Self::Error> { unimplemented!() }
 }
 ```
 
@@ -233,14 +234,14 @@ impl Encrypt for User {
         C: Cipher,
         A: IntoAad<'a>,
     {
-        let aad = aad.into_aad();
         // Encrypt the user as a map of named fields, encrypting only the
         // password hash. id and email are not stored here for brevity —
         // a real implementation would also encrypt or pass them through.
+        // The AAD is supplied once, to `encrypt_map`.
         cipher
-            .encrypt_map()
-            .encrypt_entry("password_hash", self.password_hash, aad.clone())?
-            .end(aad)
+            .encrypt_map(aad)
+            .encrypt_entry("password_hash", self.password_hash)?
+            .end()
     }
 }
 

--- a/packages/aead/src/aad/mod.rs
+++ b/packages/aead/src/aad/mod.rs
@@ -72,6 +72,51 @@ impl<'a> Aad<'a> {
         const MAP_ENTRY_DOMAIN: &[u8] = b"vitaminc/aead/map-entry/v1";
         pae::encode(&[MAP_ENTRY_DOMAIN, self.as_bytes(), key.as_bytes()])
     }
+
+    /// Derives the AAD a structural marker must be sealed against.
+    ///
+    /// Markers are sealed empty plaintexts whose tag is the only thing
+    /// authenticating a structural fact — "this sequence is empty", "this
+    /// map is empty", "this value is absent". Like [`for_map_entry`], the
+    /// encoding is a labelled three-piece `PAE(domain, aad, kind)`: the
+    /// leading domain label keeps marker AAD disjoint from user-supplied
+    /// composite AAD (a two-piece `PAE(label, aad)` would collide with a
+    /// caller binding the tuple `(label, aad)` at the top level), and the
+    /// `kind` piece keeps the marker kinds disjoint from each other, so a
+    /// stored marker can never be replayed as a different structural claim.
+    ///
+    /// [`Cipher::encrypt_none`](crate::Cipher::encrypt_none),
+    /// [`SeqCipher::end`](crate::SeqCipher::end) and
+    /// [`MapCipher::end`](crate::MapCipher::end) implementations are
+    /// required to derive marker AAD through these methods — both sides
+    /// must use them, or nothing decrypts.
+    ///
+    /// [`for_map_entry`]: Aad::for_map_entry
+    fn for_marker(&self, kind: &[u8]) -> Aad<'static> {
+        const MARKER_DOMAIN: &[u8] = b"vitaminc/aead/marker/v1";
+        pae::encode(&[MARKER_DOMAIN, self.as_bytes(), kind])
+    }
+
+    /// Marker AAD for an empty sequence — see [`for_marker`](Aad::for_marker)
+    /// (private; this method and its siblings are the public surface).
+    pub fn for_empty_sequence(&self) -> Aad<'static> {
+        self.for_marker(b"empty-sequence")
+    }
+
+    /// Marker AAD for an empty map.
+    pub fn for_empty_map(&self) -> Aad<'static> {
+        self.for_marker(b"empty-map")
+    }
+
+    /// Marker AAD for an authenticated absent value (`Option::None`).
+    ///
+    /// Domain separation here is what stops a `Single` leaf sealed under the
+    /// bare AAD from being re-tagged as a `None` marker (silent authenticated
+    /// data deletion) — and, symmetrically, an absence marker from validating
+    /// as an encrypted empty byte string.
+    pub fn for_none(&self) -> Aad<'static> {
+        self.for_marker(b"none")
+    }
 }
 
 /// Types that can be canonically converted into an [`Aad`].
@@ -282,6 +327,45 @@ mod tests {
         let bound = Aad::from_slice(b"ctx").for_map_entry("name");
         let tuple = (Aad::from_slice(b"ctx"), "name").into_aad();
         assert_ne!(bound.as_bytes(), tuple.as_bytes());
+    }
+
+    #[test]
+    fn marker_aads_pin_encoding() {
+        // The exact bytes are a wire-format commitment: PAE(domain, aad, kind).
+        // Changing them breaks decryption of existing markers.
+        let aad = Aad::from_slice(b"ctx");
+        for (derived, kind) in [
+            (aad.for_empty_sequence(), b"empty-sequence".as_slice()),
+            (aad.for_empty_map(), b"empty-map"),
+            (aad.for_none(), b"none"),
+        ] {
+            let expected = Aad::pae(&[b"vitaminc/aead/marker/v1", b"ctx", kind]);
+            assert_eq!(derived.as_bytes(), expected.as_bytes());
+        }
+    }
+
+    #[test]
+    fn marker_aads_differ_from_tuple_aad_and_each_other() {
+        // The domain label keeps marker AAD disjoint from a user binding a
+        // matching (label, aad) tuple at the top level, and the kind piece
+        // keeps the three markers disjoint from one another.
+        let aad = Aad::from_slice(b"ctx");
+        let markers = [
+            aad.for_empty_sequence(),
+            aad.for_empty_map(),
+            aad.for_none(),
+        ];
+        for (i, m) in markers.iter().enumerate() {
+            let tuple = (
+                b"vitaminc/aead/marker/v1".as_slice(),
+                Aad::from_slice(b"ctx"),
+            )
+                .into_aad();
+            assert_ne!(m.as_bytes(), tuple.as_bytes());
+            for other in &markers[i + 1..] {
+                assert_ne!(m.as_bytes(), other.as_bytes());
+            }
+        }
     }
 
     #[test]

--- a/packages/aead/src/aad/mod.rs
+++ b/packages/aead/src/aad/mod.rs
@@ -40,11 +40,14 @@ impl<'a> Aad<'a> {
         self.0.is_empty()
     }
 
-    /// Converts a borrowed `Aad` into an owned one, copying the bytes if necessary.
-    pub fn into_owned(self) -> Aad<'a> {
+    /// Converts a borrowed `Aad` into an owned one, copying the bytes if
+    /// necessary. The result borrows nothing, so it can outlive the input —
+    /// which is what lets the sequence and map sub-ciphers hold the AAD they
+    /// were constructed with for the lifetime of the builder chain.
+    pub fn into_owned(self) -> Aad<'static> {
         match self.0 {
-            x @ Cow::Borrowed(_) => Self(x.into_owned().into()),
-            Cow::Owned(_) => self,
+            Cow::Borrowed(slice) => Aad(Cow::Owned(slice.to_vec())),
+            Cow::Owned(owned) => Aad(Cow::Owned(owned)),
         }
     }
 

--- a/packages/aead/src/aad/mod.rs
+++ b/packages/aead/src/aad/mod.rs
@@ -51,6 +51,27 @@ impl<'a> Aad<'a> {
     pub(crate) fn pae(pieces: &[&[u8]]) -> Self {
         pae::encode(pieces)
     }
+
+    /// Derives the AAD a map entry's value must be sealed against, binding the
+    /// entry `key` to this (caller-supplied) AAD.
+    ///
+    /// Map keys travel in the clear inside a ciphertext container, so without
+    /// this binding an attacker holding a stored ciphertext could swap or
+    /// rename keys undetected, silently reassigning values to different
+    /// fields. [`MapCipher::encrypt_value`](crate::MapCipher::encrypt_value)
+    /// and [`MapAccess::next_entry`](crate::MapAccess::next_entry)
+    /// implementations are required to derive each entry's effective AAD
+    /// through this method — both sides must use it, or nothing decrypts.
+    ///
+    /// The encoding is `PAE(domain, aad, key)`. The leading domain-separation
+    /// label keeps the result disjoint from user-supplied composite AAD: a
+    /// caller binding the tuple `(aad, key)` at the top level (e.g. via
+    /// [`ContextTag`](crate::ContextTag)) encodes `PAE(aad, key)`, which can
+    /// never collide with a map entry's three-piece, labelled encoding.
+    pub fn for_map_entry(&self, key: &str) -> Aad<'static> {
+        const MAP_ENTRY_DOMAIN: &[u8] = b"vitaminc/aead/map-entry/v1";
+        pae::encode(&[MAP_ENTRY_DOMAIN, self.as_bytes(), key.as_bytes()])
+    }
 }
 
 /// Types that can be canonically converted into an [`Aad`].
@@ -243,6 +264,38 @@ mod tests {
         // `None` is PAE-encoded as zero pieces: LE64(0) = 8 zero bytes.
         assert_eq!(none_aad.as_bytes(), &[0u8; 8]);
         assert_ne!(none_aad.as_bytes(), some_aad.as_bytes());
+    }
+
+    #[test]
+    fn for_map_entry_pins_encoding() {
+        // The exact bytes are a wire-format commitment: PAE(domain, aad, key).
+        // Changing them breaks decryption of existing ciphertexts.
+        let bound = Aad::from_slice(b"ctx").for_map_entry("name");
+        let expected = Aad::pae(&[b"vitaminc/aead/map-entry/v1", b"ctx", b"name"]);
+        assert_eq!(bound.as_bytes(), expected.as_bytes());
+    }
+
+    #[test]
+    fn for_map_entry_differs_from_tuple_aad() {
+        // The domain label keeps map-entry AAD disjoint from a user binding
+        // the same (aad, key) pair as tuple AAD at the top level.
+        let bound = Aad::from_slice(b"ctx").for_map_entry("name");
+        let tuple = (Aad::from_slice(b"ctx"), "name").into_aad();
+        assert_ne!(bound.as_bytes(), tuple.as_bytes());
+    }
+
+    #[test]
+    fn for_map_entry_is_key_sensitive() {
+        let aad = Aad::from_slice(b"ctx");
+        assert_ne!(
+            aad.for_map_entry("a").as_bytes(),
+            aad.for_map_entry("b").as_bytes()
+        );
+        // Moving bytes between AAD and key must not collide (PAE injectivity).
+        assert_ne!(
+            Aad::from_slice(b"ctxa").for_map_entry("").as_bytes(),
+            Aad::from_slice(b"ctx").for_map_entry("a").as_bytes()
+        );
     }
 
     #[test]

--- a/packages/aead/src/cipher.rs
+++ b/packages/aead/src/cipher.rs
@@ -81,12 +81,22 @@ pub trait Cipher: Sized {
         self.encrypt_bytes_vec(copy, aad)
     }
 
-    /// Begin encrypting a sequence of values. `size_hint` lets the implementation
-    /// preallocate when known.
-    fn encrypt_seq(self, size_hint: Option<usize>) -> Self::SeqCipher;
+    /// Begin encrypting a sequence of values under `aad`. `size_hint` lets the
+    /// implementation preallocate when known.
+    ///
+    /// The AAD is captured **once**, here, and applies to every element and to
+    /// the empty marker. Sub-cipher methods therefore take no AAD of their
+    /// own: there is no second place to supply it, so an element and its
+    /// container can never end up sealed under different AAD.
+    fn encrypt_seq<'a, A>(self, size_hint: Option<usize>, aad: A) -> Self::SeqCipher
+    where
+        A: IntoAad<'a>;
 
-    /// Begin encrypting a map of key/value pairs.
-    fn encrypt_map(self) -> Self::MapCipher;
+    /// Begin encrypting a map of key/value pairs under `aad`, captured once —
+    /// see [`encrypt_seq`](Cipher::encrypt_seq).
+    fn encrypt_map<'a, A>(self, aad: A) -> Self::MapCipher
+    where
+        A: IntoAad<'a>;
 
     /// Encrypt a present optional value. Default forwards to the inner value's
     /// [`Encrypt`] impl — the `Some` discriminator is implicit in the structural
@@ -136,11 +146,10 @@ pub trait Cipher: Sized {
 
 /// Sub-cipher driving the encryption of a sequence of values.
 ///
-/// Obtained from [`Cipher::encrypt_seq`]. Each element is encrypted with
+/// Obtained from [`Cipher::encrypt_seq`], which fixes the AAD for the whole
+/// sequence. Each element is encrypted with
 /// [`encrypt_next`](SeqCipher::encrypt_next); the caller finalises the sequence
-/// with [`end`](SeqCipher::end) to produce the cipher's `Ok` output. The AAD is
-/// supplied again at finalisation so an empty sequence, which has no element
-/// ciphertexts to authenticate it, can still produce an authenticated marker.
+/// with [`end`](SeqCipher::end) to produce the cipher's `Ok` output.
 pub trait SeqCipher: Sized {
     /// The final encrypted output produced by [`end`](SeqCipher::end).
     type Ok;
@@ -148,10 +157,12 @@ pub trait SeqCipher: Sized {
     type Error;
 
     /// Encrypt the next element in the sequence, returning the updated cipher.
-    fn encrypt_next<'a, T, A>(self, data: T, aad: A) -> Result<Self, Self::Error>
+    ///
+    /// The element is sealed against the AAD supplied to
+    /// [`Cipher::encrypt_seq`].
+    fn encrypt_next<T>(self, data: T) -> Result<Self, Self::Error>
     where
-        T: Encrypt,
-        A: IntoAad<'a>;
+        T: Encrypt;
 
     /// Append a passthrough (unencrypted) element to the sequence.
     ///
@@ -163,27 +174,26 @@ pub trait SeqCipher: Sized {
 
     /// Finalise the sequence and return the produced ciphertext container.
     ///
-    /// Implementations must authenticate `aad` even when no encrypted elements
-    /// were appended. Otherwise an empty sequence used as a map value would not
-    /// authenticate the map entry's derived AAD, allowing its cleartext key to
-    /// be renamed without detection. The empty marker must be sealed against
-    /// [`Aad::for_empty_sequence`](crate::Aad::for_empty_sequence) of the
-    /// caller's AAD.
+    /// Implementations must authenticate the sequence's AAD even when no
+    /// encrypted elements were appended. Otherwise an empty sequence used as a
+    /// map value would not authenticate the map entry's derived AAD, allowing
+    /// its cleartext key to be renamed without detection. The empty marker
+    /// must be sealed against
+    /// [`Aad::for_empty_sequence`](crate::Aad::for_empty_sequence) of that AAD.
     ///
     /// A sequence whose elements are all passthrough must be **rejected**:
     /// passthrough elements authenticate nothing, so such a container would
-    /// carry no tag binding `aad` at all — decrypt implementations must
+    /// carry no tag binding the AAD at all — decrypt implementations must
     /// likewise refuse to open one.
-    fn end<'a, A>(self, aad: A) -> Result<Self::Ok, Self::Error>
-    where
-        A: IntoAad<'a>;
+    fn end(self) -> Result<Self::Ok, Self::Error>;
 }
 
 /// Sub-cipher driving the encryption of a map of key/value pairs.
 ///
-/// Obtained from [`Cipher::encrypt_map`]. Keys are not encrypted; values are.
-/// The expected call order is key → value → key → value → … → `end`, or use
-/// the [`encrypt_entry`](MapCipher::encrypt_entry) convenience method.
+/// Obtained from [`Cipher::encrypt_map`], which fixes the AAD for the whole
+/// map. Keys are not encrypted; values are. The expected call order is
+/// key → value → key → value → … → `end`, or use the
+/// [`encrypt_entry`](MapCipher::encrypt_entry) convenience method.
 ///
 /// Keys may be `&'static str` or owned `String`s (anything
 /// `Into<Cow<'static, str>>`), so maps with runtime-derived keys — e.g. values
@@ -222,26 +232,23 @@ pub trait MapCipher: Sized {
 
     /// Encrypt the value associated with the most recently supplied key.
     ///
-    /// Implementations **must not** seal the value against `aad` directly:
-    /// they must bind the pending key alongside it via
+    /// Implementations **must not** seal the value against the map's AAD
+    /// directly: they must bind the pending key alongside it via
     /// [`Aad::for_map_entry`](crate::Aad::for_map_entry), so that key and value
     /// are cryptographically inseparable in the stored ciphertext.
-    fn encrypt_value<'a, T, A>(self, value: T, aad: A) -> Result<Self, Self::Error>
+    fn encrypt_value<T>(self, value: T) -> Result<Self, Self::Error>
     where
-        T: Encrypt,
-        A: IntoAad<'a>;
+        T: Encrypt;
 
     /// Convenience for [`encrypt_key`](MapCipher::encrypt_key) followed by
     /// [`encrypt_value`](MapCipher::encrypt_value).
-    fn encrypt_entry<'a, K, T, A>(self, key: K, value: T, aad: A) -> Result<Self, Self::Error>
+    fn encrypt_entry<K, T>(self, key: K, value: T) -> Result<Self, Self::Error>
     where
         K: Into<Cow<'static, str>>,
         T: Encrypt,
-        A: IntoAad<'a>,
         Self: Sized,
     {
-        self.encrypt_key(key)
-            .and_then(|mc| mc.encrypt_value(value, aad))
+        self.encrypt_key(key).and_then(|mc| mc.encrypt_value(value))
     }
 
     /// Insert a passthrough (unencrypted) entry under `key`. Equivalent to
@@ -258,16 +265,13 @@ pub trait MapCipher: Sized {
 
     /// Finalise the map and return the produced ciphertext container.
     ///
-    /// Implementations must authenticate `aad` even when no encrypted entries
-    /// were appended. Otherwise an empty map used as a map value would not
-    /// authenticate the outer entry's derived AAD, allowing its cleartext key
-    /// to be renamed without detection. The empty marker must be sealed
-    /// against [`Aad::for_empty_map`](crate::Aad::for_empty_map) of the
-    /// caller's AAD.
+    /// Implementations must authenticate the map's AAD even when no encrypted
+    /// entries were appended. Otherwise an empty map used as a map value would
+    /// not authenticate the outer entry's derived AAD, allowing its cleartext
+    /// key to be renamed without detection. The empty marker must be sealed
+    /// against [`Aad::for_empty_map`](crate::Aad::for_empty_map) of that AAD.
     ///
     /// A map whose entries are all passthrough must be **rejected** — see
     /// [`SeqCipher::end`].
-    fn end<'a, A>(self, aad: A) -> Result<Self::Ok, Self::Error>
-    where
-        A: IntoAad<'a>;
+    fn end(self) -> Result<Self::Ok, Self::Error>;
 }

--- a/packages/aead/src/cipher.rs
+++ b/packages/aead/src/cipher.rs
@@ -102,6 +102,12 @@ pub trait Cipher: Sized {
     /// Encrypt the absent case of an optional value. Must produce a
     /// cryptographically authenticated marker — distinguishable from any
     /// `Some(_)` ciphertext and bound to `aad` so it cannot be forged.
+    ///
+    /// Implementations must seal the marker against
+    /// [`Aad::for_none`](crate::Aad::for_none) of the caller's AAD (and the
+    /// decrypt side must verify the sealed plaintext is empty under the same
+    /// derivation), so a `Some(_)` leaf sealed under the bare AAD can never
+    /// be re-tagged as an authenticated absence.
     fn encrypt_none<'a, A>(self, aad: A) -> Result<Self::Ok, Self::Error>
     where
         A: IntoAad<'a>;
@@ -160,7 +166,14 @@ pub trait SeqCipher: Sized {
     /// Implementations must authenticate `aad` even when no encrypted elements
     /// were appended. Otherwise an empty sequence used as a map value would not
     /// authenticate the map entry's derived AAD, allowing its cleartext key to
-    /// be renamed without detection.
+    /// be renamed without detection. The empty marker must be sealed against
+    /// [`Aad::for_empty_sequence`](crate::Aad::for_empty_sequence) of the
+    /// caller's AAD.
+    ///
+    /// A sequence whose elements are all passthrough must be **rejected**:
+    /// passthrough elements authenticate nothing, so such a container would
+    /// carry no tag binding `aad` at all — decrypt implementations must
+    /// likewise refuse to open one.
     fn end<'a, A>(self, aad: A) -> Result<Self::Ok, Self::Error>
     where
         A: IntoAad<'a>;
@@ -248,7 +261,12 @@ pub trait MapCipher: Sized {
     /// Implementations must authenticate `aad` even when no encrypted entries
     /// were appended. Otherwise an empty map used as a map value would not
     /// authenticate the outer entry's derived AAD, allowing its cleartext key
-    /// to be renamed without detection.
+    /// to be renamed without detection. The empty marker must be sealed
+    /// against [`Aad::for_empty_map`](crate::Aad::for_empty_map) of the
+    /// caller's AAD.
+    ///
+    /// A map whose entries are all passthrough must be **rejected** — see
+    /// [`SeqCipher::end`].
     fn end<'a, A>(self, aad: A) -> Result<Self::Ok, Self::Error>
     where
         A: IntoAad<'a>;

--- a/packages/aead/src/cipher.rs
+++ b/packages/aead/src/cipher.rs
@@ -1,4 +1,5 @@
 use std::any::Any;
+use std::borrow::Cow;
 
 use vitaminc_protected::{Controlled, Protected};
 
@@ -162,14 +163,22 @@ pub trait SeqCipher: Sized {
 /// The expected call order is key → value → key → value → … → `end`, or use
 /// the [`encrypt_entry`](MapCipher::encrypt_entry) convenience method.
 ///
-/// # Static keys only
+/// Keys may be `&'static str` or owned `String`s (anything
+/// `Into<Cow<'static, str>>`), so maps with runtime-derived keys — e.g. values
+/// crossing an FFI boundary — can be encrypted as well as decrypted.
 ///
-/// [`encrypt_key`](MapCipher::encrypt_key) takes a `&'static str`, so maps can
-/// only be *encrypted* when their keys are known at compile time. A
-/// `HashMap<String, T>` with runtime-derived keys can be *decrypted* (the
-/// [`Decrypt`](crate::Decrypt) impl yields `HashMap<String, T>`) but cannot be
-/// encrypted directly — only `HashMap<&'static str, T>` implements
-/// [`Encrypt`](crate::Encrypt).
+/// # Key authentication
+///
+/// Keys travel in the clear, but they are **not** unauthenticated:
+/// implementations must bind each entry's key into the AAD its value is sealed
+/// against, via [`Aad::for_map_entry`](crate::Aad::for_map_entry). Swapping or
+/// renaming keys in a stored ciphertext therefore causes the affected values to
+/// fail decryption. [`MapAccess`](crate::MapAccess) implementations perform the
+/// symmetric binding on decrypt.
+///
+/// The exception is [`passthrough_entry`](MapCipher::passthrough_entry): a
+/// passthrough value is neither encrypted nor authenticated, so nothing seals
+/// its key either.
 pub trait MapCipher: Sized {
     /// The final encrypted output produced by [`end`](MapCipher::end).
     type Ok;
@@ -177,16 +186,24 @@ pub trait MapCipher: Sized {
     type Error;
 
     /// Record the next key. Keys are stored in the clear — only values are
-    /// encrypted.
+    /// encrypted — but each key is bound into its value's AAD (see the
+    /// trait-level *Key authentication* notes).
     ///
     /// Must be followed by exactly one [`encrypt_value`](MapCipher::encrypt_value)
     /// before the next `encrypt_key` or [`end`](MapCipher::end). Calling
     /// `encrypt_key` twice with no intervening `encrypt_value` is a trait-contract
     /// violation; implementations should return an error rather than silently
     /// dropping the first key.
-    fn encrypt_key(self, key: &'static str) -> Result<Self, Self::Error>;
+    fn encrypt_key<K>(self, key: K) -> Result<Self, Self::Error>
+    where
+        K: Into<Cow<'static, str>>;
 
     /// Encrypt the value associated with the most recently supplied key.
+    ///
+    /// Implementations **must not** seal the value against `aad` directly:
+    /// they must bind the pending key alongside it via
+    /// [`Aad::for_map_entry`](crate::Aad::for_map_entry), so that key and value
+    /// are cryptographically inseparable in the stored ciphertext.
     fn encrypt_value<'a, T, A>(self, value: T, aad: A) -> Result<Self, Self::Error>
     where
         T: Encrypt,
@@ -194,13 +211,9 @@ pub trait MapCipher: Sized {
 
     /// Convenience for [`encrypt_key`](MapCipher::encrypt_key) followed by
     /// [`encrypt_value`](MapCipher::encrypt_value).
-    fn encrypt_entry<'a, T, A>(
-        self,
-        key: &'static str,
-        value: T,
-        aad: A,
-    ) -> Result<Self, Self::Error>
+    fn encrypt_entry<'a, K, T, A>(self, key: K, value: T, aad: A) -> Result<Self, Self::Error>
     where
+        K: Into<Cow<'static, str>>,
         T: Encrypt,
         A: IntoAad<'a>,
         Self: Sized,
@@ -214,9 +227,11 @@ pub trait MapCipher: Sized {
     /// without AEAD treatment.
     ///
     /// See [`Cipher::passthrough`] — passthrough values are non-sensitive by
-    /// design and must not carry secret data.
-    fn passthrough_entry<T>(self, key: &'static str, value: T) -> Result<Self, Self::Error>
+    /// design and must not carry secret data. Neither the value nor its key is
+    /// authenticated.
+    fn passthrough_entry<K, T>(self, key: K, value: T) -> Result<Self, Self::Error>
     where
+        K: Into<Cow<'static, str>>,
         T: Any + Send + 'static;
 
     /// Finalise the map and return the produced ciphertext container.

--- a/packages/aead/src/cipher.rs
+++ b/packages/aead/src/cipher.rs
@@ -132,7 +132,9 @@ pub trait Cipher: Sized {
 ///
 /// Obtained from [`Cipher::encrypt_seq`]. Each element is encrypted with
 /// [`encrypt_next`](SeqCipher::encrypt_next); the caller finalises the sequence
-/// with [`end`](SeqCipher::end) to produce the cipher's `Ok` output.
+/// with [`end`](SeqCipher::end) to produce the cipher's `Ok` output. The AAD is
+/// supplied again at finalisation so an empty sequence, which has no element
+/// ciphertexts to authenticate it, can still produce an authenticated marker.
 pub trait SeqCipher: Sized {
     /// The final encrypted output produced by [`end`](SeqCipher::end).
     type Ok;
@@ -154,7 +156,14 @@ pub trait SeqCipher: Sized {
         T: Any + Send + 'static;
 
     /// Finalise the sequence and return the produced ciphertext container.
-    fn end(self) -> Result<Self::Ok, Self::Error>;
+    ///
+    /// Implementations must authenticate `aad` even when no encrypted elements
+    /// were appended. Otherwise an empty sequence used as a map value would not
+    /// authenticate the map entry's derived AAD, allowing its cleartext key to
+    /// be renamed without detection.
+    fn end<'a, A>(self, aad: A) -> Result<Self::Ok, Self::Error>
+    where
+        A: IntoAad<'a>;
 }
 
 /// Sub-cipher driving the encryption of a map of key/value pairs.
@@ -235,5 +244,12 @@ pub trait MapCipher: Sized {
         T: Any + Send + 'static;
 
     /// Finalise the map and return the produced ciphertext container.
-    fn end(self) -> Result<Self::Ok, Self::Error>;
+    ///
+    /// Implementations must authenticate `aad` even when no encrypted entries
+    /// were appended. Otherwise an empty map used as a map value would not
+    /// authenticate the outer entry's derived AAD, allowing its cleartext key
+    /// to be renamed without detection.
+    fn end<'a, A>(self, aad: A) -> Result<Self::Ok, Self::Error>
+    where
+        A: IntoAad<'a>;
 }

--- a/packages/aead/src/context.rs
+++ b/packages/aead/src/context.rs
@@ -368,11 +368,17 @@ mod tests {
             Ok(data.risky_unwrap())
         }
 
-        fn encrypt_seq(self, _size_hint: Option<usize>) -> Self::SeqCipher {
+        fn encrypt_seq<'a, A>(self, _size_hint: Option<usize>, _aad: A) -> Self::SeqCipher
+        where
+            A: IntoAad<'a>,
+        {
             UnusedSeq
         }
 
-        fn encrypt_map(self) -> Self::MapCipher {
+        fn encrypt_map<'a, A>(self, _aad: A) -> Self::MapCipher
+        where
+            A: IntoAad<'a>,
+        {
             UnusedMap
         }
 
@@ -396,10 +402,9 @@ mod tests {
         type Ok = Vec<u8>;
         type Error = Unspecified;
 
-        fn encrypt_next<'a, T, A>(self, _data: T, _aad: A) -> Result<Self, Self::Error>
+        fn encrypt_next<T>(self, _data: T) -> Result<Self, Self::Error>
         where
             T: Encrypt,
-            A: IntoAad<'a>,
         {
             Ok(self)
         }
@@ -411,10 +416,7 @@ mod tests {
             Ok(self)
         }
 
-        fn end<'a, A>(self, _aad: A) -> Result<Self::Ok, Self::Error>
-        where
-            A: IntoAad<'a>,
-        {
+        fn end(self) -> Result<Self::Ok, Self::Error> {
             Ok(Vec::new())
         }
     }
@@ -430,10 +432,9 @@ mod tests {
             Ok(self)
         }
 
-        fn encrypt_value<'a, T, A>(self, _value: T, _aad: A) -> Result<Self, Self::Error>
+        fn encrypt_value<T>(self, _value: T) -> Result<Self, Self::Error>
         where
             T: Encrypt,
-            A: IntoAad<'a>,
         {
             Ok(self)
         }
@@ -446,10 +447,7 @@ mod tests {
             Ok(self)
         }
 
-        fn end<'a, A>(self, _aad: A) -> Result<Self::Ok, Self::Error>
-        where
-            A: IntoAad<'a>,
-        {
+        fn end(self) -> Result<Self::Ok, Self::Error> {
             Ok(Vec::new())
         }
     }

--- a/packages/aead/src/context.rs
+++ b/packages/aead/src/context.rs
@@ -420,7 +420,10 @@ mod tests {
         type Ok = Vec<u8>;
         type Error = Unspecified;
 
-        fn encrypt_key(self, _key: &'static str) -> Result<Self, Self::Error> {
+        fn encrypt_key<K>(self, _key: K) -> Result<Self, Self::Error>
+        where
+            K: Into<std::borrow::Cow<'static, str>>,
+        {
             Ok(self)
         }
 
@@ -432,8 +435,9 @@ mod tests {
             Ok(self)
         }
 
-        fn passthrough_entry<T>(self, _key: &'static str, _value: T) -> Result<Self, Self::Error>
+        fn passthrough_entry<K, T>(self, _key: K, _value: T) -> Result<Self, Self::Error>
         where
+            K: Into<std::borrow::Cow<'static, str>>,
             T: Any + Send + 'static,
         {
             Ok(self)

--- a/packages/aead/src/context.rs
+++ b/packages/aead/src/context.rs
@@ -411,7 +411,10 @@ mod tests {
             Ok(self)
         }
 
-        fn end(self) -> Result<Self::Ok, Self::Error> {
+        fn end<'a, A>(self, _aad: A) -> Result<Self::Ok, Self::Error>
+        where
+            A: IntoAad<'a>,
+        {
             Ok(Vec::new())
         }
     }
@@ -443,7 +446,10 @@ mod tests {
             Ok(self)
         }
 
-        fn end(self) -> Result<Self::Ok, Self::Error> {
+        fn end<'a, A>(self, _aad: A) -> Result<Self::Ok, Self::Error>
+        where
+            A: IntoAad<'a>,
+        {
             Ok(Vec::new())
         }
     }

--- a/packages/aead/src/decipher/mod.rs
+++ b/packages/aead/src/decipher/mod.rs
@@ -154,9 +154,12 @@ pub trait MapAccess<'c> {
     /// Returns the next decrypted `(key, value)` entry, or `None` when the map is exhausted.
     ///
     /// As with [`SeqAccess::next_element`], implementations **must authenticate each value
-    /// against the map's associated data** — thread the AAD supplied to
-    /// [`Decipher::decrypt_map`] into the value's [`Decrypt::decrypt_with_aad`], mirroring
-    /// [`MapCipher::encrypt_value`](crate::MapCipher::encrypt_value).
+    /// against the map's associated data** — and additionally against the entry's own key.
+    /// Derive the effective AAD by passing the AAD supplied to [`Decipher::decrypt_map`]
+    /// through [`Aad::for_map_entry`](crate::Aad::for_map_entry) with the entry key, mirroring
+    /// the binding [`MapCipher::encrypt_value`](crate::MapCipher::encrypt_value) performs at
+    /// encrypt time. An implementation that decrypts values against the bare map AAD leaves
+    /// keys swappable in stored ciphertext (and will fail to decrypt conforming ciphertexts).
     fn next_entry<T: Decrypt<'c> + 'c>(&mut self) -> Result<Option<(String, T)>, Self::Error>;
 }
 

--- a/packages/aead/src/encrypt/impls.rs
+++ b/packages/aead/src/encrypt/impls.rs
@@ -89,6 +89,30 @@ where
     }
 }
 
+/// The runtime-keyed counterpart of the `HashMap<&'static str, T>` impl above,
+/// for maps whose keys are not known at compile time (e.g. values arriving
+/// across an FFI boundary). Round-trips with the `Decrypt` impl for
+/// `HashMap<String, T>`.
+impl<T> Encrypt for HashMap<String, T>
+where
+    T: Encrypt,
+{
+    fn encrypt_with_aad<'a, C: Cipher, A: IntoAad<'a>>(
+        self,
+        cipher: C,
+        aad: A,
+    ) -> Result<C::Ok, C::Error> {
+        let aad: Aad = aad.into_aad();
+
+        self.into_iter()
+            .try_fold(cipher.encrypt_map(), |c, (k, v)| {
+                c.encrypt_key(k)
+                    .and_then(|c| c.encrypt_value(v, aad.clone()))
+            })?
+            .end()
+    }
+}
+
 impl<T> Encrypt for Protected<T>
 where
     T: Encrypt + Zeroize,

--- a/packages/aead/src/encrypt/impls.rs
+++ b/packages/aead/src/encrypt/impls.rs
@@ -3,7 +3,9 @@ use crate::{
     cipher::{MapCipher, SeqCipher},
     Aad, IntoAad,
 };
+use std::borrow::Cow;
 use std::collections::HashMap;
+use std::hash::Hash;
 use vitaminc_protected::{Controlled, Equatable, Protected};
 use zeroize::Zeroize;
 
@@ -69,32 +71,14 @@ impl<const N: usize> Encrypt for [u8; N] {
     }
 }
 
-impl<T> Encrypt for HashMap<&'static str, T>
+/// One impl covers both compile-time keys (`&'static str`) and runtime keys
+/// (`String`, e.g. values arriving across an FFI boundary) — anything
+/// [`MapCipher::encrypt_key`](crate::MapCipher::encrypt_key) accepts. A single
+/// impl keeps the two key shapes on one map-encryption protocol: a change
+/// applied to one cannot silently miss the other.
+impl<K, T> Encrypt for HashMap<K, T>
 where
-    T: Encrypt,
-{
-    fn encrypt_with_aad<'a, C: Cipher, A: IntoAad<'a>>(
-        self,
-        cipher: C,
-        aad: A,
-    ) -> Result<C::Ok, C::Error> {
-        let aad: Aad = aad.into_aad();
-
-        self.into_iter()
-            .try_fold(cipher.encrypt_map(), |c, (k, v)| {
-                c.encrypt_key(k)
-                    .and_then(|c| c.encrypt_value(v, aad.clone()))
-            })?
-            .end(aad)
-    }
-}
-
-/// The runtime-keyed counterpart of the `HashMap<&'static str, T>` impl above,
-/// for maps whose keys are not known at compile time (e.g. values arriving
-/// across an FFI boundary). Round-trips with the `Decrypt` impl for
-/// `HashMap<String, T>`.
-impl<T> Encrypt for HashMap<String, T>
-where
+    K: Into<Cow<'static, str>> + Eq + Hash,
     T: Encrypt,
 {
     fn encrypt_with_aad<'a, C: Cipher, A: IntoAad<'a>>(

--- a/packages/aead/src/encrypt/impls.rs
+++ b/packages/aead/src/encrypt/impls.rs
@@ -1,7 +1,7 @@
 use super::{Cipher, Encrypt};
 use crate::{
     cipher::{MapCipher, SeqCipher},
-    Aad, IntoAad,
+    IntoAad,
 };
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -43,21 +43,20 @@ impl<T> Encrypt for Vec<T>
 where
     T: Encrypt,
 {
-    /// All entries in the vec are encrypted with the same Aad.
-    /// Passing `aad` as a reference otherwise the value will be cloned for each element
+    /// Every element is encrypted under the sequence's AAD, which
+    /// [`Cipher::encrypt_seq`] captures once.
     fn encrypt_with_aad<'a, C: Cipher, A: IntoAad<'a>>(
         self,
         cipher: C,
         aad: A,
     ) -> Result<C::Ok, C::Error> {
-        let aad: Aad = aad.into_aad();
         let len = self.len();
 
         self.into_iter()
-            .try_fold(cipher.encrypt_seq(Some(len)), |c, item| {
-                c.encrypt_next(item, aad.clone())
+            .try_fold(cipher.encrypt_seq(Some(len), aad), |c, item| {
+                c.encrypt_next(item)
             })?
-            .end(aad)
+            .end()
     }
 }
 
@@ -86,14 +85,11 @@ where
         cipher: C,
         aad: A,
     ) -> Result<C::Ok, C::Error> {
-        let aad: Aad = aad.into_aad();
-
         self.into_iter()
-            .try_fold(cipher.encrypt_map(), |c, (k, v)| {
-                c.encrypt_key(k)
-                    .and_then(|c| c.encrypt_value(v, aad.clone()))
+            .try_fold(cipher.encrypt_map(aad), |c, (k, v)| {
+                c.encrypt_key(k).and_then(|c| c.encrypt_value(v))
             })?
-            .end(aad)
+            .end()
     }
 }
 

--- a/packages/aead/src/encrypt/impls.rs
+++ b/packages/aead/src/encrypt/impls.rs
@@ -55,7 +55,7 @@ where
             .try_fold(cipher.encrypt_seq(Some(len)), |c, item| {
                 c.encrypt_next(item, aad.clone())
             })?
-            .end()
+            .end(aad)
     }
 }
 
@@ -85,7 +85,7 @@ where
                 c.encrypt_key(k)
                     .and_then(|c| c.encrypt_value(v, aad.clone()))
             })?
-            .end()
+            .end(aad)
     }
 }
 
@@ -109,7 +109,7 @@ where
                 c.encrypt_key(k)
                     .and_then(|c| c.encrypt_value(v, aad.clone()))
             })?
-            .end()
+            .end(aad)
     }
 }
 

--- a/packages/aead/src/hlist/cipher.rs
+++ b/packages/aead/src/hlist/cipher.rs
@@ -70,6 +70,12 @@ where
     L: HList,
 {
     /// Add an encrypted entry.
+    ///
+    /// The value is sealed against [`Aad::for_map_entry`](crate::Aad::for_map_entry)
+    /// of the caller's AAD and `key` — the same contract as the dynamic
+    /// [`MapCipher`](crate::MapCipher) — so a stored entry's cleartext key
+    /// cannot be swapped or renamed undetected. Open with a counterpart that
+    /// derives the same binding (e.g. `Aes256Cipher::open_entry`).
     pub fn encrypt_entry<'a, A>(
         self,
         key: &'static str,
@@ -79,7 +85,8 @@ where
     where
         A: IntoAad<'a>,
     {
-        let encrypted = self.cipher.encrypt_bytes(value, aad)?;
+        let entry_aad = aad.into_aad().for_map_entry(key);
+        let encrypted = self.cipher.encrypt_bytes(value, entry_aad)?;
         Ok(StaticMapBuilder {
             cipher: self.cipher,
             list: HCons(
@@ -110,7 +117,8 @@ where
         }
     }
 
-    /// Add an authenticated absent entry.
+    /// Add an authenticated absent entry, key-bound like
+    /// [`encrypt_entry`](StaticMapBuilder::encrypt_entry).
     pub fn none_entry<'a, A>(
         self,
         key: &'static str,
@@ -119,7 +127,8 @@ where
     where
         A: IntoAad<'a>,
     {
-        let absent = self.cipher.encrypt_none(aad)?;
+        let entry_aad = aad.into_aad().for_map_entry(key);
+        let absent = self.cipher.encrypt_none(entry_aad)?;
         Ok(StaticMapBuilder {
             cipher: self.cipher,
             list: HCons(Entry { key, value: absent }, self.list),

--- a/packages/encrypt/src/cipher.rs
+++ b/packages/encrypt/src/cipher.rs
@@ -7,23 +7,28 @@ use vitaminc_aead::{
     LocalCipherText, MapAccess, MapCipher, NonceGenerator, RandomNonceGenerator, SeqAccess,
     SeqCipher, Unspecified,
 };
-use vitaminc_protected::Protected;
+use vitaminc_protected::{Controlled, Protected};
 
 /// The recursive ciphertext container produced by [`Aes256Cipher`].
 ///
 /// The shape mirrors the structure of the plaintext that was encrypted: a
-/// single value yields [`Single`](AesCipherText::Single), a `Vec` yields
-/// [`Sequence`](AesCipherText::Sequence), a `HashMap` yields
-/// [`Map`](AesCipherText::Map). Nested structures are represented recursively.
+/// single value yields [`Single`](AesCipherText::Single), while non-empty
+/// `Vec`s and `HashMap`s yield [`Sequence`](AesCipherText::Sequence) and
+/// [`Map`](AesCipherText::Map). Empty composites use authenticated marker
+/// variants. Nested structures are represented recursively.
 #[derive(Debug)]
 pub enum AesCipherText {
     /// A single sealed value (nonce + ciphertext + tag).
     Single(LocalCipherText),
     /// A sequence of ciphertexts produced from a `Vec`-shaped plaintext.
     Sequence(Vec<AesCipherText>),
+    /// An empty sequence authenticated under domain-separated AAD.
+    EmptySequence(LocalCipherText),
     /// A map of (cleartext key, ciphertext value) pairs produced from a
     /// `HashMap`-shaped plaintext. Keys are not encrypted.
     Map(Vec<(String, AesCipherText)>),
+    /// An empty map authenticated under domain-separated AAD.
+    EmptyMap(LocalCipherText),
     /// The authenticated absent marker produced by [`Cipher::encrypt_none`].
     /// Stores a sealed empty plaintext whose tag binds the supplied AAD.
     None(LocalCipherText),
@@ -54,6 +59,35 @@ impl Aes256Cipher {
             key: key.cipher_key()?,
         })
     }
+
+    fn seal_empty_marker<'a, A>(&self, aad: A) -> Result<LocalCipherText, Unspecified>
+    where
+        A: IntoAad<'a>,
+    {
+        let nonce = self.nonce_generator.generate()?;
+        let nonce_bytes: [u8; NONCE_LEN] = nonce.as_ref().try_into().map_err(|_| Unspecified)?;
+        let aad = aad.into_aad();
+
+        CipherTextBuilder::new()
+            .append_nonce(nonce)
+            .append_target_plaintext(Vec::<u8>::new())
+            .accepts_ciphertext_and_tag_ok(|mut buf| {
+                self.key
+                    .seal(&nonce_bytes, aad.as_bytes(), &mut buf)
+                    .map(|()| buf)
+            })
+            .build()
+    }
+}
+
+fn empty_sequence_aad<'a>(aad: Aad<'a>) -> Aad<'a> {
+    let domain: &'a [u8] = b"vitaminc/aead/empty-sequence/v1";
+    (domain, aad).into_aad()
+}
+
+fn empty_map_aad<'a>(aad: Aad<'a>) -> Aad<'a> {
+    let domain: &'a [u8] = b"vitaminc/aead/empty-map/v1";
+    (domain, aad).into_aad()
 }
 
 impl<'c> Cipher for &'c Aes256Cipher {
@@ -105,20 +139,7 @@ impl<'c> Cipher for &'c Aes256Cipher {
     where
         A: IntoAad<'a>,
     {
-        let nonce = self.nonce_generator.generate()?;
-        let nonce_bytes: [u8; NONCE_LEN] = nonce.as_ref().try_into().map_err(|_| Unspecified)?;
-        let aad = aad.into_aad();
-
-        CipherTextBuilder::new()
-            .append_nonce(nonce)
-            .append_target_plaintext(Vec::<u8>::new())
-            .accepts_ciphertext_and_tag_ok(|mut buf| {
-                self.key
-                    .seal(&nonce_bytes, aad.as_bytes(), &mut buf)
-                    .map(|()| buf)
-            })
-            .build()
-            .map(AesCipherText::None)
+        self.seal_empty_marker(aad).map(AesCipherText::None)
     }
 
     fn passthrough<T>(self, value: T) -> Result<Self::Ok, Self::Error>
@@ -159,8 +180,18 @@ impl<'c> SeqCipher for AesSeqCipher<'c> {
         Ok(self)
     }
 
-    fn end(self) -> Result<Self::Ok, Self::Error> {
-        Ok(AesCipherText::Sequence(self.items))
+    fn end<'a, A>(self, aad: A) -> Result<Self::Ok, Self::Error>
+    where
+        A: IntoAad<'a>,
+    {
+        if self.items.is_empty() {
+            let aad = empty_sequence_aad(aad.into_aad());
+            self.cipher
+                .seal_empty_marker(aad)
+                .map(AesCipherText::EmptySequence)
+        } else {
+            Ok(AesCipherText::Sequence(self.items))
+        }
     }
 }
 
@@ -240,12 +271,22 @@ impl<'c> MapCipher for AesMapCipher<'c> {
         Ok(self)
     }
 
-    fn end(self) -> Result<Self::Ok, Self::Error> {
+    fn end<'a, A>(self, aad: A) -> Result<Self::Ok, Self::Error>
+    where
+        A: IntoAad<'a>,
+    {
         // Finalising with a pending key would silently drop the entry.
         if self.current_key.is_some() {
             return Err(Unspecified);
         }
-        Ok(AesCipherText::Map(self.entries))
+        if self.entries.is_empty() {
+            let aad = empty_map_aad(aad.into_aad());
+            self.cipher
+                .seal_empty_marker(aad)
+                .map(AesCipherText::EmptyMap)
+        } else {
+            Ok(AesCipherText::Map(self.entries))
+        }
     }
 }
 
@@ -316,6 +357,19 @@ impl AesDecipher<'_> {
             .accepts_plaintext_ok(|data| cipher.key.open(&nonce_bytes, aad, data))
             .read()
     }
+
+    fn verify_empty_marker(
+        cipher: &Aes256Cipher,
+        ct: LocalCipherText,
+        aad: &[u8],
+    ) -> Result<(), Unspecified> {
+        let plaintext = Self::decrypt_local_ciphertext(cipher, ct, aad)?;
+        if plaintext.risky_ref().is_empty() {
+            Ok(())
+        } else {
+            Err(Unspecified)
+        }
+    }
 }
 
 impl<'c> Decipher<'c> for AesDecipher<'c> {
@@ -354,11 +408,21 @@ impl<'c> Decipher<'c> for AesDecipher<'c> {
         A: IntoAad<'a>,
     {
         match self.ciphertext {
-            AesCipherText::Sequence(items) => {
+            AesCipherText::Sequence(items) if !items.is_empty() => {
                 let seq_access = AesSeqAccess {
                     cipher: self.cipher,
                     items: items.into_iter(),
                     aad: aad.into_aad(),
+                };
+                visitor.visit_seq(seq_access)
+            }
+            AesCipherText::EmptySequence(ct) => {
+                let aad = empty_sequence_aad(aad.into_aad());
+                Self::verify_empty_marker(self.cipher, ct, aad.as_bytes())?;
+                let seq_access = AesSeqAccess {
+                    cipher: self.cipher,
+                    items: Vec::new().into_iter(),
+                    aad,
                 };
                 visitor.visit_seq(seq_access)
             }
@@ -372,11 +436,21 @@ impl<'c> Decipher<'c> for AesDecipher<'c> {
         A: IntoAad<'a>,
     {
         match self.ciphertext {
-            AesCipherText::Map(entries) => {
+            AesCipherText::Map(entries) if !entries.is_empty() => {
                 let map_access = AesMapAccess {
                     cipher: self.cipher,
                     entries: entries.into_iter(),
                     aad: aad.into_aad(),
+                };
+                visitor.visit_map(map_access)
+            }
+            AesCipherText::EmptyMap(ct) => {
+                let aad = empty_map_aad(aad.into_aad());
+                Self::verify_empty_marker(self.cipher, ct, aad.as_bytes())?;
+                let map_access = AesMapAccess {
+                    cipher: self.cipher,
+                    entries: Vec::new().into_iter(),
+                    aad,
                 };
                 visitor.visit_map(map_access)
             }
@@ -577,14 +651,8 @@ mod test {
 
     #[quickcheck]
     fn decrypt_seq_fails_with_wrong_aad(key: Key, plaintext: Vec<String>) -> bool {
-        // The Sequence path re-supplies the same AAD to every element, so a wrong
-        // AAD must fail the per-element authentication rather than silently
-        // decrypting (see `AesSeqAccess::next_element`). An empty sequence has no
-        // element tags to reject — the container shape itself is not
-        // AEAD-authenticated on either side — so skip it.
-        if plaintext.is_empty() {
-            return true;
-        }
+        // Non-empty sequences reject a wrong AAD at an element; empty sequences
+        // reject it at their authenticated, domain-separated marker.
         let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
         let ciphertext = plaintext
             .encrypt_with_aad(&cipher, "correct-aad")
@@ -599,10 +667,9 @@ mod test {
         // Positive counterpart to `decrypt_seq_fails_with_wrong_aad`: every element
         // must authenticate when the *correct* AAD is re-supplied per element by
         // `AesSeqAccess::next_element`. Exercises the borrowed-AAD seq path across
-        // arbitrary element counts (the empty vec has no element tags and trivially
-        // roundtrips). A wrong-AAD-fails test alone can't catch a regression where
-        // the per-element AAD is dropped or mis-borrowed so even the correct AAD
-        // fails — only this positive multi-element roundtrip does.
+        // arbitrary element counts, including the authenticated empty marker. A
+        // wrong-AAD-fails test alone can't catch a regression where the correct AAD
+        // fails — only this positive roundtrip does.
         let aad = "seq-aad";
         let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
         let ciphertext = plaintext
@@ -679,6 +746,26 @@ mod test {
             .expect("Encryption failed");
         assert!(cipher
             .decrypt_with_aad::<HashMap<String, String>, _>(ciphertext, "wrong-aad")
+            .is_err());
+    }
+
+    #[test]
+    fn empty_composites_fail_with_wrong_aad() {
+        let key = Key::from([42u8; 32]);
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+
+        let empty_sequence = Vec::<String>::new()
+            .encrypt_with_aad(&cipher, "correct-aad")
+            .expect("Encryption failed");
+        assert!(cipher
+            .decrypt_with_aad::<Vec<String>, _>(empty_sequence, "wrong-aad")
+            .is_err());
+
+        let empty_map = HashMap::<String, String>::new()
+            .encrypt_with_aad(&cipher, "correct-aad")
+            .expect("Encryption failed");
+        assert!(cipher
+            .decrypt_with_aad::<HashMap<String, String>, _>(empty_map, "wrong-aad")
             .is_err());
     }
 
@@ -966,7 +1053,7 @@ mod test {
         let key = Key::from([42u8; 32]);
         let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
         let map = (&cipher).encrypt_map().encrypt_key("pending").unwrap();
-        assert!(map.end().is_err());
+        assert!(map.end(()).is_err());
     }
 
     #[test]
@@ -977,7 +1064,7 @@ mod test {
         let ciphertext = (&cipher)
             .encrypt_map()
             .passthrough_entry("version", 1u32)
-            .and_then(|m| m.end())
+            .and_then(|m| m.end(()))
             .expect("passthrough_entry should succeed without a pending key");
         match ciphertext {
             AesCipherText::Map(entries) => {
@@ -1031,6 +1118,109 @@ mod test {
 
         let result: Result<HashMap<String, u32>, _> = cipher.decrypt(AesCipherText::Map(entries));
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn renamed_map_key_with_empty_sequence_value_fails_decryption() {
+        let key = Key::from([42u8; 32]);
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+        let mut map = HashMap::new();
+        map.insert("roles".to_string(), Vec::<String>::new());
+
+        let mut entries = match map.encrypt(&cipher).expect("Encryption failed") {
+            AesCipherText::Map(entries) => entries,
+            _ => panic!("expected Map ciphertext"),
+        };
+        entries[0].0 = "is_admin".to_string();
+
+        let result: Result<HashMap<String, Vec<String>>, _> =
+            cipher.decrypt(AesCipherText::Map(entries));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn renamed_map_key_with_empty_map_value_fails_decryption() {
+        let key = Key::from([42u8; 32]);
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+        let mut map = HashMap::new();
+        map.insert("roles".to_string(), HashMap::<String, String>::new());
+
+        let mut entries = match map.encrypt(&cipher).expect("Encryption failed") {
+            AesCipherText::Map(entries) => entries,
+            _ => panic!("expected Map ciphertext"),
+        };
+        entries[0].0 = "is_admin".to_string();
+
+        let result: Result<HashMap<String, HashMap<String, String>>, _> =
+            cipher.decrypt(AesCipherText::Map(entries));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn unauthenticated_empty_composite_shapes_are_rejected() {
+        let key = Key::from([42u8; 32]);
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+
+        assert!(cipher
+            .decrypt::<Vec<String>>(AesCipherText::Sequence(Vec::new()))
+            .is_err());
+        assert!(cipher
+            .decrypt::<HashMap<String, String>>(AesCipherText::Map(Vec::new()))
+            .is_err());
+    }
+
+    #[test]
+    fn empty_composite_markers_are_domain_separated() {
+        let key = Key::from([42u8; 32]);
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+
+        let sequence_marker = match Vec::<String>::new()
+            .encrypt_with_aad(&cipher, "context")
+            .expect("Encryption failed")
+        {
+            AesCipherText::EmptySequence(marker) => marker,
+            _ => panic!("expected EmptySequence ciphertext"),
+        };
+        assert!(cipher
+            .decrypt_with_aad::<HashMap<String, String>, _>(
+                AesCipherText::EmptyMap(sequence_marker),
+                "context",
+            )
+            .is_err());
+
+        let map_marker = match HashMap::<String, String>::new()
+            .encrypt_with_aad(&cipher, "context")
+            .expect("Encryption failed")
+        {
+            AesCipherText::EmptyMap(marker) => marker,
+            _ => panic!("expected EmptyMap ciphertext"),
+        };
+        assert!(
+            cipher
+                .decrypt_with_aad::<Vec<String>, _>(
+                    AesCipherText::EmptySequence(map_marker),
+                    "context",
+                )
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn empty_composite_markers_reject_nonempty_plaintext() {
+        let key = Key::from([42u8; 32]);
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+        let aad = empty_sequence_aad(Aad::from_slice(b"context"));
+        let marker = match "not-empty"
+            .encrypt_with_aad(&cipher, aad)
+            .expect("Encryption failed")
+        {
+            AesCipherText::Single(marker) => marker,
+            _ => panic!("expected Single ciphertext"),
+        };
+
+        assert!(cipher
+            .decrypt_with_aad::<Vec<String>, _>(AesCipherText::EmptySequence(marker), "context",)
+            .is_err());
     }
 
     #[test]
@@ -1308,7 +1498,7 @@ mod test {
             .unwrap()
             .encrypt_next("third", ())
             .unwrap()
-            .end()
+            .end(())
             .unwrap();
         match ct {
             AesCipherText::Sequence(items) => {
@@ -1335,7 +1525,7 @@ mod test {
             .unwrap()
             .passthrough_entry("schema_version", 1u32)
             .unwrap()
-            .end()
+            .end(())
             .unwrap();
         assert!(cipher.decrypt::<HashMap<String, String>>(ct).is_err());
     }

--- a/packages/encrypt/src/cipher.rs
+++ b/packages/encrypt/src/cipher.rs
@@ -80,16 +80,6 @@ impl Aes256Cipher {
     }
 }
 
-fn empty_sequence_aad<'a>(aad: Aad<'a>) -> Aad<'a> {
-    let domain: &'a [u8] = b"vitaminc/aead/empty-sequence/v1";
-    (domain, aad).into_aad()
-}
-
-fn empty_map_aad<'a>(aad: Aad<'a>) -> Aad<'a> {
-    let domain: &'a [u8] = b"vitaminc/aead/empty-map/v1";
-    (domain, aad).into_aad()
-}
-
 impl<'c> Cipher for &'c Aes256Cipher {
     type Ok = AesCipherText;
     type Error = Unspecified;
@@ -124,6 +114,7 @@ impl<'c> Cipher for &'c Aes256Cipher {
         AesSeqCipher {
             cipher: self,
             items: Vec::with_capacity(size_hint.unwrap_or(0)),
+            encrypted: false,
         }
     }
 
@@ -132,6 +123,7 @@ impl<'c> Cipher for &'c Aes256Cipher {
             cipher: self,
             entries: Vec::new(),
             current_key: None,
+            encrypted: false,
         }
     }
 
@@ -139,7 +131,10 @@ impl<'c> Cipher for &'c Aes256Cipher {
     where
         A: IntoAad<'a>,
     {
-        self.seal_empty_marker(aad).map(AesCipherText::None)
+        // Domain-separated so a `Single` leaf sealed under the bare AAD can
+        // never be re-tagged as an authenticated absence (and vice versa).
+        self.seal_empty_marker(aad.into_aad().for_none())
+            .map(AesCipherText::None)
     }
 
     fn passthrough<T>(self, value: T) -> Result<Self::Ok, Self::Error>
@@ -156,6 +151,11 @@ impl<'c> Cipher for &'c Aes256Cipher {
 pub struct AesSeqCipher<'c> {
     cipher: &'c Aes256Cipher,
     items: Vec<AesCipherText>,
+    /// Whether at least one item was appended through the authenticated
+    /// [`encrypt_next`](SeqCipher::encrypt_next) path. Passthrough items
+    /// authenticate nothing, so a sequence with items but no encrypted ones
+    /// would otherwise carry no AEAD tag at all — see [`end`](SeqCipher::end).
+    encrypted: bool,
 }
 
 impl<'c> SeqCipher for AesSeqCipher<'c> {
@@ -169,6 +169,7 @@ impl<'c> SeqCipher for AesSeqCipher<'c> {
     {
         let encrypted = data.encrypt_with_aad(self.cipher, aad)?;
         self.items.push(encrypted);
+        self.encrypted = true;
         Ok(self)
     }
 
@@ -185,10 +186,16 @@ impl<'c> SeqCipher for AesSeqCipher<'c> {
         A: IntoAad<'a>,
     {
         if self.items.is_empty() {
-            let aad = empty_sequence_aad(aad.into_aad());
             self.cipher
-                .seal_empty_marker(aad)
+                .seal_empty_marker(aad.into_aad().for_empty_sequence())
                 .map(AesCipherText::EmptySequence)
+        } else if !self.encrypted {
+            // Every item is a passthrough: nothing in the container
+            // authenticates the AAD (or, when the sequence is a map value,
+            // its entry key). Such a container would decrypt under any AAD,
+            // so refuse to produce it — all-passthrough data has no business
+            // going through a cipher.
+            Err(Unspecified)
         } else {
             Ok(AesCipherText::Sequence(self.items))
         }
@@ -217,6 +224,10 @@ pub struct AesMapCipher<'c> {
     cipher: &'c Aes256Cipher,
     entries: Vec<(String, AesCipherText)>,
     current_key: Option<Cow<'static, str>>,
+    /// Whether at least one entry was appended through the authenticated
+    /// [`encrypt_value`](MapCipher::encrypt_value) path — see
+    /// [`AesSeqCipher::encrypted`] and [`end`](MapCipher::end).
+    encrypted: bool,
 }
 
 impl<'c> MapCipher for AesMapCipher<'c> {
@@ -249,6 +260,7 @@ impl<'c> MapCipher for AesMapCipher<'c> {
         let entry_aad = aad.into_aad().for_map_entry(&key);
         let encrypted = value.encrypt_with_aad(self.cipher, entry_aad)?;
         self.entries.push((key.into_owned(), encrypted));
+        self.encrypted = true;
         Ok(self)
     }
 
@@ -280,10 +292,13 @@ impl<'c> MapCipher for AesMapCipher<'c> {
             return Err(Unspecified);
         }
         if self.entries.is_empty() {
-            let aad = empty_map_aad(aad.into_aad());
             self.cipher
-                .seal_empty_marker(aad)
+                .seal_empty_marker(aad.into_aad().for_empty_map())
                 .map(AesCipherText::EmptyMap)
+        } else if !self.encrypted {
+            // Every entry is a passthrough: nothing authenticates the AAD or
+            // the entry keys — see `AesSeqCipher::end`.
+            Err(Unspecified)
         } else {
             Ok(AesCipherText::Map(self.entries))
         }
@@ -408,7 +423,15 @@ impl<'c> Decipher<'c> for AesDecipher<'c> {
         A: IntoAad<'a>,
     {
         match self.ciphertext {
-            AesCipherText::Sequence(items) if !items.is_empty() => {
+            // At least one non-passthrough item is required: passthrough
+            // items authenticate nothing, so an all-passthrough sequence
+            // (which `AesSeqCipher::end` refuses to produce) would decrypt
+            // under any AAD. Mirrors the encrypt-side rejection.
+            AesCipherText::Sequence(items)
+                if items
+                    .iter()
+                    .any(|i| !matches!(i, AesCipherText::Passthrough(_))) =>
+            {
                 let seq_access = AesSeqAccess {
                     cipher: self.cipher,
                     items: items.into_iter(),
@@ -417,8 +440,12 @@ impl<'c> Decipher<'c> for AesDecipher<'c> {
                 visitor.visit_seq(seq_access)
             }
             AesCipherText::EmptySequence(ct) => {
-                let aad = empty_sequence_aad(aad.into_aad());
-                Self::verify_empty_marker(self.cipher, ct, aad.as_bytes())?;
+                let aad = aad.into_aad();
+                Self::verify_empty_marker(self.cipher, ct, aad.for_empty_sequence().as_bytes())?;
+                // Store the caller's raw AAD, not the marker derivation: the
+                // iterator is empty so it is never read today, but a wrapped
+                // value here would silently diverge from the encrypt side if
+                // a future visitor consulted it.
                 let seq_access = AesSeqAccess {
                     cipher: self.cipher,
                     items: Vec::new().into_iter(),
@@ -436,7 +463,12 @@ impl<'c> Decipher<'c> for AesDecipher<'c> {
         A: IntoAad<'a>,
     {
         match self.ciphertext {
-            AesCipherText::Map(entries) if !entries.is_empty() => {
+            // At least one non-passthrough entry required — see `decrypt_seq`.
+            AesCipherText::Map(entries)
+                if entries
+                    .iter()
+                    .any(|(_, v)| !matches!(v, AesCipherText::Passthrough(_))) =>
+            {
                 let map_access = AesMapAccess {
                     cipher: self.cipher,
                     entries: entries.into_iter(),
@@ -445,8 +477,9 @@ impl<'c> Decipher<'c> for AesDecipher<'c> {
                 visitor.visit_map(map_access)
             }
             AesCipherText::EmptyMap(ct) => {
-                let aad = empty_map_aad(aad.into_aad());
-                Self::verify_empty_marker(self.cipher, ct, aad.as_bytes())?;
+                let aad = aad.into_aad();
+                Self::verify_empty_marker(self.cipher, ct, aad.for_empty_map().as_bytes())?;
+                // Raw caller AAD, not the marker derivation — see `decrypt_seq`.
                 let map_access = AesMapAccess {
                     cipher: self.cipher,
                     entries: Vec::new().into_iter(),
@@ -477,9 +510,13 @@ impl<'c> Decipher<'c> for AesDecipher<'c> {
     {
         match self.ciphertext {
             AesCipherText::None(ct) => {
-                // Verify the AAD-bound tag over the empty plaintext.
+                // Verify the tag over the domain-separated marker AAD AND
+                // that the sealed plaintext is actually empty. Without both,
+                // a `Single(leaf)` sealed under the same caller AAD could be
+                // re-tagged as `None(leaf)` and decrypt as Ok(None) — silent
+                // authenticated data deletion.
                 let aad = aad.into_aad();
-                Self::decrypt_local_ciphertext(self.cipher, ct, aad.as_bytes())?;
+                Self::verify_empty_marker(self.cipher, ct, aad.for_none().as_bytes())?;
                 Ok(None)
             }
             // Passthrough must never be decoded as an Option payload.
@@ -1077,15 +1114,19 @@ mod test {
     fn passthrough_entry_succeeds_with_no_pending_key() {
         let key = Key::from([42u8; 32]);
         let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
-        // Sanity: the new guard does not break the happy path.
+        // Sanity: the new guard does not break the happy path. An encrypted
+        // sibling is included because an all-passthrough map is rejected at
+        // end() — see `all_passthrough_map_fails_to_encrypt`.
         let ciphertext = (&cipher)
             .encrypt_map()
             .passthrough_entry("version", 1u32)
+            .and_then(|m| m.encrypt_key("email"))
+            .and_then(|m| m.encrypt_value("ada@example.com", ()))
             .and_then(|m| m.end(()))
             .expect("passthrough_entry should succeed without a pending key");
         match ciphertext {
             AesCipherText::Map(entries) => {
-                assert_eq!(entries.len(), 1);
+                assert_eq!(entries.len(), 2);
                 assert_eq!(entries[0].0, "version");
                 assert!(matches!(entries[0].1, AesCipherText::Passthrough(_)));
             }
@@ -1186,6 +1227,99 @@ mod test {
             .is_err());
     }
 
+    // --- All-passthrough composites ---
+    //
+    // Passthrough items authenticate nothing, so a composite containing only
+    // passthrough items would carry no AEAD tag at all: it would "decrypt"
+    // under any AAD, and as a map value its cleartext key could be renamed
+    // undetected. Both sides refuse: `end()` won't produce such a container,
+    // and the decrypt arms reject one arriving from storage.
+
+    #[test]
+    fn all_passthrough_sequence_fails_to_encrypt() {
+        let key = Key::from([42u8; 32]);
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+        let result = (&cipher)
+            .encrypt_seq(Some(1))
+            .passthrough_next(1u32)
+            .and_then(|s| s.end("context"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn all_passthrough_map_fails_to_encrypt() {
+        let key = Key::from([42u8; 32]);
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+        let result = (&cipher)
+            .encrypt_map()
+            .passthrough_entry("version", 1u32)
+            .and_then(|m| m.end("context"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn all_passthrough_composites_fail_to_decrypt() {
+        let key = Key::from([42u8; 32]);
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+
+        let hostile_seq = AesCipherText::Sequence(vec![AesCipherText::Passthrough(Box::new(1u32))]);
+        assert!(cipher.decrypt::<Vec<String>>(hostile_seq).is_err());
+
+        let hostile_map = AesCipherText::Map(vec![(
+            "version".to_string(),
+            AesCipherText::Passthrough(Box::new(1u32)),
+        )]);
+        assert!(cipher
+            .decrypt::<HashMap<String, String>>(hostile_map)
+            .is_err());
+    }
+
+    // --- None marker integrity ---
+    //
+    // The None marker is sealed under `Aad::for_none` and verified to contain
+    // an empty plaintext, so a `Single` leaf can't be re-tagged as an
+    // authenticated absence (silent data deletion), nor an absence as an
+    // encrypted empty byte string.
+
+    #[test]
+    fn single_retagged_as_none_fails_to_decrypt() {
+        let key = Key::from([42u8; 32]);
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+        let leaf = match "secret".encrypt_with_aad(&cipher, "context").unwrap() {
+            AesCipherText::Single(leaf) => leaf,
+            _ => panic!("expected Single ciphertext"),
+        };
+        let result: Result<Option<String>, _> =
+            cipher.decrypt_with_aad(AesCipherText::None(leaf), "context");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn empty_single_retagged_as_none_fails_to_decrypt() {
+        // Even an EMPTY encrypted string can't masquerade as None: the marker
+        // AAD is domain-separated, not just emptiness-checked.
+        let key = Key::from([42u8; 32]);
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+        let leaf = match "".encrypt_with_aad(&cipher, "context").unwrap() {
+            AesCipherText::Single(leaf) => leaf,
+            _ => panic!("expected Single ciphertext"),
+        };
+        let result: Result<Option<String>, _> =
+            cipher.decrypt_with_aad(AesCipherText::None(leaf), "context");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn none_marker_still_roundtrips() {
+        let key = Key::from([42u8; 32]);
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+        let ct = Option::<String>::None
+            .encrypt_with_aad(&cipher, "context")
+            .unwrap();
+        let decrypted: Option<String> = cipher.decrypt_with_aad(ct, "context").unwrap();
+        assert_eq!(decrypted, None);
+    }
+
     #[test]
     fn empty_composite_markers_are_domain_separated() {
         let key = Key::from([42u8; 32]);
@@ -1226,7 +1360,7 @@ mod test {
     fn empty_composite_markers_reject_nonempty_plaintext() {
         let key = Key::from([42u8; 32]);
         let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
-        let aad = empty_sequence_aad(Aad::from_slice(b"context"));
+        let aad = Aad::from_slice(b"context").for_empty_sequence();
         let marker = match "not-empty"
             .encrypt_with_aad(&cipher, aad)
             .expect("Encryption failed")

--- a/packages/encrypt/src/cipher.rs
+++ b/packages/encrypt/src/cipher.rs
@@ -1,6 +1,7 @@
 use crate::backend::{CipherKey, NONCE_LEN};
 use crate::Key;
 use std::any::Any;
+use std::borrow::Cow;
 use vitaminc_aead::{
     Aad, Cipher, CipherTextBuilder, Decipher, DecipherVisitor, Decrypt, Encrypt, IntoAad,
     LocalCipherText, MapAccess, MapCipher, NonceGenerator, RandomNonceGenerator, SeqAccess,
@@ -165,7 +166,10 @@ impl<'c> SeqCipher for AesSeqCipher<'c> {
 
 /// [`MapCipher`] driver for [`Aes256Cipher`]. Keys are stored in the clear;
 /// values are encrypted under their own fresh nonce and accumulated into an
-/// [`AesCipherText::Map`].
+/// [`AesCipherText::Map`]. Each value is sealed against
+/// [`Aad::for_map_entry`] of the caller's AAD and its key, so swapping or
+/// renaming keys in a stored ciphertext fails decryption (passthrough
+/// entries excepted — they are unauthenticated by design).
 ///
 /// This driver is intended for encrypting sources that already enforce key
 /// uniqueness themselves — `HashMap`s and structs (whose field names are
@@ -181,21 +185,24 @@ impl<'c> SeqCipher for AesSeqCipher<'c> {
 pub struct AesMapCipher<'c> {
     cipher: &'c Aes256Cipher,
     entries: Vec<(String, AesCipherText)>,
-    current_key: Option<&'static str>,
+    current_key: Option<Cow<'static, str>>,
 }
 
 impl<'c> MapCipher for AesMapCipher<'c> {
     type Ok = AesCipherText;
     type Error = Unspecified;
 
-    fn encrypt_key(mut self, key: &'static str) -> Result<Self, Self::Error> {
+    fn encrypt_key<K>(mut self, key: K) -> Result<Self, Self::Error>
+    where
+        K: Into<Cow<'static, str>>,
+    {
         // A key already pending means `encrypt_key` was called twice with no
         // intervening `encrypt_value` — a trait-contract violation. Fail rather
         // than silently drop the first key.
         if self.current_key.is_some() {
             return Err(Unspecified);
         }
-        self.current_key = Some(key);
+        self.current_key = Some(key.into());
         Ok(self)
     }
 
@@ -205,13 +212,18 @@ impl<'c> MapCipher for AesMapCipher<'c> {
         A: IntoAad<'a>,
     {
         let key = self.current_key.take().ok_or(Unspecified)?;
-        let encrypted = value.encrypt_with_aad(self.cipher, aad)?;
-        self.entries.push((key.to_string(), encrypted));
+        // Seal against PAE(domain, aad, key) — the trait contract that makes
+        // key and value inseparable. `AesMapAccess::next_entry` derives the
+        // same AAD on decrypt.
+        let entry_aad = aad.into_aad().for_map_entry(&key);
+        let encrypted = value.encrypt_with_aad(self.cipher, entry_aad)?;
+        self.entries.push((key.into_owned(), encrypted));
         Ok(self)
     }
 
-    fn passthrough_entry<T>(mut self, key: &'static str, value: T) -> Result<Self, Self::Error>
+    fn passthrough_entry<K, T>(mut self, key: K, value: T) -> Result<Self, Self::Error>
     where
+        K: Into<Cow<'static, str>>,
         T: Any + Send + 'static,
     {
         // A key already pending means `encrypt_key` ran without a matching
@@ -221,8 +233,10 @@ impl<'c> MapCipher for AesMapCipher<'c> {
         if self.current_key.is_some() {
             return Err(Unspecified);
         }
-        self.entries
-            .push((key.to_string(), AesCipherText::Passthrough(Box::new(value))));
+        self.entries.push((
+            key.into().into_owned(),
+            AesCipherText::Passthrough(Box::new(value)),
+        ));
         Ok(self)
     }
 
@@ -457,8 +471,10 @@ impl<'c, 'a> MapAccess<'c> for AesMapAccess<'c, 'a> {
             None => return Ok(None),
         };
         let decipher = self.cipher.decipher(ct);
-        // Borrow the stored AAD bytes per entry — see `AesSeqAccess::next_element`.
-        let value = T::decrypt_with_aad(decipher, self.aad.as_bytes())?;
+        // Mirror `AesMapCipher::encrypt_value`: the value was sealed against
+        // PAE(domain, aad, key), so a swapped or renamed key fails here.
+        let entry_aad = self.aad.for_map_entry(&key);
+        let value = T::decrypt_with_aad(decipher, entry_aad)?;
         Ok(Some((key, value)))
     }
 }
@@ -971,6 +987,88 @@ mod test {
             }
             _ => panic!("expected Map ciphertext"),
         }
+    }
+
+    // --- Map key authentication ---
+    //
+    // Each map value is sealed against `Aad::for_map_entry(aad, key)`, so key
+    // and value are cryptographically inseparable: an attacker who swaps or
+    // renames the cleartext keys inside a stored ciphertext cannot produce a
+    // map that still decrypts.
+
+    fn encrypted_two_entry_map(cipher: &Aes256Cipher) -> Vec<(String, AesCipherText)> {
+        let mut map = HashMap::new();
+        map.insert("a", 1u32);
+        map.insert("b", 2u32);
+        match map.encrypt(cipher).expect("Encryption failed") {
+            AesCipherText::Map(entries) => entries,
+            _ => panic!("expected Map ciphertext"),
+        }
+    }
+
+    #[test]
+    fn swapped_map_keys_fail_decryption() {
+        let key = Key::from([42u8; 32]);
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+        let mut entries = encrypted_two_entry_map(&cipher);
+
+        // Exchange the cleartext keys, leaving each value in place.
+        let (k0, k1) = (entries[0].0.clone(), entries[1].0.clone());
+        entries[0].0 = k1;
+        entries[1].0 = k0;
+
+        let result: Result<HashMap<String, u32>, _> = cipher.decrypt(AesCipherText::Map(entries));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn renamed_map_key_fails_decryption() {
+        let key = Key::from([42u8; 32]);
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+        let mut entries = encrypted_two_entry_map(&cipher);
+
+        entries[0].0 = "evil".to_string();
+
+        let result: Result<HashMap<String, u32>, _> = cipher.decrypt(AesCipherText::Map(entries));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn reordered_map_entries_still_decrypt() {
+        // Reordering entries WITHOUT touching the key↔value pairing is fine —
+        // a map is unordered, and each value stays sealed against its own key.
+        let key = Key::from([42u8; 32]);
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+        let mut entries = encrypted_two_entry_map(&cipher);
+
+        entries.swap(0, 1);
+
+        let decrypted: HashMap<String, u32> = cipher
+            .decrypt(AesCipherText::Map(entries))
+            .expect("reordered entries should decrypt");
+        assert_eq!(decrypted.len(), 2);
+    }
+
+    #[test]
+    fn runtime_string_keys_roundtrip() {
+        // Keys built at runtime (the FFI case) — exercises the
+        // `HashMap<String, T>` Encrypt impl and Cow-keyed `encrypt_key`.
+        let key = Key::from([42u8; 32]);
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+
+        let mut map: HashMap<String, String> = HashMap::new();
+        for id in 0..3 {
+            map.insert(format!("user:{id}"), format!("value-{id}"));
+        }
+
+        let ciphertext = map
+            .clone()
+            .encrypt_with_aad(&cipher, "context")
+            .expect("Encryption failed");
+        let decrypted: HashMap<String, String> = cipher
+            .decrypt_with_aad(ciphertext, "context")
+            .expect("Decryption failed");
+        assert_eq!(decrypted, map);
     }
 
     // --- Nonce uniqueness (fundamental AEAD property) ---

--- a/packages/encrypt/src/cipher.rs
+++ b/packages/encrypt/src/cipher.rs
@@ -110,19 +110,29 @@ impl<'c> Cipher for &'c Aes256Cipher {
             .map(AesCipherText::Single)
     }
 
-    fn encrypt_seq(self, size_hint: Option<usize>) -> Self::SeqCipher {
+    fn encrypt_seq<'a, A>(self, size_hint: Option<usize>, aad: A) -> Self::SeqCipher
+    where
+        A: IntoAad<'a>,
+    {
         AesSeqCipher {
             cipher: self,
             items: Vec::with_capacity(size_hint.unwrap_or(0)),
+            // Owned once here, then borrowed per element — cheaper than the
+            // per-element clone the old AAD-per-call shape required.
+            aad: aad.into_aad().into_owned(),
             encrypted: false,
         }
     }
 
-    fn encrypt_map(self) -> Self::MapCipher {
+    fn encrypt_map<'a, A>(self, aad: A) -> Self::MapCipher
+    where
+        A: IntoAad<'a>,
+    {
         AesMapCipher {
             cipher: self,
             entries: Vec::new(),
             current_key: None,
+            aad: aad.into_aad().into_owned(),
             encrypted: false,
         }
     }
@@ -151,6 +161,9 @@ impl<'c> Cipher for &'c Aes256Cipher {
 pub struct AesSeqCipher<'c> {
     cipher: &'c Aes256Cipher,
     items: Vec<AesCipherText>,
+    /// The AAD fixed at [`Cipher::encrypt_seq`], applied to every element and
+    /// to the empty marker.
+    aad: Aad<'static>,
     /// Whether at least one item was appended through the authenticated
     /// [`encrypt_next`](SeqCipher::encrypt_next) path. Passthrough items
     /// authenticate nothing, so a sequence with items but no encrypted ones
@@ -162,12 +175,12 @@ impl<'c> SeqCipher for AesSeqCipher<'c> {
     type Ok = AesCipherText;
     type Error = Unspecified;
 
-    fn encrypt_next<'a, T, A>(mut self, data: T, aad: A) -> Result<Self, Self::Error>
+    fn encrypt_next<T>(mut self, data: T) -> Result<Self, Self::Error>
     where
         T: Encrypt,
-        A: IntoAad<'a>,
     {
-        let encrypted = data.encrypt_with_aad(self.cipher, aad)?;
+        // Borrow the stored AAD — no allocation per element.
+        let encrypted = data.encrypt_with_aad(self.cipher, Aad::from_slice(self.aad.as_bytes()))?;
         self.items.push(encrypted);
         self.encrypted = true;
         Ok(self)
@@ -181,13 +194,10 @@ impl<'c> SeqCipher for AesSeqCipher<'c> {
         Ok(self)
     }
 
-    fn end<'a, A>(self, aad: A) -> Result<Self::Ok, Self::Error>
-    where
-        A: IntoAad<'a>,
-    {
+    fn end(self) -> Result<Self::Ok, Self::Error> {
         if self.items.is_empty() {
             self.cipher
-                .seal_empty_marker(aad.into_aad().for_empty_sequence())
+                .seal_empty_marker(self.aad.for_empty_sequence())
                 .map(AesCipherText::EmptySequence)
         } else if !self.encrypted {
             // Every item is a passthrough: nothing in the container
@@ -224,6 +234,10 @@ pub struct AesMapCipher<'c> {
     cipher: &'c Aes256Cipher,
     entries: Vec<(String, AesCipherText)>,
     current_key: Option<Cow<'static, str>>,
+    /// The AAD fixed at [`Cipher::encrypt_map`]. Each entry's value is sealed
+    /// against `for_map_entry` of this; the empty marker against
+    /// `for_empty_map` of it.
+    aad: Aad<'static>,
     /// Whether at least one entry was appended through the authenticated
     /// [`encrypt_value`](MapCipher::encrypt_value) path — see
     /// [`AesSeqCipher::encrypted`] and [`end`](MapCipher::end).
@@ -248,16 +262,15 @@ impl<'c> MapCipher for AesMapCipher<'c> {
         Ok(self)
     }
 
-    fn encrypt_value<'a, U, A>(mut self, value: U, aad: A) -> Result<Self, Self::Error>
+    fn encrypt_value<U>(mut self, value: U) -> Result<Self, Self::Error>
     where
         U: Encrypt,
-        A: IntoAad<'a>,
     {
         let key = self.current_key.take().ok_or(Unspecified)?;
         // Seal against PAE(domain, aad, key) — the trait contract that makes
         // key and value inseparable. `AesMapAccess::next_entry` derives the
         // same AAD on decrypt.
-        let entry_aad = aad.into_aad().for_map_entry(&key);
+        let entry_aad = self.aad.for_map_entry(&key);
         let encrypted = value.encrypt_with_aad(self.cipher, entry_aad)?;
         self.entries.push((key.into_owned(), encrypted));
         self.encrypted = true;
@@ -283,17 +296,14 @@ impl<'c> MapCipher for AesMapCipher<'c> {
         Ok(self)
     }
 
-    fn end<'a, A>(self, aad: A) -> Result<Self::Ok, Self::Error>
-    where
-        A: IntoAad<'a>,
-    {
+    fn end(self) -> Result<Self::Ok, Self::Error> {
         // Finalising with a pending key would silently drop the entry.
         if self.current_key.is_some() {
             return Err(Unspecified);
         }
         if self.entries.is_empty() {
             self.cipher
-                .seal_empty_marker(aad.into_aad().for_empty_map())
+                .seal_empty_marker(self.aad.for_empty_map())
                 .map(AesCipherText::EmptyMap)
         } else if !self.encrypted {
             // Every entry is a passthrough: nothing authenticates the AAD or
@@ -1081,7 +1091,7 @@ mod test {
     fn encrypt_key_twice_without_value_fails() {
         let key = Key::from([42u8; 32]);
         let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
-        let map = (&cipher).encrypt_map().encrypt_key("first").unwrap();
+        let map = (&cipher).encrypt_map(()).encrypt_key("first").unwrap();
         assert!(map.encrypt_key("second").is_err());
     }
 
@@ -1089,15 +1099,15 @@ mod test {
     fn encrypt_value_without_pending_key_fails() {
         let key = Key::from([42u8; 32]);
         let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
-        let map = (&cipher).encrypt_map();
-        assert!(map.encrypt_value("orphan-value", ()).is_err());
+        let map = (&cipher).encrypt_map(());
+        assert!(map.encrypt_value("orphan-value").is_err());
     }
 
     #[test]
     fn passthrough_entry_with_pending_key_fails() {
         let key = Key::from([42u8; 32]);
         let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
-        let map = (&cipher).encrypt_map().encrypt_key("pending").unwrap();
+        let map = (&cipher).encrypt_map(()).encrypt_key("pending").unwrap();
         // Adopting the new key here would silently drop "pending".
         assert!(map.passthrough_entry("other", 42u32).is_err());
     }
@@ -1106,8 +1116,8 @@ mod test {
     fn end_with_pending_key_fails() {
         let key = Key::from([42u8; 32]);
         let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
-        let map = (&cipher).encrypt_map().encrypt_key("pending").unwrap();
-        assert!(map.end(()).is_err());
+        let map = (&cipher).encrypt_map(()).encrypt_key("pending").unwrap();
+        assert!(map.end().is_err());
     }
 
     #[test]
@@ -1118,11 +1128,11 @@ mod test {
         // sibling is included because an all-passthrough map is rejected at
         // end() — see `all_passthrough_map_fails_to_encrypt`.
         let ciphertext = (&cipher)
-            .encrypt_map()
+            .encrypt_map(())
             .passthrough_entry("version", 1u32)
             .and_then(|m| m.encrypt_key("email"))
-            .and_then(|m| m.encrypt_value("ada@example.com", ()))
-            .and_then(|m| m.end(()))
+            .and_then(|m| m.encrypt_value("ada@example.com"))
+            .and_then(|m| m.end())
             .expect("passthrough_entry should succeed without a pending key");
         match ciphertext {
             AesCipherText::Map(entries) => {
@@ -1227,6 +1237,67 @@ mod test {
             .is_err());
     }
 
+    // --- Composite AAD is fixed at construction ---
+    //
+    // The sub-cipher captures the AAD once, so a hand-written `Encrypt` impl
+    // has no second place to supply it and cannot seal the elements and the
+    // container under different AAD. Before this shape, an impl that threaded
+    // the real AAD to `encrypt_next` but `()` to `end` round-tripped happily
+    // with data and produced an undecryptable ciphertext the first time the
+    // collection was empty.
+
+    /// A hand-written `Encrypt` impl driving the sub-cipher directly, of the
+    /// kind a derive macro would generate.
+    struct Tags(Vec<String>);
+
+    impl Encrypt for Tags {
+        fn encrypt_with_aad<'a, C, A>(self, cipher: C, aad: A) -> Result<C::Ok, C::Error>
+        where
+            C: Cipher,
+            A: IntoAad<'a>,
+        {
+            let len = self.0.len();
+            self.0
+                .into_iter()
+                .try_fold(cipher.encrypt_seq(Some(len), aad), |c, item| {
+                    c.encrypt_next(item)
+                })?
+                .end()
+        }
+    }
+
+    #[test]
+    fn hand_written_impl_roundtrips_empty_and_nonempty() {
+        let key = Key::from([42u8; 32]);
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+
+        let ct = Tags(vec!["a".into(), "b".into()])
+            .encrypt_with_aad(&cipher, "user:42")
+            .expect("Encryption failed");
+        let out: Vec<String> = cipher
+            .decrypt_with_aad(ct, "user:42")
+            .expect("non-empty should decrypt");
+        assert_eq!(out, vec!["a".to_string(), "b".to_string()]);
+
+        // The case that used to break: no elements, so the marker's AAD is
+        // the only thing carrying the caller's context.
+        let ct = Tags(Vec::new())
+            .encrypt_with_aad(&cipher, "user:42")
+            .expect("Encryption failed");
+        let out: Vec<String> = cipher
+            .decrypt_with_aad(ct, "user:42")
+            .expect("empty should decrypt under the same AAD");
+        assert!(out.is_empty());
+
+        // And it is still AAD-sensitive — the marker binds "user:42".
+        let ct = Tags(Vec::new())
+            .encrypt_with_aad(&cipher, "user:42")
+            .expect("Encryption failed");
+        assert!(cipher
+            .decrypt_with_aad::<Vec<String>, _>(ct, "user:99")
+            .is_err());
+    }
+
     // --- All-passthrough composites ---
     //
     // Passthrough items authenticate nothing, so a composite containing only
@@ -1240,9 +1311,9 @@ mod test {
         let key = Key::from([42u8; 32]);
         let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
         let result = (&cipher)
-            .encrypt_seq(Some(1))
+            .encrypt_seq(Some(1), "context")
             .passthrough_next(1u32)
-            .and_then(|s| s.end("context"));
+            .and_then(|s| s.end());
         assert!(result.is_err());
     }
 
@@ -1251,9 +1322,9 @@ mod test {
         let key = Key::from([42u8; 32]);
         let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
         let result = (&cipher)
-            .encrypt_map()
+            .encrypt_map("context")
             .passthrough_entry("version", 1u32)
-            .and_then(|m| m.end("context"));
+            .and_then(|m| m.end());
         assert!(result.is_err());
     }
 
@@ -1642,14 +1713,14 @@ mod test {
     fn seq_cipher_accepts_mixed_encrypt_next_and_passthrough_next() {
         let cipher = Aes256Cipher::new(&Key::from([40u8; 32])).expect("Failed to create cipher");
         let ct = (&cipher)
-            .encrypt_seq(Some(3))
-            .encrypt_next("first", ())
+            .encrypt_seq(Some(3), ())
+            .encrypt_next("first")
             .unwrap()
             .passthrough_next(99u32)
             .unwrap()
-            .encrypt_next("third", ())
+            .encrypt_next("third")
             .unwrap()
-            .end(())
+            .end()
             .unwrap();
         match ct {
             AesCipherText::Sequence(items) => {
@@ -1669,14 +1740,14 @@ mod test {
         // Passthrough variant, failing the whole decode.
         let cipher = Aes256Cipher::new(&Key::from([41u8; 32])).expect("Failed to create cipher");
         let ct = (&cipher)
-            .encrypt_map()
+            .encrypt_map(())
             .encrypt_key("name")
             .unwrap()
-            .encrypt_value("Alice".to_string(), ())
+            .encrypt_value("Alice".to_string())
             .unwrap()
             .passthrough_entry("schema_version", 1u32)
             .unwrap()
-            .end(())
+            .end()
             .unwrap();
         assert!(cipher.decrypt::<HashMap<String, String>>(ct).is_err());
     }

--- a/packages/encrypt/src/cipher.rs
+++ b/packages/encrypt/src/cipher.rs
@@ -734,6 +734,23 @@ mod test {
     }
 
     #[test]
+    fn roundtrip_empty_hashmap_with_aad() {
+        let key = Key::from([42u8; 32]);
+        let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
+        let plaintext = HashMap::<String, String>::new();
+
+        let ciphertext = plaintext
+            .clone()
+            .encrypt_with_aad(&cipher, "map-context")
+            .expect("Encryption failed");
+        let decrypted: HashMap<String, String> = cipher
+            .decrypt_with_aad(ciphertext, "map-context")
+            .expect("Decryption failed");
+
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
     fn decrypt_hashmap_fails_with_wrong_aad() {
         let key = Key::from([42u8; 32]);
         let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");

--- a/packages/encrypt/src/cipher_static.rs
+++ b/packages/encrypt/src/cipher_static.rs
@@ -4,7 +4,7 @@
 
 use crate::backend::NONCE_LEN;
 use crate::Aes256Cipher;
-use vitaminc_aead::hlist::{Absent, Encrypted, StaticCipher};
+use vitaminc_aead::hlist::{Absent, Encrypted, Entry, StaticCipher};
 use vitaminc_aead::{CipherTextBuilder, IntoAad, NonceGenerator, Unspecified};
 use vitaminc_protected::Protected;
 
@@ -27,21 +27,15 @@ impl StaticCipher for &Aes256Cipher {
     where
         A: IntoAad<'a>,
     {
-        let local = seal_into_local(self, Protected::new(Vec::new()), absent_aad(aad))?;
+        // `Aad::for_none` domain-separates the absence marker from an empty
+        // `Encrypted`: both seal an empty plaintext, so without it an
+        // `Absent` slot could be swapped for an empty `Encrypted` one (and
+        // vice versa) without tripping tag verification. Shared with the
+        // dynamic path's `Cipher::encrypt_none`, so both absence markers use
+        // one wire commitment. `verify_absent` re-derives the same AAD.
+        let local = seal_into_local(self, Protected::new(Vec::new()), aad.into_aad().for_none())?;
         Ok(Absent::from_local(local))
     }
-}
-
-/// Domain-separate the absence marker from an empty [`Encrypted`].
-///
-/// Both seal an empty plaintext, so without this their `LocalCipherText` bytes
-/// would be identical under the same `(key, AAD)` and an `Absent` slot could be
-/// swapped for an empty `Encrypted` one (and vice versa) without tripping tag
-/// verification. Prefixing a fixed label binds the "absent" role into the tag
-/// (PAE-encoded via the tuple `IntoAad` impl), so the two no longer
-/// cross-validate. `verify_absent` re-derives the same wrapped AAD.
-fn absent_aad<'a, A: IntoAad<'a>>(aad: A) -> (&'a [u8], A) {
-    (b"vitaminc:absent", aad)
 }
 
 impl Aes256Cipher {
@@ -68,7 +62,39 @@ impl Aes256Cipher {
         // Sealed plaintext is empty by construction; we only care about the
         // tag verification. The returned `Protected<Vec<u8>>` drops at the
         // end of this expression. The AAD is wrapped to match `encrypt_none`.
-        open_local(self, ct.into_local(), absent_aad(aad)).map(|_| ())
+        open_local(self, ct.into_local(), aad.into_aad().for_none()).map(|_| ())
+    }
+
+    /// Open a map [`Entry`]'s encrypted value, deriving the same
+    /// [`Aad::for_map_entry`](vitaminc_aead::Aad::for_map_entry) binding
+    /// [`StaticMapBuilder::encrypt_entry`] sealed it under — so an entry
+    /// whose cleartext key was renamed or swapped fails to open.
+    ///
+    /// [`StaticMapBuilder::encrypt_entry`]: vitaminc_aead::hlist::StaticMapBuilder::encrypt_entry
+    pub fn open_entry<'a, A>(
+        &self,
+        entry: Entry<Encrypted>,
+        aad: A,
+    ) -> Result<Protected<Vec<u8>>, Unspecified>
+    where
+        A: IntoAad<'a>,
+    {
+        let entry_aad = aad.into_aad().for_map_entry(entry.key);
+        open_local(self, entry.value.into_local(), entry_aad)
+    }
+
+    /// Verify a map [`Entry`]'s absent marker, key-bound like
+    /// [`open_entry`](Aes256Cipher::open_entry).
+    pub fn verify_absent_entry<'a, A>(
+        &self,
+        entry: Entry<Absent>,
+        aad: A,
+    ) -> Result<(), Unspecified>
+    where
+        A: IntoAad<'a>,
+    {
+        let entry_aad = aad.into_aad().for_map_entry(entry.key);
+        self.verify_absent(entry.value, entry_aad)
     }
 }
 
@@ -176,22 +202,27 @@ mod test {
         // Decryption is destructuring. No downcast, no shape check, no Box.
         let Map(HCons(prefs_e, HCons(nickname_e, HCons(version_e, HCons(pw_e, HNil))))) = user_ct;
 
+        assert_eq!(pw_e.key, "password_hash");
+        assert_eq!(version_e.key, "version");
+        assert_eq!(nickname_e.key, "nickname");
+        assert_eq!(prefs_e.key, "preferences");
+
+        let version: u8 = version_e.value.0; // typed access, no fallibility
         let pw = String::from_utf8(
             cipher
-                .open(pw_e.value, AAD)
+                .open_entry(pw_e, AAD)
                 .expect("open pw")
                 .risky_unwrap(),
         )
         .unwrap();
-        let version: u8 = version_e.value.0; // typed access, no fallibility
         cipher
-            .verify_absent(nickname_e.value, AAD)
+            .verify_absent_entry(nickname_e, AAD)
             .expect("verify none");
 
         let Map(HCons(theme_e, HNil)) = prefs_e.value;
         let theme = String::from_utf8(
             cipher
-                .open(theme_e.value, INNER_AAD)
+                .open_entry(theme_e, INNER_AAD)
                 .expect("open theme")
                 .risky_unwrap(),
         )
@@ -200,10 +231,45 @@ mod test {
         assert_eq!(pw, "argon2id$hash");
         assert_eq!(version, 3u8);
         assert_eq!(theme, "midnight");
-        assert_eq!(pw_e.key, "password_hash");
-        assert_eq!(version_e.key, "version");
-        assert_eq!(nickname_e.key, "nickname");
-        assert_eq!(prefs_e.key, "preferences");
+    }
+
+    // Entry values are sealed against `Aad::for_map_entry(aad, key)`, so a
+    // stored entry whose cleartext key is renamed (the untrusted-input path a
+    // future deserializer would expose) must fail to open — the same key-swap
+    // resistance the dynamic MapCipher enforces.
+
+    #[test]
+    fn static_entry_with_renamed_key_fails_to_open() {
+        let key = Key::from([9u8; 32]);
+        let cipher = Aes256Cipher::new(&key).expect("cipher init");
+        let map = (&cipher)
+            .encrypt_map()
+            .encrypt_entry("email", Protected::new(b"ada@example.com".to_vec()), AAD)
+            .expect("encrypt")
+            .end();
+        let Map(HCons(entry, HNil)) = map;
+        let renamed = Entry {
+            key: "backup_email",
+            value: entry.value,
+        };
+        assert!(cipher.open_entry(renamed, AAD).is_err());
+    }
+
+    #[test]
+    fn static_absent_entry_with_renamed_key_fails_to_verify() {
+        let key = Key::from([9u8; 32]);
+        let cipher = Aes256Cipher::new(&key).expect("cipher init");
+        let map = (&cipher)
+            .encrypt_map()
+            .none_entry("nickname", AAD)
+            .expect("encrypt none")
+            .end();
+        let Map(HCons(entry, HNil)) = map;
+        let renamed = Entry {
+            key: "email",
+            value: entry.value,
+        };
+        assert!(cipher.verify_absent_entry(renamed, AAD).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

First core-trait step toward NAPI/FFI encryption support: makes encrypted maps safe and usable for runtime-keyed data.

* **Map keys are now authenticated.** Keys travel in the clear inside `AesCipherText::Map`, and were previously not bound to their values — swapping or renaming keys in a stored ciphertext went undetected, silently reassigning encrypted values to different fields. Each value is now sealed against a new public helper `Aad::for_map_entry(aad, key)` = `PAE("vitaminc/aead/map-entry/v1", aad, key)`, applied symmetrically in `AesMapCipher::encrypt_value` and `AesMapAccess::next_entry`. The domain-separation label keeps entry AAD disjoint from user-composed tuple AAD (e.g. `ContextTag`'s `(aad, tag)` layout). The contract is documented on `MapCipher` and `MapAccess` for other cipher implementations.
* **Runtime-derived map keys.** `MapCipher::encrypt_key` / `passthrough_entry` / `encrypt_entry` now accept `impl Into<Cow<'static, str>>` instead of `&'static str` (source-compatible for existing callers), and `HashMap<String, T>` gains an `Encrypt` impl so runtime-keyed maps round-trip with the existing `Decrypt` impl. This is a prerequisite for encrypting JS objects across the upcoming NAPI boundary.

## Breaking changes

* **Ciphertext format:** map ciphertexts sealed before this change no longer decrypt (per-entry AAD derivation changed).
* **API:** third-party `MapCipher` implementations must update key-parameter signatures and perform the `Aad::for_map_entry` binding on both sides.

## Deliberately out of scope

Sequences have the analogous gap — elements are not bound to their position or the sequence length, so reorder/truncation/duplication of `Vec` ciphertexts is undetectable. Ordered sequences (tuples) and order-independent collections (records encrypted for random-access database reads) need two distinct mechanisms, so this is deferred to cipherstash/vitaminc#252 — ideally resolved before 1.0 within the same format-breaking window as this change.

## Testing

* New tamper tests: swapped keys fail decryption; renamed key fails; reordering entries *without* touching key↔value pairing still succeeds (maps are unordered).
* New round-trip test for runtime `String` keys with AAD.
* Byte-level pinning tests for the `for_map_entry` encoding (exact PAE bytes, disjointness from tuple AAD, key sensitivity/injectivity).
* Full workspace suite, clippy, and `cargo fmt --check` clean. (`vitaminc-kms` integration test requires LocalStack on :4566 and is unaffected by this change.)

Closes #269
