### PR TITLE
feat(aead)!: shared generic CipherText container and typed passthrough currency

### DIFF
--- a/packages/aead/README.md
+++ b/packages/aead/README.md
@@ -45,6 +45,9 @@ pub struct MyMapCipher<'c>(&'c MyCipher /* + state */);
 impl<'c> Cipher for &'c MyCipher {
     type Ok = MyCipherText;
     type Error = Unspecified;
+    // The passthrough payload type: Box<dyn Any + Send> for Rust-native use
+    // (callers box in, downcast out), or an owned host-value type for FFI.
+    type Passthrough = Box<dyn Any + Send + 'static>;
     type SeqCipher = MySeqCipher<'c>;
     type MapCipher = MyMapCipher<'c>;
 
@@ -82,10 +85,7 @@ impl<'c> Cipher for &'c MyCipher {
         unimplemented!("produce an authenticated 'absent' marker bound to `aad`")
     }
 
-    fn passthrough<T>(self, _value: T) -> Result<Self::Ok, Self::Error>
-    where
-        T: Any + Send + 'static,
-    {
+    fn passthrough(self, _value: Self::Passthrough) -> Result<Self::Ok, Self::Error> {
         unimplemented!("store `value` unencrypted inside the cipher's output container")
     }
 }
@@ -93,16 +93,16 @@ impl<'c> Cipher for &'c MyCipher {
 impl<'c> SeqCipher for MySeqCipher<'c> {
     type Ok = MyCipherText;
     type Error = Unspecified;
+    type Passthrough = Box<dyn Any + Send + 'static>;
 
     fn encrypt_next<T>(self, _data: T) -> Result<Self, Self::Error>
     where
         T: vitaminc_aead::Encrypt,
     { unimplemented!() }
 
-    fn passthrough_next<T>(self, _value: T) -> Result<Self, Self::Error>
-    where
-        T: Any + Send + 'static,
-    { unimplemented!() }
+    fn passthrough_next(self, _value: Self::Passthrough) -> Result<Self, Self::Error> {
+        unimplemented!()
+    }
 
     fn end(self) -> Result<Self::Ok, Self::Error> { unimplemented!() }
 }
@@ -110,6 +110,7 @@ impl<'c> SeqCipher for MySeqCipher<'c> {
 impl<'c> MapCipher for MyMapCipher<'c> {
     type Ok = MyCipherText;
     type Error = Unspecified;
+    type Passthrough = Box<dyn Any + Send + 'static>;
 
     fn encrypt_key<K>(self, _key: K) -> Result<Self, Self::Error>
     where
@@ -124,10 +125,9 @@ impl<'c> MapCipher for MyMapCipher<'c> {
         T: vitaminc_aead::Encrypt,
     { unimplemented!() }
 
-    fn passthrough_entry<K, T>(self, _key: K, _value: T) -> Result<Self, Self::Error>
+    fn passthrough_entry<K>(self, _key: K, _value: Self::Passthrough) -> Result<Self, Self::Error>
     where
         K: Into<std::borrow::Cow<'static, str>>,
-        T: Any + Send + 'static,
     { unimplemented!() }
 
     fn end(self) -> Result<Self::Ok, Self::Error> { unimplemented!() }

--- a/packages/aead/src/cipher.rs
+++ b/packages/aead/src/cipher.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::borrow::Cow;
 
 use vitaminc_protected::{Controlled, Protected};
@@ -40,10 +39,19 @@ pub trait Cipher: Sized {
     /// The error type returned on cipher failure. Implementations should keep
     /// this opaque — see [`Unspecified`].
     type Error;
+    /// The payload type carried by [`passthrough`](Cipher::passthrough)
+    /// values.
+    ///
+    /// Rust-native ciphers typically use `Box<dyn Any + Send + 'static>`:
+    /// callers box on the way in and downcast on the way out. Ciphers
+    /// targeting an FFI boundary instead use an owned host-value type (e.g. a
+    /// converted JS value), carried value-in/value-out without the cipher ever
+    /// inspecting it.
+    type Passthrough;
     /// The sub-cipher returned by [`encrypt_seq`](Cipher::encrypt_seq).
-    type SeqCipher: SeqCipher<Ok = Self::Ok, Error = Self::Error>;
+    type SeqCipher: SeqCipher<Ok = Self::Ok, Error = Self::Error, Passthrough = Self::Passthrough>;
     /// The sub-cipher returned by [`encrypt_map`](Cipher::encrypt_map).
-    type MapCipher: MapCipher<Ok = Self::Ok, Error = Self::Error>;
+    type MapCipher: MapCipher<Ok = Self::Ok, Error = Self::Error, Passthrough = Self::Passthrough>;
 
     /// Encrypt the given byte vector with the supplied associated data.
     ///
@@ -122,26 +130,25 @@ pub trait Cipher: Sized {
     where
         A: IntoAad<'a>;
 
-    /// Pass a typed value through the cipher's output container **without**
+    /// Pass a value through the cipher's output container **without**
     /// encrypting it. Intended for fields that need to survive the encryption
     /// envelope in the clear (e.g. a schema version tag).
     ///
-    /// The value is typed at the API boundary but stored opaquely by the
-    /// cipher; the corresponding [`Decipher::decrypt_passthrough`] checks the
-    /// type at runtime.
+    /// The value has the cipher's [`Passthrough`](Cipher::Passthrough) type,
+    /// stored opaquely and returned as-is by the corresponding
+    /// [`Decipher::decrypt_passthrough`].
     ///
     /// # ⚠️ Non-sensitive data only
     ///
-    /// Passthrough values travel **in the clear** alongside the ciphertext.
-    /// Do not use this for secret-bearing data such as keys, plaintexts, or
-    /// credentials — there is no encryption, no zeroize discipline applied
-    /// to the boxed value, and no guarantee about when the storage is freed.
-    /// For secrets, use [`encrypt_with_aad`](crate::Encrypt::encrypt_with_aad)
-    /// (via the [`Encrypt`](crate::Encrypt) trait) or wrap in
+    /// Passthrough values travel **in the clear** alongside the ciphertext,
+    /// and — unlike map keys — are not authenticated either. Do not use this
+    /// for secret-bearing data such as keys, plaintexts, or credentials —
+    /// there is no encryption, no zeroize discipline applied to the payload,
+    /// and no guarantee about when the storage is freed. For secrets, use
+    /// [`encrypt_with_aad`](crate::Encrypt::encrypt_with_aad) (via the
+    /// [`Encrypt`](crate::Encrypt) trait) or wrap in
     /// [`vitaminc_protected::Protected`].
-    fn passthrough<T>(self, value: T) -> Result<Self::Ok, Self::Error>
-    where
-        T: Any + Send + 'static;
+    fn passthrough(self, value: Self::Passthrough) -> Result<Self::Ok, Self::Error>;
 }
 
 /// Sub-cipher driving the encryption of a sequence of values.
@@ -155,6 +162,9 @@ pub trait SeqCipher: Sized {
     type Ok;
     /// The error type for sequence operations.
     type Error;
+    /// The passthrough payload type — matches the parent
+    /// [`Cipher::Passthrough`].
+    type Passthrough;
 
     /// Encrypt the next element in the sequence, returning the updated cipher.
     ///
@@ -168,9 +178,7 @@ pub trait SeqCipher: Sized {
     ///
     /// See [`Cipher::passthrough`] — passthrough values are non-sensitive by
     /// design and must not carry secret data.
-    fn passthrough_next<T>(self, value: T) -> Result<Self, Self::Error>
-    where
-        T: Any + Send + 'static;
+    fn passthrough_next(self, value: Self::Passthrough) -> Result<Self, Self::Error>;
 
     /// Finalise the sequence and return the produced ciphertext container.
     ///
@@ -216,6 +224,9 @@ pub trait MapCipher: Sized {
     type Ok;
     /// The error type for map operations.
     type Error;
+    /// The passthrough payload type — matches the parent
+    /// [`Cipher::Passthrough`].
+    type Passthrough;
 
     /// Record the next key. Keys are stored in the clear — only values are
     /// encrypted — but each key is bound into its value's AAD (see the
@@ -258,10 +269,9 @@ pub trait MapCipher: Sized {
     /// See [`Cipher::passthrough`] — passthrough values are non-sensitive by
     /// design and must not carry secret data. Neither the value nor its key is
     /// authenticated.
-    fn passthrough_entry<K, T>(self, key: K, value: T) -> Result<Self, Self::Error>
+    fn passthrough_entry<K>(self, key: K, value: Self::Passthrough) -> Result<Self, Self::Error>
     where
-        K: Into<Cow<'static, str>>,
-        T: Any + Send + 'static;
+        K: Into<Cow<'static, str>>;
 
     /// Finalise the map and return the produced ciphertext container.
     ///

--- a/packages/aead/src/container.rs
+++ b/packages/aead/src/container.rs
@@ -1,0 +1,56 @@
+/// The recursive ciphertext container shared by tree-shaped [`Cipher`]
+/// implementations.
+///
+/// The shape mirrors the structure of the plaintext that was encrypted: a
+/// single value yields [`Single`](CipherText::Single), while non-empty `Vec`s
+/// and `HashMap`s yield [`Sequence`](CipherText::Sequence) and
+/// [`Map`](CipherText::Map). Empty composites use the authenticated marker
+/// variants [`EmptySequence`](CipherText::EmptySequence) and
+/// [`EmptyMap`](CipherText::EmptyMap), since they contain no element
+/// ciphertexts to authenticate the supplied AAD. Nested structures are
+/// represented recursively.
+///
+/// Concrete ciphers instantiate the two parameters:
+///
+/// - `Leaf` is the sealed leaf ciphertext (nonce + ciphertext + tag) — e.g.
+///   [`LocalCipherText`](crate::LocalCipherText) for a local AES cipher, or an
+///   envelope leaf that additionally carries a wrapped data key.
+/// - `P` is the passthrough payload type, fixed by the cipher's
+///   [`Cipher::Passthrough`](crate::Cipher::Passthrough) associated type.
+///   Rust-native ciphers typically use `Box<dyn Any + Send>`; FFI-targeting
+///   ciphers use an owned host-value type carried value-in/value-out.
+///
+/// Only the `Leaf` type carries a byte-level format commitment (and should
+/// implement `serde` where ciphertexts are persisted). The container itself
+/// has no canonical byte representation: hosts project it onto their native
+/// structures (e.g. a JS object tree across an FFI boundary), with leaves as
+/// opaque byte strings.
+///
+/// [`Cipher`]: crate::Cipher
+#[derive(Debug)]
+pub enum CipherText<Leaf, P> {
+    /// A single sealed value.
+    Single(Leaf),
+    /// A sequence of ciphertexts produced from a `Vec`-shaped plaintext.
+    Sequence(Vec<CipherText<Leaf, P>>),
+    /// An empty sequence, authenticated under domain-separated AAD via the
+    /// marker leaf produced at [`SeqCipher::end`](crate::SeqCipher::end).
+    EmptySequence(Leaf),
+    /// A map of (cleartext key, ciphertext value) pairs produced from a
+    /// map-shaped plaintext. Keys are stored in the clear but are bound into
+    /// each value's AAD via [`Aad::for_map_entry`](crate::Aad::for_map_entry),
+    /// so they cannot be swapped or renamed undetected (passthrough entries
+    /// excepted).
+    Map(Vec<(String, CipherText<Leaf, P>)>),
+    /// An empty map, authenticated under domain-separated AAD via the marker
+    /// leaf produced at [`MapCipher::end`](crate::MapCipher::end).
+    EmptyMap(Leaf),
+    /// The authenticated absent marker produced by
+    /// [`Cipher::encrypt_none`](crate::Cipher::encrypt_none). Stores a sealed
+    /// empty plaintext whose tag binds the supplied AAD.
+    None(Leaf),
+    /// A value passed through the container **unencrypted and
+    /// unauthenticated** via [`Cipher::passthrough`](crate::Cipher::passthrough).
+    /// Non-sensitive data only — see the trait docs.
+    Passthrough(P),
+}

--- a/packages/aead/src/context.rs
+++ b/packages/aead/src/context.rs
@@ -322,7 +322,6 @@ mod tests {
         cipher::{MapCipher, SeqCipher},
         DecipherVisitor, Unspecified,
     };
-    use std::any::Any;
     use std::cell::RefCell;
     use std::rc::Rc;
     use vitaminc_protected::{Controlled, Protected};
@@ -353,6 +352,7 @@ mod tests {
     impl Cipher for &MockCipher {
         type Ok = Vec<u8>;
         type Error = Unspecified;
+        type Passthrough = ();
         type SeqCipher = UnusedSeq;
         type MapCipher = UnusedMap;
 
@@ -390,10 +390,7 @@ mod tests {
             Ok(Vec::new())
         }
 
-        fn passthrough<U>(self, _value: U) -> Result<Self::Ok, Self::Error>
-        where
-            U: Any + Send + 'static,
-        {
+        fn passthrough(self, _value: Self::Passthrough) -> Result<Self::Ok, Self::Error> {
             Ok(Vec::new())
         }
     }
@@ -401,6 +398,7 @@ mod tests {
     impl SeqCipher for UnusedSeq {
         type Ok = Vec<u8>;
         type Error = Unspecified;
+        type Passthrough = ();
 
         fn encrypt_next<T>(self, _data: T) -> Result<Self, Self::Error>
         where
@@ -409,10 +407,7 @@ mod tests {
             Ok(self)
         }
 
-        fn passthrough_next<T>(self, _value: T) -> Result<Self, Self::Error>
-        where
-            T: Any + Send + 'static,
-        {
+        fn passthrough_next(self, _value: Self::Passthrough) -> Result<Self, Self::Error> {
             Ok(self)
         }
 
@@ -424,6 +419,7 @@ mod tests {
     impl MapCipher for UnusedMap {
         type Ok = Vec<u8>;
         type Error = Unspecified;
+        type Passthrough = ();
 
         fn encrypt_key<K>(self, _key: K) -> Result<Self, Self::Error>
         where
@@ -439,10 +435,13 @@ mod tests {
             Ok(self)
         }
 
-        fn passthrough_entry<K, T>(self, _key: K, _value: T) -> Result<Self, Self::Error>
+        fn passthrough_entry<K>(
+            self,
+            _key: K,
+            _value: Self::Passthrough,
+        ) -> Result<Self, Self::Error>
         where
             K: Into<std::borrow::Cow<'static, str>>,
-            T: Any + Send + 'static,
         {
             Ok(self)
         }
@@ -633,6 +632,8 @@ mod tests {
         where
             T: Send + 'c;
 
+        type Passthrough = ();
+
         fn map_ok<T, U, F>(ok: Self::Ok<T>, f: F) -> Self::Ok<U>
         where
             T: Send + 'c,
@@ -667,10 +668,7 @@ mod tests {
             None
         }
 
-        fn decrypt_passthrough<T>(self) -> Self::Ok<T>
-        where
-            T: Any + Send + 'static,
-        {
+        fn decrypt_passthrough(self) -> Self::Ok<Self::Passthrough> {
             None
         }
 

--- a/packages/aead/src/decipher/mod.rs
+++ b/packages/aead/src/decipher/mod.rs
@@ -1,7 +1,5 @@
 pub mod impls;
 
-use std::any::Any;
-
 use vitaminc_protected::Protected;
 
 use crate::{Aad, IntoAad, Unspecified};
@@ -30,6 +28,11 @@ pub trait Decipher<'c>: Sized {
     type Ok<T>
     where
         T: Send + 'c;
+
+    /// The payload type returned by
+    /// [`decrypt_passthrough`](Decipher::decrypt_passthrough) — matches the
+    /// encrypt-side [`Cipher::Passthrough`](crate::Cipher::Passthrough).
+    type Passthrough: Send + 'c;
 
     /// Transform the inner value of an [`Ok`](Decipher::Ok) container.
     ///
@@ -78,14 +81,17 @@ pub trait Decipher<'c>: Sized {
         A: IntoAad<'a>;
 
     /// Recover a value stored via [`Cipher::passthrough`](crate::Cipher::passthrough).
-    /// Returns an error if the ciphertext is not a passthrough or the stored
-    /// type does not match `T`.
+    /// Returns an error if the ciphertext is not a passthrough.
+    ///
+    /// The payload comes back as the decipher's
+    /// [`Passthrough`](Decipher::Passthrough) type, exactly as stored —
+    /// value-in/value-out. Where that type is `Box<dyn Any + Send>`, as it is
+    /// for Rust-native ciphers, callers downcast to a concrete type themselves
+    /// (concrete deciphers may offer a typed convenience for this).
     ///
     /// See [`Cipher::passthrough`] — passthrough values are non-sensitive by
     /// design and must not be used to carry secret data.
-    fn decrypt_passthrough<T>(self) -> Self::Ok<T>
-    where
-        T: Any + Send + 'static;
+    fn decrypt_passthrough(self) -> Self::Ok<Self::Passthrough>;
 
     /// Decrypt an `Option<T>`, authenticating against `aad`. The decipher inspects the
     /// ciphertext shape: a `None`-marker variant produces `Ok(None)` (after AAD

--- a/packages/aead/src/lib.rs
+++ b/packages/aead/src/lib.rs
@@ -3,6 +3,7 @@
 mod aad;
 mod cipher;
 mod ciphertext;
+mod container;
 mod context;
 mod decipher;
 mod encrypt;
@@ -16,6 +17,8 @@ pub use aad::{Aad, IntoAad};
 pub use cipher::{Cipher, MapCipher, SeqCipher, Unspecified};
 #[doc(inline)]
 pub use ciphertext::{CipherTextBuilder, LocalCipherText};
+#[doc(inline)]
+pub use container::CipherText;
 #[doc(inline)]
 pub use context::ContextTag;
 #[doc(inline)]

--- a/packages/encrypt/src/cipher.rs
+++ b/packages/encrypt/src/cipher.rs
@@ -3,42 +3,29 @@ use crate::Key;
 use std::any::Any;
 use std::borrow::Cow;
 use vitaminc_aead::{
-    Aad, Cipher, CipherTextBuilder, Decipher, DecipherVisitor, Decrypt, Encrypt, IntoAad,
-    LocalCipherText, MapAccess, MapCipher, NonceGenerator, RandomNonceGenerator, SeqAccess,
-    SeqCipher, Unspecified,
+    Aad, Cipher, CipherText, CipherTextBuilder, Decipher, DecipherVisitor, Decrypt, Encrypt,
+    IntoAad, LocalCipherText, MapAccess, MapCipher, NonceGenerator, RandomNonceGenerator,
+    SeqAccess, SeqCipher, Unspecified,
 };
 use vitaminc_protected::{Controlled, Protected};
 
-/// The recursive ciphertext container produced by [`Aes256Cipher`].
+/// The passthrough payload type used by [`Aes256Cipher`]: type-erased boxed
+/// values, downcast back to a concrete type at decrypt time via
+/// [`AesDecipher::decrypt_passthrough_as`].
+pub type BoxedPassthrough = Box<dyn Any + Send + 'static>;
+
+/// The recursive ciphertext container produced by [`Aes256Cipher`] — the
+/// shared [`CipherText`] tree instantiated with [`LocalCipherText`] leaves
+/// and [`BoxedPassthrough`] passthrough values.
 ///
 /// The shape mirrors the structure of the plaintext that was encrypted: a
-/// single value yields [`Single`](AesCipherText::Single), while non-empty
-/// `Vec`s and `HashMap`s yield [`Sequence`](AesCipherText::Sequence) and
-/// [`Map`](AesCipherText::Map). Empty composites use authenticated marker
-/// variants. Nested structures are represented recursively.
-#[derive(Debug)]
-pub enum AesCipherText {
-    /// A single sealed value (nonce + ciphertext + tag).
-    Single(LocalCipherText),
-    /// A sequence of ciphertexts produced from a `Vec`-shaped plaintext.
-    Sequence(Vec<AesCipherText>),
-    /// An empty sequence authenticated under domain-separated AAD.
-    EmptySequence(LocalCipherText),
-    /// A map of (cleartext key, ciphertext value) pairs produced from a
-    /// `HashMap`-shaped plaintext. Keys are not encrypted.
-    Map(Vec<(String, AesCipherText)>),
-    /// An empty map authenticated under domain-separated AAD.
-    EmptyMap(LocalCipherText),
-    /// The authenticated absent marker produced by [`Cipher::encrypt_none`].
-    /// Stores a sealed empty plaintext whose tag binds the supplied AAD.
-    None(LocalCipherText),
-    /// A typed value passed through unencrypted via [`Cipher::passthrough`].
-    /// Not serializable to bytes — see
-    /// `packages/aead/src/cipher.rs` for the API-level type bound and the
-    /// runtime downcast performed by
-    /// [`Decipher::decrypt_passthrough`](vitaminc_aead::Decipher::decrypt_passthrough).
-    Passthrough(Box<dyn Any + Send + 'static>),
-}
+/// single value yields [`Single`](CipherText::Single), while non-empty
+/// `Vec`s and `HashMap`s yield [`Sequence`](CipherText::Sequence) and
+/// [`Map`](CipherText::Map). Empty composites use the authenticated marker
+/// variants [`EmptySequence`](CipherText::EmptySequence) and
+/// [`EmptyMap`](CipherText::EmptyMap). Nested structures are represented
+/// recursively.
+pub type AesCipherText = CipherText<LocalCipherText, BoxedPassthrough>;
 
 /// Implements AES-256-GCM. Backend is selected at compile time:
 /// `aws-lc-rs` on native targets, `aes-gcm` (RustCrypto) on `wasm32`.
@@ -83,6 +70,7 @@ impl Aes256Cipher {
 impl<'c> Cipher for &'c Aes256Cipher {
     type Ok = AesCipherText;
     type Error = Unspecified;
+    type Passthrough = BoxedPassthrough;
     type SeqCipher = AesSeqCipher<'c>;
     type MapCipher = AesMapCipher<'c>;
 
@@ -147,11 +135,8 @@ impl<'c> Cipher for &'c Aes256Cipher {
             .map(AesCipherText::None)
     }
 
-    fn passthrough<T>(self, value: T) -> Result<Self::Ok, Self::Error>
-    where
-        T: Any + Send + 'static,
-    {
-        Ok(AesCipherText::Passthrough(Box::new(value)))
+    fn passthrough(self, value: Self::Passthrough) -> Result<Self::Ok, Self::Error> {
+        Ok(AesCipherText::Passthrough(value))
     }
 }
 
@@ -174,6 +159,7 @@ pub struct AesSeqCipher<'c> {
 impl<'c> SeqCipher for AesSeqCipher<'c> {
     type Ok = AesCipherText;
     type Error = Unspecified;
+    type Passthrough = BoxedPassthrough;
 
     fn encrypt_next<T>(mut self, data: T) -> Result<Self, Self::Error>
     where
@@ -186,11 +172,8 @@ impl<'c> SeqCipher for AesSeqCipher<'c> {
         Ok(self)
     }
 
-    fn passthrough_next<T>(mut self, value: T) -> Result<Self, Self::Error>
-    where
-        T: Any + Send + 'static,
-    {
-        self.items.push(AesCipherText::Passthrough(Box::new(value)));
+    fn passthrough_next(mut self, value: Self::Passthrough) -> Result<Self, Self::Error> {
+        self.items.push(AesCipherText::Passthrough(value));
         Ok(self)
     }
 
@@ -247,6 +230,7 @@ pub struct AesMapCipher<'c> {
 impl<'c> MapCipher for AesMapCipher<'c> {
     type Ok = AesCipherText;
     type Error = Unspecified;
+    type Passthrough = BoxedPassthrough;
 
     fn encrypt_key<K>(mut self, key: K) -> Result<Self, Self::Error>
     where
@@ -277,10 +261,9 @@ impl<'c> MapCipher for AesMapCipher<'c> {
         Ok(self)
     }
 
-    fn passthrough_entry<K, T>(mut self, key: K, value: T) -> Result<Self, Self::Error>
+    fn passthrough_entry<K>(mut self, key: K, value: Self::Passthrough) -> Result<Self, Self::Error>
     where
         K: Into<Cow<'static, str>>,
-        T: Any + Send + 'static,
     {
         // A key already pending means `encrypt_key` ran without a matching
         // `encrypt_value` — adopting it here would silently drop the pending
@@ -289,10 +272,8 @@ impl<'c> MapCipher for AesMapCipher<'c> {
         if self.current_key.is_some() {
             return Err(Unspecified);
         }
-        self.entries.push((
-            key.into().into_owned(),
-            AesCipherText::Passthrough(Box::new(value)),
-        ));
+        self.entries
+            .push((key.into().into_owned(), AesCipherText::Passthrough(value)));
         Ok(self)
     }
 
@@ -370,6 +351,20 @@ pub struct AesDecipher<'c> {
 }
 
 impl AesDecipher<'_> {
+    /// Typed convenience over [`Decipher::decrypt_passthrough`] for this
+    /// cipher's [`BoxedPassthrough`] payload type: recovers the payload and
+    /// downcasts it to `T`, returning [`Unspecified`] if the ciphertext is not
+    /// a passthrough or the stored type does not match.
+    pub fn decrypt_passthrough_as<T>(self) -> Result<T, Unspecified>
+    where
+        T: Any + Send + 'static,
+    {
+        self.decrypt_passthrough()?
+            .downcast::<T>()
+            .map(|b| *b)
+            .map_err(|_| Unspecified)
+    }
+
     fn decrypt_local_ciphertext(
         cipher: &Aes256Cipher,
         ct: LocalCipherText,
@@ -402,6 +397,8 @@ impl<'c> Decipher<'c> for AesDecipher<'c> {
         = Result<T, Unspecified>
     where
         T: Send + 'c;
+
+    type Passthrough = BoxedPassthrough;
 
     fn map_ok<T, U, F>(ok: Self::Ok<T>, f: F) -> Self::Ok<U>
     where
@@ -501,14 +498,9 @@ impl<'c> Decipher<'c> for AesDecipher<'c> {
         }
     }
 
-    fn decrypt_passthrough<T>(self) -> Self::Ok<T>
-    where
-        T: Any + Send + 'static,
-    {
+    fn decrypt_passthrough(self) -> Self::Ok<Self::Passthrough> {
         match self.ciphertext {
-            AesCipherText::Passthrough(boxed) => {
-                boxed.downcast::<T>().map(|b| *b).map_err(|_| Unspecified)
-            }
+            AesCipherText::Passthrough(boxed) => Ok(boxed),
             _ => Err(Unspecified),
         }
     }
@@ -1024,7 +1016,9 @@ mod test {
         // Type-laundering guard: a passthrough must not satisfy Option<T>.
         let key = Key::from([11u8; 32]);
         let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
-        let ciphertext = (&cipher).passthrough(42u32).expect("passthrough failed");
+        let ciphertext = (&cipher)
+            .passthrough(Box::new(42u32))
+            .expect("passthrough failed");
         assert!(cipher.decrypt::<Option<u32>>(ciphertext).is_err());
     }
 
@@ -1032,7 +1026,9 @@ mod test {
     fn roundtrip_passthrough_u32() {
         let key = Key::from([1u8; 32]);
         let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
-        let ciphertext = (&cipher).passthrough(12345u32).expect("passthrough failed");
+        let ciphertext = (&cipher)
+            .passthrough(Box::new(12345u32))
+            .expect("passthrough failed");
         let decrypted: u32 = decrypt_passthrough_via(&cipher, ciphertext).expect("decode failed");
         assert_eq!(decrypted, 12345u32);
     }
@@ -1042,7 +1038,7 @@ mod test {
         let key = Key::from([2u8; 32]);
         let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
         let ciphertext = (&cipher)
-            .passthrough(String::from("version-tag"))
+            .passthrough(Box::new(String::from("version-tag")))
             .expect("passthrough failed");
         let decrypted: String =
             decrypt_passthrough_via(&cipher, ciphertext).expect("decode failed");
@@ -1053,14 +1049,15 @@ mod test {
     fn passthrough_type_mismatch_returns_err() {
         let key = Key::from([3u8; 32]);
         let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
-        let ciphertext = (&cipher).passthrough(42u32).expect("passthrough failed");
+        let ciphertext = (&cipher)
+            .passthrough(Box::new(42u32))
+            .expect("passthrough failed");
         let result: Result<String, _> = decrypt_passthrough_via(&cipher, ciphertext);
         assert!(result.is_err());
     }
 
-    // Convenience: drive `Decipher::decrypt_passthrough` from a known
-    // ciphertext. Mirrors what a derive-generated `Decrypt` impl would do
-    // for a `#[encrypt(passthrough)]` field.
+    // Convenience: recover a typed passthrough from a known ciphertext via
+    // the decipher's `decrypt_passthrough_as` downcast helper.
     fn decrypt_passthrough_via<T>(
         cipher: &Aes256Cipher,
         ciphertext: AesCipherText,
@@ -1068,8 +1065,7 @@ mod test {
     where
         T: Any + Send + 'static,
     {
-        let decipher = cipher.decipher(ciphertext);
-        decipher.decrypt_passthrough::<T>()
+        cipher.decipher(ciphertext).decrypt_passthrough_as::<T>()
     }
 
     #[quickcheck]
@@ -1109,7 +1105,7 @@ mod test {
         let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
         let map = (&cipher).encrypt_map(()).encrypt_key("pending").unwrap();
         // Adopting the new key here would silently drop "pending".
-        assert!(map.passthrough_entry("other", 42u32).is_err());
+        assert!(map.passthrough_entry("other", Box::new(42u32)).is_err());
     }
 
     #[test]
@@ -1129,7 +1125,7 @@ mod test {
         // end() — see `all_passthrough_map_fails_to_encrypt`.
         let ciphertext = (&cipher)
             .encrypt_map(())
-            .passthrough_entry("version", 1u32)
+            .passthrough_entry("version", Box::new(1u32))
             .and_then(|m| m.encrypt_key("email"))
             .and_then(|m| m.encrypt_value("ada@example.com"))
             .and_then(|m| m.end())
@@ -1312,7 +1308,7 @@ mod test {
         let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
         let result = (&cipher)
             .encrypt_seq(Some(1), "context")
-            .passthrough_next(1u32)
+            .passthrough_next(Box::new(1u32))
             .and_then(|s| s.end());
         assert!(result.is_err());
     }
@@ -1323,7 +1319,7 @@ mod test {
         let cipher = Aes256Cipher::new(&key).expect("Failed to create cipher");
         let result = (&cipher)
             .encrypt_map("context")
-            .passthrough_entry("version", 1u32)
+            .passthrough_entry("version", Box::new(1u32))
             .and_then(|m| m.end());
         assert!(result.is_err());
     }
@@ -1532,7 +1528,7 @@ mod test {
         None::<String>.encrypt(cipher).expect("encrypt")
     }
     fn passthrough_ct(cipher: &Aes256Cipher) -> AesCipherText {
-        cipher.passthrough(7u32).expect("passthrough")
+        cipher.passthrough(Box::new(7u32)).expect("passthrough")
     }
 
     #[test]
@@ -1716,7 +1712,7 @@ mod test {
             .encrypt_seq(Some(3), ())
             .encrypt_next("first")
             .unwrap()
-            .passthrough_next(99u32)
+            .passthrough_next(Box::new(99u32))
             .unwrap()
             .encrypt_next("third")
             .unwrap()
@@ -1745,7 +1741,7 @@ mod test {
             .unwrap()
             .encrypt_value("Alice".to_string())
             .unwrap()
-            .passthrough_entry("schema_version", 1u32)
+            .passthrough_entry("schema_version", Box::new(1u32))
             .unwrap()
             .end()
             .unwrap();
@@ -1773,12 +1769,16 @@ mod test {
         // when the value is `Some(n)`. A passthrough sealed as `Option<u32>`
         // must only downcast back to `Option<u32>`.
         let cipher = Aes256Cipher::new(&Key::from([43u8; 32])).expect("Failed to create cipher");
-        let ct = cipher.passthrough(Some(42u32)).expect("passthrough failed");
+        let ct = cipher
+            .passthrough(Box::new(Some(42u32)))
+            .expect("passthrough failed");
         let decoded: Option<u32> =
             decrypt_passthrough_via(&cipher, ct).expect("decode as Option<u32> should succeed");
         assert_eq!(decoded, Some(42u32));
 
-        let ct2 = cipher.passthrough(Some(42u32)).expect("passthrough failed");
+        let ct2 = cipher
+            .passthrough(Box::new(Some(42u32)))
+            .expect("passthrough failed");
         assert!(
             decrypt_passthrough_via::<u32>(&cipher, ct2).is_err(),
             "Option<u32> passthrough must not downcast to u32"

--- a/packages/encrypt/src/lib.rs
+++ b/packages/encrypt/src/lib.rs
@@ -6,7 +6,7 @@ mod cipher;
 mod cipher_static;
 mod key;
 
-pub use cipher::{Aes256Cipher, AesCipherText, AesDecipher};
+pub use cipher::{Aes256Cipher, AesCipherText, AesDecipher, BoxedPassthrough};
 pub use key::Key;
 
 // Re-exports


### PR DESCRIPTION
## Summary

> ⚠️ **Stacked on** cipherstash/vitaminc#253 (`feat/aead-map-key-auth`) — the diff here is just the container extraction and passthrough refactor. Merge cipherstash/vitaminc#253 first, or retarget this to `main` once it lands.

Second core-trait step toward NAPI/FFI encryption support, and groundwork for `stack-encrypt` (cipherstash-suite#2019):

* **Shared generic container.** `vitaminc-aead` now provides `CipherText<Leaf, P>` — the recursive `Single`/`Sequence`/`Map`/`None`/`Passthrough` tree, generic over the sealed leaf type and the passthrough payload. `AesCipherText` becomes an alias for `CipherText<LocalCipherText, BoxedPassthrough>` (variant construction and matching are unaffected), and `ZeroKmsCipherText` in the suite can become `CipherText<DataKeyCipherText, _>` the same way. Downstream consumers — most immediately the NAPI container↔JS-object walk — get written once against the generic container instead of per cipher. Only `Leaf` carries a byte-format commitment; the container has no canonical byte form by design.
* **Typed passthrough currency.** The `Cipher`/`SeqCipher`/`MapCipher`/`Decipher` traits gain a `Passthrough` associated type, replacing the `T: Any + Send` generics on `passthrough`, `passthrough_next`, `passthrough_entry`, and `decrypt_passthrough`. A cipher declares its currency once: Rust-native ciphers use `Box<dyn Any + Send>` (callers box in; downcast out via the new typed convenience `AesDecipher::decrypt_passthrough_as::<T>()`), while FFI-targeting ciphers can declare an owned host-value type and carry passthrough values value-in/value-out with no type erasure — the NAPI case where a passthrough is "always a Value" and the cipher never inspects it.

## Breaking changes

* **API only, no ciphertext-format change.** Third-party `Cipher`/`SeqCipher`/`MapCipher` implementations add the `Passthrough` associated type and drop the generic parameters from the passthrough methods; `Decipher::decrypt_passthrough` now returns the currency directly rather than downcasting to a caller-chosen `T`.

## Testing

* Existing passthrough round-trip, type-mismatch, and state-machine tests all updated to the boxed currency and passing unchanged in behaviour.
* Full workspace suite, clippy, and `cargo fmt --check` clean (kms integration test still requires LocalStack; unrelated).

Closes cipherstash/vitaminc#270