### PR TITLE
fix(protected): harden digest secret lifecycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,6 +565,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
  "hybrid-array",
+ "zeroize",
 ]
 
 [[package]]
@@ -758,6 +759,7 @@ dependencies = [
  "const-oid",
  "crypto-common 0.2.1",
  "ctutils",
+ "zeroize",
 ]
 
 [[package]]

--- a/packages/protected/CHANGELOG.md
+++ b/packages/protected/CHANGELOG.md
@@ -1,4 +1,14 @@
 
+### Security
+
+- require `ProtectedDigest` state to implement `ZeroizeOnDrop`
+- write digest outputs directly into protected or explicitly public destinations
+
+### Breaking changes
+
+- remove return-by-value `ProtectedDigest` finalization helpers
+- add explicit public input and output methods to `ProtectedDigest`
+
 
 
 ### Miscellaneous

--- a/packages/protected/Cargo.toml
+++ b/packages/protected/Cargo.toml
@@ -27,7 +27,7 @@ vitaminc-protected-derive = { path = "../protected-derive", version = "0.2.0-pre
 [dev-dependencies]
 rmp-serde = "1.3.1"
 serde_json = "1.0.150"
-sha2 = "0.11.0"
+sha2 = { version = "0.11.0", features = ["zeroize"] }
 
 [features]
 bitvec = []

--- a/packages/protected/README.md
+++ b/packages/protected/README.md
@@ -131,6 +131,30 @@ assert_eq!(y.risky_unwrap(), [0u8; 32]);
 
 Use [flatten_array] to convert a `[Protected<T>; N]` into a `Protected<[T; N]>`.
 
+### Protected digests
+
+`ProtectedDigest` requires a digest implementation that zeroizes its internal
+state on drop. Enable the digest crate's zeroization feature, such as
+`sha2 = { version = "0.11", features = ["zeroize"] }`.
+
+Secret inputs use `update` and protected outputs use `finalize_into`. Public
+protocol framing and intentionally exposed outputs cross separate, explicitly
+named channels:
+
+```rust
+use sha2::Sha256;
+use vitaminc_protected::{Controlled, Protected, ProtectedDigest};
+
+let secret = Protected::new(*b"secret");
+let mut digest = ProtectedDigest::<Sha256>::new();
+digest.update_public(b"example/domain/v1");
+digest.update(&secret);
+
+let mut output = Protected::new([0u8; 32]);
+digest.finalize_into(&mut output);
+assert_ne!(output.risky_ref(), &[0u8; 32]);
+```
+
 ### Also in this crate
 
 Beyond the adapters above, the crate exports `TimingSafeEq` and `Choice` (timing-safe comparison), `OpaqueDebug` and `Redacted` (leak-resistant `Debug`), `ProtectedDigest`, `Zeroed`, and `AsProtectedRef` — see the [docs.rs API reference](https://docs.rs/vitaminc-protected) for details.

--- a/packages/protected/src/digest.rs
+++ b/packages/protected/src/digest.rs
@@ -7,12 +7,24 @@ use digest::FixedOutputReset;
 use digest::Output;
 use digest::OutputSizeUser;
 use digest::Reset;
+use zeroize::ZeroizeOnDrop;
 
-pub struct ProtectedDigest<D, InputScope = DefaultScope>(D, PhantomData<InputScope>);
+/// A digest whose implementation wipes its internal state on drop.
+///
+/// Secret inputs enter through [`update`](Self::update) and secret outputs are
+/// written directly into a [`Controlled`] destination by
+/// [`finalize_into`](Self::finalize_into). Public input and output crossings
+/// use explicitly named methods.
+pub struct ProtectedDigest<D, InputScope = DefaultScope>(D, PhantomData<InputScope>)
+where
+    D: Digest + ZeroizeOnDrop;
 
 // TODO: Implement Usage scopes
-// TODO: How can we force that the Digest types have Zeroize enabled? (Its a feature in the digest crate but in the 0.11.0.pre versions)
-impl<D: Digest, InputScope: Scope> ProtectedDigest<D, InputScope> {
+impl<D, InputScope> ProtectedDigest<D, InputScope>
+where
+    D: Digest + ZeroizeOnDrop,
+    InputScope: Scope,
+{
     pub fn new() -> Self {
         Self(D::new(), PhantomData)
     }
@@ -33,14 +45,16 @@ impl<D: Digest, InputScope: Scope> ProtectedDigest<D, InputScope> {
         self.0.update(data.risky_ref())
     }
 
-    pub fn finalize<T>(self) -> T
-    where
-        T: Controlled + From<Array<u8, <D as OutputSizeUser>::OutputSize>>,
-    {
-        let result = self.0.finalize();
-        result.into()
+    /// Add bytes that are intentionally public.
+    ///
+    /// This is an explicit escape from the protected-input channel for domain
+    /// separators, framing, and other non-secret protocol data.
+    pub fn update_public(&mut self, data: &[u8]) {
+        self.0.update(data)
     }
 
+    /// Finalize directly into a protected destination without creating an
+    /// ordinary intermediate digest array.
     pub fn finalize_into<'m, T>(self, out: &'m mut T)
     where
         T: Controlled,
@@ -50,22 +64,34 @@ impl<D: Digest, InputScope: Scope> ProtectedDigest<D, InputScope> {
         self.0.finalize_into(target);
     }
 
-    pub fn finalize_reset<T>(&mut self) -> T
+    /// Finalize directly into an intentionally public destination.
+    pub fn finalize_public_into<'m, T>(self, out: &'m mut T)
     where
-        D: FixedOutputReset,
-        T: Controlled + From<Array<u8, <D as OutputSizeUser>::OutputSize>>,
+        &'m mut Array<u8, <D as OutputSizeUser>::OutputSize>: From<&'m mut T>,
     {
-        let result = self.0.finalize_reset();
-        result.into()
+        let target: &mut Output<D> = out.into();
+        self.0.finalize_into(target);
     }
 
-    pub fn finalize_into_reset<'m, T>(&'m mut self, out: &'m mut T)
+    /// Finalize directly into a protected destination, then reset the digest.
+    pub fn finalize_into_reset<'m, T>(&mut self, out: &'m mut T)
     where
         D: FixedOutputReset,
         T: Controlled,
         &'m mut Array<u8, <D as OutputSizeUser>::OutputSize>: From<&'m mut T::Inner>,
     {
         let target: &mut Output<D> = out.inner_mut().into();
+        Digest::finalize_into_reset(&mut self.0, target);
+    }
+
+    /// Finalize directly into an intentionally public destination, then reset
+    /// the digest.
+    pub fn finalize_public_into_reset<'m, T>(&mut self, out: &'m mut T)
+    where
+        D: FixedOutputReset,
+        &'m mut Array<u8, <D as OutputSizeUser>::OutputSize>: From<&'m mut T>,
+    {
+        let target: &mut Output<D> = out.into();
         Digest::finalize_into_reset(&mut self.0, target);
     }
 
@@ -79,23 +105,23 @@ impl<D: Digest, InputScope: Scope> ProtectedDigest<D, InputScope> {
     pub fn output_size() -> usize {
         <D as Digest>::output_size()
     }
-
-    pub fn digest<T, O>(data: &T) -> O
-    where
-        T: Controlled + Acceptable<InputScope>,
-        T::Inner: AsRef<[u8]>,
-        O: Controlled + From<Array<u8, <D as OutputSizeUser>::OutputSize>>,
-    {
-        let mut hasher = Self::new();
-        hasher.update(data);
-        hasher.finalize()
-    }
 }
 
-impl<D: Digest, InputScope: Scope> Default for ProtectedDigest<D, InputScope> {
+impl<D, InputScope> Default for ProtectedDigest<D, InputScope>
+where
+    D: Digest + ZeroizeOnDrop,
+    InputScope: Scope,
+{
     fn default() -> Self {
         Self::new()
     }
+}
+
+impl<D, InputScope> ZeroizeOnDrop for ProtectedDigest<D, InputScope>
+where
+    D: Digest + ZeroizeOnDrop,
+    InputScope: Scope,
+{
 }
 
 #[cfg(test)]
@@ -104,47 +130,117 @@ mod tests {
     use crate::Protected;
     use sha2::{Sha256, Sha384};
 
+    const SHA256_ZEROES_32: [u8; 32] = [
+        102, 104, 122, 173, 248, 98, 189, 119, 108, 143, 193, 139, 142, 159, 142, 32, 8, 151, 20,
+        133, 110, 226, 51, 179, 144, 42, 89, 29, 13, 95, 41, 37,
+    ];
+
+    const SHA384_ZEROES_32: [u8; 48] = [
+        163, 143, 255, 75, 162, 108, 21, 228, 172, 156, 222, 140, 3, 16, 58, 200, 144, 128, 253,
+        71, 84, 95, 222, 148, 70, 200, 241, 146, 114, 158, 171, 123, 208, 58, 77, 92, 49, 135, 247,
+        95, 226, 167, 27, 14, 229, 10, 74, 64,
+    ];
+
     #[test]
-    fn test_digest_sha256_finalize() {
+    fn protected_input_finalizes_directly_into_protected_sha256_output() {
         let mut digest: ProtectedDigest<Sha256> = ProtectedDigest::new();
         digest.update(&Protected::new([0u8; 32]));
-        let result: Protected<[u8; 32]> = digest.finalize();
-        assert_eq!(
-            result.risky_unwrap(),
-            [
-                102, 104, 122, 173, 248, 98, 189, 119, 108, 143, 193, 139, 142, 159, 142, 32, 8,
-                151, 20, 133, 110, 226, 51, 179, 144, 42, 89, 29, 13, 95, 41, 37
-            ]
-        );
+        let mut output = Protected::new([0u8; 32]);
+        digest.finalize_into(&mut output);
+
+        assert_eq!(output.risky_ref(), &SHA256_ZEROES_32);
     }
 
     #[test]
-    fn test_digest_sha256_finalize_into() {
+    fn public_input_finalizes_directly_into_public_sha256_output() {
         let mut digest: ProtectedDigest<Sha256> = ProtectedDigest::new();
-        digest.update(&Protected::new([0u8; 32]));
-        let mut result = Protected::new([0u8; 32]);
-        digest.finalize_into(&mut result);
-        assert_eq!(
-            result.risky_unwrap(),
-            [
-                102, 104, 122, 173, 248, 98, 189, 119, 108, 143, 193, 139, 142, 159, 142, 32, 8,
-                151, 20, 133, 110, 226, 51, 179, 144, 42, 89, 29, 13, 95, 41, 37
-            ]
-        );
+        digest.update_public(&[0u8; 32]);
+        let mut output = [0u8; 32];
+        digest.finalize_public_into(&mut output);
+
+        assert_eq!(output, SHA256_ZEROES_32);
     }
 
     #[test]
-    fn test_digest_sha384() {
-        let mut digest: ProtectedDigest<Sha384> = ProtectedDigest::new();
-        digest.update(&Protected::new([0u8; 32]));
-        let result: Protected<[u8; 48]> = digest.finalize();
-        assert_eq!(
-            result.risky_unwrap(),
-            [
-                163, 143, 255, 75, 162, 108, 21, 228, 172, 156, 222, 140, 3, 16, 58, 200, 144, 128,
-                253, 71, 84, 95, 222, 148, 70, 200, 241, 146, 114, 158, 171, 123, 208, 58, 77, 92,
-                49, 135, 247, 95, 226, 167, 27, 14, 229, 10, 74, 64,
-            ]
-        );
+    fn sha384_finalizes_directly_into_protected_and_public_outputs() {
+        let mut protected_digest: ProtectedDigest<Sha384> = ProtectedDigest::new();
+        protected_digest.update(&Protected::new([0u8; 32]));
+        let mut protected_output = Protected::new([0u8; 48]);
+        protected_digest.finalize_into(&mut protected_output);
+
+        let mut public_digest: ProtectedDigest<Sha384> = ProtectedDigest::new();
+        public_digest.update_public(&[0u8; 32]);
+        let mut public_output = [0u8; 48];
+        public_digest.finalize_public_into(&mut public_output);
+
+        assert_eq!(protected_output.risky_ref(), &SHA384_ZEROES_32);
+        assert_eq!(public_output, SHA384_ZEROES_32);
+    }
+
+    #[test]
+    fn mixed_public_and_protected_updates_preserve_order() {
+        let secret = Protected::new(*b"secret");
+        let mut digest: ProtectedDigest<Sha256> = ProtectedDigest::new();
+        digest.update_public(b"domain");
+        digest.update(&secret);
+        let mut output = [0u8; 32];
+        digest.finalize_public_into(&mut output);
+
+        let mut reference = Sha256::new();
+        reference.update(b"domain");
+        reference.update(b"secret");
+        assert_eq!(output.as_slice(), reference.finalize().as_slice());
+    }
+
+    #[test]
+    fn protected_and_public_reset_finalization_reuses_the_digest() {
+        let input = Protected::new(*b"repeat");
+        let mut protected_digest: ProtectedDigest<Sha256> = ProtectedDigest::new();
+        protected_digest.update(&input);
+        let mut protected_first = Protected::new([0u8; 32]);
+        protected_digest.finalize_into_reset(&mut protected_first);
+        protected_digest.update(&input);
+        let mut protected_second = Protected::new([0u8; 32]);
+        protected_digest.finalize_into_reset(&mut protected_second);
+        assert_eq!(protected_first.risky_ref(), protected_second.risky_ref());
+
+        let mut public_digest: ProtectedDigest<Sha256> = ProtectedDigest::new();
+        public_digest.update_public(b"repeat");
+        let mut public_first = [0u8; 32];
+        public_digest.finalize_public_into_reset(&mut public_first);
+        public_digest.update_public(b"repeat");
+        let mut public_second = [0u8; 32];
+        public_digest.finalize_public_into_reset(&mut public_second);
+        assert_eq!(public_first, public_second);
+        assert_eq!(public_first.as_slice(), protected_first.risky_ref());
+    }
+
+    #[test]
+    fn protected_prefix_matches_sha256() {
+        let prefix = Protected::new(*b"prefix");
+        let digest: ProtectedDigest<Sha256> = ProtectedDigest::new_with_prefix(&prefix);
+        let mut output = [0u8; 32];
+        digest.finalize_public_into(&mut output);
+
+        assert_eq!(output.as_slice(), Sha256::digest(b"prefix").as_slice());
+    }
+
+    #[test]
+    fn explicit_reset_discards_previous_input() {
+        let mut digest: ProtectedDigest<Sha256> = ProtectedDigest::new();
+        digest.update_public(b"discard");
+        digest.reset();
+        digest.update_public(b"kept");
+        let mut output = [0u8; 32];
+        digest.finalize_public_into(&mut output);
+
+        assert_eq!(output.as_slice(), Sha256::digest(b"kept").as_slice());
+        assert_eq!(ProtectedDigest::<Sha256>::output_size(), 32);
+    }
+
+    #[test]
+    fn protected_digest_state_is_zeroize_on_drop() {
+        fn assert_zeroize_on_drop<T: ZeroizeOnDrop>() {}
+        assert_zeroize_on_drop::<ProtectedDigest<Sha256>>();
     }
 }


### PR DESCRIPTION
Closes #259.

## Summary

- require digest state wrapped by ProtectedDigest to implement ZeroizeOnDrop
- keep secret finalization in caller-provided protected storage and remove return-by-value helpers
- add explicit update_public and public-finalization channels
- document the hardened API and enable SHA-2 zeroization in tests

## Validation

- cargo test -p vitaminc-protected --all-features
- cargo test --workspace --all-features --exclude vitaminc-kms
- cargo check --workspace --all-features
- cargo +1.85.1 check -p vitaminc-protected --all-features --tests
- cargo clippy -p vitaminc-protected --all-features --all-targets -- -D warnings
- cargo fmt --all -- --check
- cargo mutants --no-shuffle -vV --in-diff /private/tmp/pr259.diff (3/3 caught)

The commit is GPG-signed with key F7B16D0FFDFCC12F.