### PR TITLE
test(protected): lock down negative-space guarantees

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,6 +957,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+
+[[package]]
 name = "h2"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1862,6 +1868,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1981,6 +1996,21 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "target-triple"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3a6bfce3d99adfa72d24750a61f782f3036a81e7f86d8841ee1326deaebd171"
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "thiserror"
@@ -2103,6 +2133,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.1.4+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2160,6 +2229,21 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "trybuild"
+version = "1.0.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e605bf6b39357663d8ba4e984f8be8da8df6bb32e81031d6889024ea8fd68e4"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml",
+]
 
 [[package]]
 name = "typenum"
@@ -2335,6 +2419,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "subtle",
+ "trybuild",
  "vitaminc-protected-derive",
  "zeroize",
 ]
@@ -2613,6 +2698,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wit-bindgen"

--- a/packages/protected/Cargo.toml
+++ b/packages/protected/Cargo.toml
@@ -28,6 +28,7 @@ vitaminc-protected-derive = { path = "../protected-derive", version = "0.2.0-pre
 rmp-serde = "1.3.1"
 serde_json = "1.0.150"
 sha2 = { version = "0.11.0", features = ["zeroize"] }
+trybuild = "1.0.118"
 
 [features]
 bitvec = []

--- a/packages/protected/src/as_protected_ref.rs
+++ b/packages/protected/src/as_protected_ref.rs
@@ -4,7 +4,9 @@ use std::borrow::Cow;
 /// Trait for types that can be converted to a `ProtectedRef`.
 /// Conceptually similar to the `AsRef` trait in `std` but for `Protected` types.
 /// This prevents the inner value from being accessed directly.
-/// The trait is sealed so it cannot be implemented outside of this crate.
+/// `ProtectedRef` cannot be constructed outside this crate, so downstream
+/// implementations must delegate to an existing protected source rather than
+/// wrapping an arbitrary reference.
 ///
 /// # Implementing `AsProtectedRef`
 ///

--- a/packages/protected/tests/negative_space.rs
+++ b/packages/protected/tests/negative_space.rs
@@ -1,3 +1,7 @@
+// `trybuild` launches rustc and inspects the filesystem, neither of which can
+// run inside Miri's isolated interpreter. The UI cases are exercised by the
+// normal test job; Miri remains focused on the crate's runtime unsafe code.
+#[cfg(not(miri))]
 #[test]
 fn negative_space() {
     let tests = trybuild::TestCases::new();

--- a/packages/protected/tests/negative_space.rs
+++ b/packages/protected/tests/negative_space.rs
@@ -1,0 +1,5 @@
+#[test]
+fn negative_space() {
+    let tests = trybuild::TestCases::new();
+    tests.compile_fail("tests/ui/negative_space/*.rs");
+}

--- a/packages/protected/tests/ui/negative_space/controlled_is_sealed.rs
+++ b/packages/protected/tests/ui/negative_space/controlled_is_sealed.rs
@@ -1,0 +1,21 @@
+use vitaminc_protected::Controlled;
+use zeroize::Zeroize;
+
+struct Untrusted(Vec<u8>);
+
+impl Zeroize for Untrusted {
+    fn zeroize(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+impl Controlled for Untrusted {
+    type Inner = Vec<u8>;
+
+    fn risky_unwrap(self) -> Self::Inner { self.0 }
+    fn init_from_inner(inner: Self::Inner) -> Self { Self(inner) }
+    fn risky_ref(&self) -> &Self::Inner { &self.0 }
+    fn inner_mut(&mut self) -> &mut Self::Inner { &mut self.0 }
+}
+
+fn main() {}

--- a/packages/protected/tests/ui/negative_space/controlled_is_sealed.stderr
+++ b/packages/protected/tests/ui/negative_space/controlled_is_sealed.stderr
@@ -1,0 +1,214 @@
+error[E0277]: the trait bound `Untrusted: vitaminc_protected::private::ControlledPrivate` is not satisfied
+  --> tests/ui/negative_space/controlled_is_sealed.rs:15:5
+   |
+15 |     fn risky_unwrap(self) -> Self::Inner { self.0 }
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+   |
+help: the trait `vitaminc_protected::private::ControlledPrivate` is not implemented for `Untrusted`
+  --> tests/ui/negative_space/controlled_is_sealed.rs:4:1
+   |
+ 4 | struct Untrusted(Vec<u8>);
+   | ^^^^^^^^^^^^^^^^
+help: the following other types implement trait `vitaminc_protected::private::ControlledPrivate`
+  --> src/equatable/mod.rs
+   |
+   | impl<T: ControlledPrivate + Zeroize> ControlledPrivate for Equatable<T> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Equatable<T>`
+   |
+  ::: src/exportable/mod.rs
+   |
+   | impl<T: ControlledPrivate + Zeroize> ControlledPrivate for Exportable<T> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Exportable<T>`
+   |
+  ::: src/protected/mod.rs
+   |
+   | impl<T: Zeroize> ControlledPrivate for Protected<T> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Protected<T>`
+   |
+  ::: src/usage/mod.rs
+   |
+   | impl<T: ControlledPrivate, Scope> ControlledPrivate for Usage<T, Scope> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Usage<T, Scope>`
+note: required by a bound in `Controlled`
+  --> src/controlled.rs
+   |
+   | pub trait Controlled: ControlledPrivate + Zeroize {
+   |                       ^^^^^^^^^^^^^^^^^ required by this bound in `Controlled`
+   = note: `Controlled` is a "sealed trait", because to implement it you also need to implement `vitaminc_protected::private::ControlledPrivate`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
+   = help: the following types implement the trait:
+             vitaminc_protected::Equatable<T>
+             vitaminc_protected::Exportable<T>
+             vitaminc_protected::Protected<T>
+             vitaminc_protected::Usage<T, Scope>
+
+error[E0277]: the trait bound `Untrusted: vitaminc_protected::private::ControlledPrivate` is not satisfied
+  --> tests/ui/negative_space/controlled_is_sealed.rs:16:5
+   |
+16 |     fn init_from_inner(inner: Self::Inner) -> Self { Self(inner) }
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+   |
+help: the trait `vitaminc_protected::private::ControlledPrivate` is not implemented for `Untrusted`
+  --> tests/ui/negative_space/controlled_is_sealed.rs:4:1
+   |
+ 4 | struct Untrusted(Vec<u8>);
+   | ^^^^^^^^^^^^^^^^
+help: the following other types implement trait `vitaminc_protected::private::ControlledPrivate`
+  --> src/equatable/mod.rs
+   |
+   | impl<T: ControlledPrivate + Zeroize> ControlledPrivate for Equatable<T> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Equatable<T>`
+   |
+  ::: src/exportable/mod.rs
+   |
+   | impl<T: ControlledPrivate + Zeroize> ControlledPrivate for Exportable<T> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Exportable<T>`
+   |
+  ::: src/protected/mod.rs
+   |
+   | impl<T: Zeroize> ControlledPrivate for Protected<T> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Protected<T>`
+   |
+  ::: src/usage/mod.rs
+   |
+   | impl<T: ControlledPrivate, Scope> ControlledPrivate for Usage<T, Scope> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Usage<T, Scope>`
+note: required by a bound in `Controlled`
+  --> src/controlled.rs
+   |
+   | pub trait Controlled: ControlledPrivate + Zeroize {
+   |                       ^^^^^^^^^^^^^^^^^ required by this bound in `Controlled`
+   = note: `Controlled` is a "sealed trait", because to implement it you also need to implement `vitaminc_protected::private::ControlledPrivate`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
+   = help: the following types implement the trait:
+             vitaminc_protected::Equatable<T>
+             vitaminc_protected::Exportable<T>
+             vitaminc_protected::Protected<T>
+             vitaminc_protected::Usage<T, Scope>
+
+error[E0277]: the trait bound `Untrusted: vitaminc_protected::private::ControlledPrivate` is not satisfied
+  --> tests/ui/negative_space/controlled_is_sealed.rs:17:5
+   |
+17 |     fn risky_ref(&self) -> &Self::Inner { &self.0 }
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+   |
+help: the trait `vitaminc_protected::private::ControlledPrivate` is not implemented for `Untrusted`
+  --> tests/ui/negative_space/controlled_is_sealed.rs:4:1
+   |
+ 4 | struct Untrusted(Vec<u8>);
+   | ^^^^^^^^^^^^^^^^
+help: the following other types implement trait `vitaminc_protected::private::ControlledPrivate`
+  --> src/equatable/mod.rs
+   |
+   | impl<T: ControlledPrivate + Zeroize> ControlledPrivate for Equatable<T> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Equatable<T>`
+   |
+  ::: src/exportable/mod.rs
+   |
+   | impl<T: ControlledPrivate + Zeroize> ControlledPrivate for Exportable<T> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Exportable<T>`
+   |
+  ::: src/protected/mod.rs
+   |
+   | impl<T: Zeroize> ControlledPrivate for Protected<T> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Protected<T>`
+   |
+  ::: src/usage/mod.rs
+   |
+   | impl<T: ControlledPrivate, Scope> ControlledPrivate for Usage<T, Scope> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Usage<T, Scope>`
+note: required by a bound in `Controlled`
+  --> src/controlled.rs
+   |
+   | pub trait Controlled: ControlledPrivate + Zeroize {
+   |                       ^^^^^^^^^^^^^^^^^ required by this bound in `Controlled`
+   = note: `Controlled` is a "sealed trait", because to implement it you also need to implement `vitaminc_protected::private::ControlledPrivate`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
+   = help: the following types implement the trait:
+             vitaminc_protected::Equatable<T>
+             vitaminc_protected::Exportable<T>
+             vitaminc_protected::Protected<T>
+             vitaminc_protected::Usage<T, Scope>
+
+error[E0277]: the trait bound `Untrusted: vitaminc_protected::private::ControlledPrivate` is not satisfied
+  --> tests/ui/negative_space/controlled_is_sealed.rs:18:5
+   |
+18 |     fn inner_mut(&mut self) -> &mut Self::Inner { &mut self.0 }
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+   |
+help: the trait `vitaminc_protected::private::ControlledPrivate` is not implemented for `Untrusted`
+  --> tests/ui/negative_space/controlled_is_sealed.rs:4:1
+   |
+ 4 | struct Untrusted(Vec<u8>);
+   | ^^^^^^^^^^^^^^^^
+help: the following other types implement trait `vitaminc_protected::private::ControlledPrivate`
+  --> src/equatable/mod.rs
+   |
+   | impl<T: ControlledPrivate + Zeroize> ControlledPrivate for Equatable<T> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Equatable<T>`
+   |
+  ::: src/exportable/mod.rs
+   |
+   | impl<T: ControlledPrivate + Zeroize> ControlledPrivate for Exportable<T> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Exportable<T>`
+   |
+  ::: src/protected/mod.rs
+   |
+   | impl<T: Zeroize> ControlledPrivate for Protected<T> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Protected<T>`
+   |
+  ::: src/usage/mod.rs
+   |
+   | impl<T: ControlledPrivate, Scope> ControlledPrivate for Usage<T, Scope> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Usage<T, Scope>`
+note: required by a bound in `Controlled`
+  --> src/controlled.rs
+   |
+   | pub trait Controlled: ControlledPrivate + Zeroize {
+   |                       ^^^^^^^^^^^^^^^^^ required by this bound in `Controlled`
+   = note: `Controlled` is a "sealed trait", because to implement it you also need to implement `vitaminc_protected::private::ControlledPrivate`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
+   = help: the following types implement the trait:
+             vitaminc_protected::Equatable<T>
+             vitaminc_protected::Exportable<T>
+             vitaminc_protected::Protected<T>
+             vitaminc_protected::Usage<T, Scope>
+
+error[E0277]: the trait bound `Untrusted: vitaminc_protected::private::ControlledPrivate` is not satisfied
+  --> tests/ui/negative_space/controlled_is_sealed.rs:12:21
+   |
+12 | impl Controlled for Untrusted {
+   |                     ^^^^^^^^^ unsatisfied trait bound
+   |
+help: the trait `vitaminc_protected::private::ControlledPrivate` is not implemented for `Untrusted`
+  --> tests/ui/negative_space/controlled_is_sealed.rs:4:1
+   |
+ 4 | struct Untrusted(Vec<u8>);
+   | ^^^^^^^^^^^^^^^^
+help: the following other types implement trait `vitaminc_protected::private::ControlledPrivate`
+  --> src/equatable/mod.rs
+   |
+   | impl<T: ControlledPrivate + Zeroize> ControlledPrivate for Equatable<T> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Equatable<T>`
+   |
+  ::: src/exportable/mod.rs
+   |
+   | impl<T: ControlledPrivate + Zeroize> ControlledPrivate for Exportable<T> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Exportable<T>`
+   |
+  ::: src/protected/mod.rs
+   |
+   | impl<T: Zeroize> ControlledPrivate for Protected<T> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Protected<T>`
+   |
+  ::: src/usage/mod.rs
+   |
+   | impl<T: ControlledPrivate, Scope> ControlledPrivate for Usage<T, Scope> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Usage<T, Scope>`
+note: required by a bound in `Controlled`
+  --> src/controlled.rs
+   |
+   | pub trait Controlled: ControlledPrivate + Zeroize {
+   |                       ^^^^^^^^^^^^^^^^^ required by this bound in `Controlled`
+   = note: `Controlled` is a "sealed trait", because to implement it you also need to implement `vitaminc_protected::private::ControlledPrivate`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
+   = help: the following types implement the trait:
+             vitaminc_protected::Equatable<T>
+             vitaminc_protected::Exportable<T>
+             vitaminc_protected::Protected<T>
+             vitaminc_protected::Usage<T, Scope>

--- a/packages/protected/tests/ui/negative_space/equatable_has_no_deref.rs
+++ b/packages/protected/tests/ui/negative_space/equatable_has_no_deref.rs
@@ -1,0 +1,9 @@
+use std::ops::Deref;
+use vitaminc_protected::{Equatable, Protected};
+
+fn require_deref<T: Deref>(_: &T) {}
+
+fn main() {
+    let secret: Equatable<Protected<String>> = Equatable::new(String::from("secret"));
+    require_deref(&secret);
+}

--- a/packages/protected/tests/ui/negative_space/equatable_has_no_deref.stderr
+++ b/packages/protected/tests/ui/negative_space/equatable_has_no_deref.stderr
@@ -1,0 +1,13 @@
+error[E0277]: the trait bound `Equatable<Protected<String>>: Deref` is not satisfied
+ --> tests/ui/negative_space/equatable_has_no_deref.rs:8:19
+  |
+8 |     require_deref(&secret);
+  |     ------------- ^^^^^^^ the trait `Deref` is not implemented for `Equatable<Protected<String>>`
+  |     |
+  |     required by a bound introduced by this call
+  |
+note: required by a bound in `require_deref`
+ --> tests/ui/negative_space/equatable_has_no_deref.rs:4:21
+  |
+4 | fn require_deref<T: Deref>(_: &T) {}
+  |                     ^^^^^ required by this bound in `require_deref`

--- a/packages/protected/tests/ui/negative_space/exportable_has_no_deref.rs
+++ b/packages/protected/tests/ui/negative_space/exportable_has_no_deref.rs
@@ -1,0 +1,9 @@
+use std::ops::Deref;
+use vitaminc_protected::{Exportable, Protected};
+
+fn require_deref<T: Deref>(_: &T) {}
+
+fn main() {
+    let secret: Exportable<Protected<String>> = Exportable::new(String::from("secret"));
+    require_deref(&secret);
+}

--- a/packages/protected/tests/ui/negative_space/exportable_has_no_deref.stderr
+++ b/packages/protected/tests/ui/negative_space/exportable_has_no_deref.stderr
@@ -1,0 +1,13 @@
+error[E0277]: the trait bound `Exportable<Protected<String>>: Deref` is not satisfied
+ --> tests/ui/negative_space/exportable_has_no_deref.rs:8:19
+  |
+8 |     require_deref(&secret);
+  |     ------------- ^^^^^^^ the trait `Deref` is not implemented for `Exportable<Protected<String>>`
+  |     |
+  |     required by a bound introduced by this call
+  |
+note: required by a bound in `require_deref`
+ --> tests/ui/negative_space/exportable_has_no_deref.rs:4:21
+  |
+4 | fn require_deref<T: Deref>(_: &T) {}
+  |                     ^^^^^ required by this bound in `require_deref`

--- a/packages/protected/tests/ui/negative_space/protected_has_no_deref.rs
+++ b/packages/protected/tests/ui/negative_space/protected_has_no_deref.rs
@@ -1,0 +1,8 @@
+use std::ops::Deref;
+use vitaminc_protected::Protected;
+
+fn require_deref<T: Deref>(_: &T) {}
+
+fn main() {
+    require_deref(&Protected::new(String::from("secret")));
+}

--- a/packages/protected/tests/ui/negative_space/protected_has_no_deref.stderr
+++ b/packages/protected/tests/ui/negative_space/protected_has_no_deref.stderr
@@ -1,0 +1,13 @@
+error[E0277]: the trait bound `Protected<String>: Deref` is not satisfied
+ --> tests/ui/negative_space/protected_has_no_deref.rs:7:19
+  |
+7 |     require_deref(&Protected::new(String::from("secret")));
+  |     ------------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Deref` is not implemented for `Protected<String>`
+  |     |
+  |     required by a bound introduced by this call
+  |
+note: required by a bound in `require_deref`
+ --> tests/ui/negative_space/protected_has_no_deref.rs:4:21
+  |
+4 | fn require_deref<T: Deref>(_: &T) {}
+  |                     ^^^^^ required by this bound in `require_deref`

--- a/packages/protected/tests/ui/negative_space/protected_has_no_deserialize.rs
+++ b/packages/protected/tests/ui/negative_space/protected_has_no_deserialize.rs
@@ -1,0 +1,8 @@
+use serde::de::DeserializeOwned;
+use vitaminc_protected::Protected;
+
+fn require_deserialize<T: DeserializeOwned>() {}
+
+fn main() {
+    require_deserialize::<Protected<String>>();
+}

--- a/packages/protected/tests/ui/negative_space/protected_has_no_deserialize.stderr
+++ b/packages/protected/tests/ui/negative_space/protected_has_no_deserialize.stderr
@@ -1,0 +1,22 @@
+error[E0277]: the trait bound `Protected<String>: serde::de::DeserializeOwned` is not satisfied
+ --> tests/ui/negative_space/protected_has_no_deserialize.rs:7:27
+  |
+7 |     require_deserialize::<Protected<String>>();
+  |                           ^^^^^^^^^^^^^^^^^ the trait `for<'de> Deserialize<'de>` is not implemented for `Protected<String>`
+  |
+  = help: the following other types implement trait `Deserialize<'de>`:
+            &'a Path
+            &'a [u8]
+            &'a serde_bytes::bytearray::ByteArray<N>
+            &'a serde_bytes::bytes::Bytes
+            &'a str
+            ()
+            (T,)
+            (T0, T1)
+          and $N others
+  = note: required for `Protected<String>` to implement `DeserializeOwned`
+note: required by a bound in `require_deserialize`
+ --> tests/ui/negative_space/protected_has_no_deserialize.rs:4:27
+  |
+4 | fn require_deserialize<T: DeserializeOwned>() {}
+  |                           ^^^^^^^^^^^^^^^^ required by this bound in `require_deserialize`

--- a/packages/protected/tests/ui/negative_space/protected_has_no_equality.rs
+++ b/packages/protected/tests/ui/negative_space/protected_has_no_equality.rs
@@ -1,0 +1,7 @@
+use vitaminc_protected::Protected;
+
+fn main() {
+    let left = Protected::new(String::from("secret"));
+    let right = Protected::new(String::from("secret"));
+    let _ = left == right;
+}

--- a/packages/protected/tests/ui/negative_space/protected_has_no_equality.stderr
+++ b/packages/protected/tests/ui/negative_space/protected_has_no_equality.stderr
@@ -1,0 +1,13 @@
+error[E0369]: binary operation `==` cannot be applied to type `Protected<String>`
+ --> tests/ui/negative_space/protected_has_no_equality.rs:6:18
+  |
+6 |     let _ = left == right;
+  |             ---- ^^ ----- Protected<String>
+  |             |
+  |             Protected<String>
+  |
+note: `Protected<String>` does not implement `PartialEq`
+ --> src/protected/mod.rs
+  |
+  | pub struct Protected<T: Zeroize>(pub(crate) T);
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Protected<String>` is defined in another crate

--- a/packages/protected/tests/ui/negative_space/protected_has_no_serialize.rs
+++ b/packages/protected/tests/ui/negative_space/protected_has_no_serialize.rs
@@ -1,0 +1,8 @@
+use serde::Serialize;
+use vitaminc_protected::Protected;
+
+fn require_serialize<T: Serialize>(_: &T) {}
+
+fn main() {
+    require_serialize(&Protected::new(String::from("secret")));
+}

--- a/packages/protected/tests/ui/negative_space/protected_has_no_serialize.stderr
+++ b/packages/protected/tests/ui/negative_space/protected_has_no_serialize.stderr
@@ -1,0 +1,25 @@
+error[E0277]: the trait bound `Protected<String>: serde::Serialize` is not satisfied
+ --> tests/ui/negative_space/protected_has_no_serialize.rs:7:23
+  |
+7 |     require_serialize(&Protected::new(String::from("secret")));
+  |     ----------------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Serialize` is not implemented for `Protected<String>`
+  |     |
+  |     required by a bound introduced by this call
+  |
+  = note: for local types consider adding `#[derive(serde::Serialize)]` to your `Protected<String>` type
+  = note: for types from other crates check whether the crate offers a `serde` feature flag
+  = help: the following other types implement trait `Serialize`:
+            &'a T
+            &'a mut T
+            ()
+            (T,)
+            (T0, T1)
+            (T0, T1, T2)
+            (T0, T1, T2, T3)
+            (T0, T1, T2, T3, T4)
+          and $N others
+note: required by a bound in `require_serialize`
+ --> tests/ui/negative_space/protected_has_no_serialize.rs:4:25
+  |
+4 | fn require_serialize<T: Serialize>(_: &T) {}
+  |                         ^^^^^^^^^ required by this bound in `require_serialize`

--- a/packages/protected/tests/ui/negative_space/protected_inner_is_private.rs
+++ b/packages/protected/tests/ui/negative_space/protected_inner_is_private.rs
@@ -1,0 +1,6 @@
+use vitaminc_protected::Protected;
+
+fn main() {
+    let secret = Protected::new(String::from("secret"));
+    let _ = &secret.0;
+}

--- a/packages/protected/tests/ui/negative_space/protected_inner_is_private.stderr
+++ b/packages/protected/tests/ui/negative_space/protected_inner_is_private.stderr
@@ -1,0 +1,5 @@
+error[E0616]: field `0` of struct `Protected` is private
+ --> tests/ui/negative_space/protected_inner_is_private.rs:5:21
+  |
+5 |     let _ = &secret.0;
+  |                     ^ private field

--- a/packages/protected/tests/ui/negative_space/protected_is_not_copy.rs
+++ b/packages/protected/tests/ui/negative_space/protected_is_not_copy.rs
@@ -1,0 +1,7 @@
+use vitaminc_protected::Protected;
+
+fn require_copy<T: Copy>(_: &T) {}
+
+fn main() {
+    require_copy(&Protected::new([0_u8; 32]));
+}

--- a/packages/protected/tests/ui/negative_space/protected_is_not_copy.stderr
+++ b/packages/protected/tests/ui/negative_space/protected_is_not_copy.stderr
@@ -1,0 +1,13 @@
+error[E0277]: the trait bound `Protected<[u8; 32]>: Copy` is not satisfied
+ --> tests/ui/negative_space/protected_is_not_copy.rs:6:18
+  |
+6 |     require_copy(&Protected::new([0_u8; 32]));
+  |     ------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `Protected<[u8; 32]>`
+  |     |
+  |     required by a bound introduced by this call
+  |
+note: required by a bound in `require_copy`
+ --> tests/ui/negative_space/protected_is_not_copy.rs:3:20
+  |
+3 | fn require_copy<T: Copy>(_: &T) {}
+  |                    ^^^^ required by this bound in `require_copy`

--- a/packages/protected/tests/ui/negative_space/protected_ref_cannot_be_constructed.rs
+++ b/packages/protected/tests/ui/negative_space/protected_ref_cannot_be_constructed.rs
@@ -1,0 +1,6 @@
+use vitaminc_protected::ProtectedRef;
+
+fn main() {
+    let bytes = [0_u8; 32];
+    let _ = ProtectedRef(&bytes);
+}

--- a/packages/protected/tests/ui/negative_space/protected_ref_cannot_be_constructed.stderr
+++ b/packages/protected/tests/ui/negative_space/protected_ref_cannot_be_constructed.stderr
@@ -1,0 +1,11 @@
+error[E0423]: cannot initialize a tuple struct which contains private fields
+ --> tests/ui/negative_space/protected_ref_cannot_be_constructed.rs:5:13
+  |
+5 |     let _ = ProtectedRef(&bytes);
+  |             ^^^^^^^^^^^^
+  |
+note: constructor is not visible here due to private fields
+ --> src/as_protected_ref.rs
+  |
+  | pub struct ProtectedRef<'a, T>(&'a T)
+  |                                ^^^^^ private field

--- a/packages/protected/tests/ui/negative_space/usage_has_no_deref.rs
+++ b/packages/protected/tests/ui/negative_space/usage_has_no_deref.rs
@@ -1,0 +1,9 @@
+use std::ops::Deref;
+use vitaminc_protected::{Protected, Usage};
+
+fn require_deref<T: Deref>(_: &T) {}
+
+fn main() {
+    let secret: Usage<Protected<String>> = Usage::new(String::from("secret"));
+    require_deref(&secret);
+}

--- a/packages/protected/tests/ui/negative_space/usage_has_no_deref.stderr
+++ b/packages/protected/tests/ui/negative_space/usage_has_no_deref.stderr
@@ -1,0 +1,13 @@
+error[E0277]: the trait bound `Usage<Protected<String>>: Deref` is not satisfied
+ --> tests/ui/negative_space/usage_has_no_deref.rs:8:19
+  |
+8 |     require_deref(&secret);
+  |     ------------- ^^^^^^^ the trait `Deref` is not implemented for `Usage<Protected<String>>`
+  |     |
+  |     required by a bound introduced by this call
+  |
+note: required by a bound in `require_deref`
+ --> tests/ui/negative_space/usage_has_no_deref.rs:4:21
+  |
+4 | fn require_deref<T: Deref>(_: &T) {}
+  |                     ^^^^^ required by this bound in `require_deref`


### PR DESCRIPTION
## Summary

- add trybuild compile-fail coverage for protected-type negative-space guarantees
- verify controlled wrappers do not implement Deref
- verify bare Protected cannot be compared, serialized, deserialized, copied, or accessed directly
- verify Controlled remains sealed and ProtectedRef cannot be directly constructed
- correct AsProtectedRef documentation to describe its actual construction boundary

## Validation

- cargo test -p vitaminc-protected
- cargo fmt --check