### PR TITLE
refactor(bindings): vcvalue becomes model-only; the codec moves into vcencrypt

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -56,8 +56,11 @@ jobs:
         # The codec lives in vcencrypt (wazero falls back to its interpreter
         # on 386); vcvalue is model-only but stays covered too since it is
         # the layer a future stack-encrypt Go SDK imports.
+        # Joined with && because the configured shell (bash -l) does not set
+        # -e: with independent lines, only the last command's exit status
+        # would decide the step, hiding a vcvalue failure.
         run: |
-          (cd bindings/go/vcvalue && CGO_ENABLED=0 GOOS=linux GOARCH=386 go test ./...)
+          (cd bindings/go/vcvalue && CGO_ENABLED=0 GOOS=linux GOARCH=386 go test ./...) &&
           (cd bindings/go/vcencrypt && CGO_ENABLED=0 GOOS=linux GOARCH=386 go test ./...)
 
       - name: run example (userrecord)

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -47,15 +47,18 @@ jobs:
         working-directory: bindings/go/vcencrypt
         run: CGO_ENABLED=0 go test ./...
 
-      - name: test (vcvalue on 32-bit GOARCH)
-        # vcvalue is the durable layer a future stack-encrypt Go SDK imports,
-        # and the u32-bound guards are load-bearing where int is 32 bits: a
-        # hostile length prefix >= 2^31 coerces negative there and would
-        # panic make() without them. A build check cannot catch that class —
-        # the tests (including the fuzz seed corpora) must actually run on
-        # 386, which linux/amd64 runners execute natively.
-        working-directory: bindings/go/vcvalue
-        run: CGO_ENABLED=0 GOOS=linux GOARCH=386 go test ./...
+      - name: test (32-bit GOARCH)
+        # The transport codec's u32-bound guards are load-bearing where int
+        # is 32 bits: a hostile length prefix >= 2^31 coerces negative there
+        # and would panic make() without them. A build check cannot catch
+        # that class — the tests (including the fuzz seed corpora) must
+        # actually run on 386, which linux/amd64 runners execute natively.
+        # The codec lives in vcencrypt (wazero falls back to its interpreter
+        # on 386); vcvalue is model-only but stays covered too since it is
+        # the layer a future stack-encrypt Go SDK imports.
+        run: |
+          (cd bindings/go/vcvalue && CGO_ENABLED=0 GOOS=linux GOARCH=386 go test ./...)
+          (cd bindings/go/vcencrypt && CGO_ENABLED=0 GOOS=linux GOARCH=386 go test ./...)
 
       - name: run example (userrecord)
         # The examples directory is its own Go module, outside every

--- a/bindings/go/vcencrypt/README.md
+++ b/bindings/go/vcencrypt/README.md
@@ -47,7 +47,7 @@ become dependencies of the binding itself. (There is also a testable
 
 ### Encrypting a user record with mixed fields
 
-A type controls its own sealing by implementing `vcvalue.Encryptable` (the Go
+A type controls its own sealing by implementing `vcencrypt.Encryptable` (the Go
 analog of Rust's `impl Encrypt`, since Go has no orphan impls). Non-secret
 fields opt into passthrough explicitly — they travel **unencrypted and
 unauthenticated**, so a database can read and index them without the key:
@@ -60,7 +60,7 @@ type User struct {
     Name      string
 }
 
-func (u User) EncryptValue(enc vcvalue.Encoder) error {
+func (u User) EncryptValue(enc vcencrypt.Encoder) error {
     m := enc.Map()
     m.Field("id").Passthrough().Int64(u.ID)
     m.Field("created_at").Passthrough().String(u.CreatedAt)

--- a/bindings/go/vcencrypt/abi_hostile_test.go
+++ b/bindings/go/vcencrypt/abi_hostile_test.go
@@ -5,8 +5,6 @@ import (
 	"context"
 	"errors"
 	"testing"
-
-	"github.com/cipherstash/vitaminc/bindings/go/vcvalue"
 )
 
 // These tests drive the raw vc_* exports with hostile (ptr, len) pairs the
@@ -154,7 +152,7 @@ func TestGuestRejectsNullAadWithNonzeroLength(t *testing.T) {
 	}
 	defer func() { _ = cipher.Close(ctx) }()
 
-	encoded, err := vcvalue.Marshal("attack at dawn")
+	encoded, err := marshal("attack at dawn")
 	if err != nil {
 		t.Fatalf("Marshal: %v", err)
 	}

--- a/bindings/go/vcencrypt/ciphertext.go
+++ b/bindings/go/vcencrypt/ciphertext.go
@@ -1,20 +1,22 @@
-package vcvalue
+package vcencrypt
 
 import (
 	"errors"
 	"fmt"
 	"slices"
+
+	"github.com/cipherstash/vitaminc/bindings/go/vcvalue"
 )
 
 // A ciphertext is made of ordinary Go values — the same dynamic shape as
 // decoded plaintext — with marker types distinguishing what is sealed from
 // what travels in the clear:
 //
-//   - Sealed: one encrypted leaf (version(1) || nonce || ciphertext || tag)
-//   - SealedNone: the authenticated absent marker
-//   - SealedEmptySeq / SealedEmptyMap: authenticated markers for empty
+//   - vcvalue.Sealed: one encrypted leaf (version(1) || nonce || ciphertext || tag)
+//   - vcvalue.SealedNone: the authenticated absent marker
+//   - vcvalue.SealedEmptySeq / vcvalue.SealedEmptyMap: authenticated markers for empty
 //     composites, which have no element ciphertexts to bind the AAD
-//   - Plain{V: ...}: a passthrough field, readable without the key
+//   - vcvalue.Plain{V: ...}: a passthrough field, readable without the key
 //   - []any: a sequence of ciphertext nodes
 //   - map[string]any: a record of named nodes. Keys travel in the clear but
 //     each is cryptographically bound to its sealed value — renaming or
@@ -23,9 +25,9 @@ import (
 //     any subset of entries decrypts independently.
 //
 // There is deliberately no dedicated tree type and no conversion step: a
-// map-shaped ciphertext binds directly as database named parameters (Sealed
-// and Plain implement driver.Valuer), and leaves loaded back from columns go
-// into a map[string]any for decryption. Only the Sealed leaf bytes are a
+// map-shaped ciphertext binds directly as database named parameters (vcvalue.Sealed
+// and vcvalue.Plain implement driver.Valuer), and leaves loaded back from columns go
+// into a map[string]any for decryption. Only the vcvalue.Sealed leaf bytes are a
 // frozen format; the transport encoding crossing the FFI boundary is an
 // implementation detail.
 
@@ -40,16 +42,16 @@ const (
 	ctEmptyMap    byte = 0x07
 )
 
-// MarshalCipherText encodes a ciphertext value into transport bytes. Bare
-// plaintext values are rejected — a passthrough must be marked with Plain, so
+// marshalCipherText encodes a ciphertext value into transport bytes. Bare
+// plaintext values are rejected — a passthrough must be marked with vcvalue.Plain, so
 // a value can never end up travelling unencrypted by accident.
-func MarshalCipherText(v any) ([]byte, error) {
+func marshalCipherText(v any) ([]byte, error) {
 	return encodeCipherText(nil, v, 0)
 }
 
-// UnmarshalCipherText decodes a transport-encoded ciphertext into the dynamic
+// unmarshalCipherText decodes a transport-encoded ciphertext into the dynamic
 // shape above, requiring the whole buffer to be consumed.
-func UnmarshalCipherText(buf []byte) (any, error) {
+func unmarshalCipherText(buf []byte) (any, error) {
 	r := &reader{buf: buf}
 	ct, err := decodeCipherText(r, 0)
 	if err != nil {
@@ -63,19 +65,19 @@ func UnmarshalCipherText(buf []byte) (any, error) {
 
 func encodeCipherText(out []byte, v any, depth int) ([]byte, error) {
 	if depth > maxDepth {
-		return nil, errors.New("vcvalue: ciphertext is nested too deeply")
+		return nil, errors.New("vcencrypt: ciphertext is nested too deeply")
 	}
 	switch n := v.(type) {
-	case Sealed:
+	case vcvalue.Sealed:
 		out = append(out, ctSingle)
 		return appendChunk(out, n)
-	case SealedNone:
+	case vcvalue.SealedNone:
 		out = append(out, ctNone)
 		return appendChunk(out, n)
-	case SealedEmptySeq:
+	case vcvalue.SealedEmptySeq:
 		out = append(out, ctEmptySeq)
 		return appendChunk(out, n)
-	case SealedEmptyMap:
+	case vcvalue.SealedEmptyMap:
 		out = append(out, ctEmptyMap)
 		return appendChunk(out, n)
 	case []any:
@@ -110,13 +112,13 @@ func encodeCipherText(out []byte, v any, depth int) ([]byte, error) {
 			}
 		}
 		return out, nil
-	case Plain:
+	case vcvalue.Plain:
 		// The payload node sits one level deeper; reject it here because the
 		// value encoder's scalar channels never re-check depth, and emitting
 		// bytes the decoder is guaranteed to reject (decodeValue enforces the
 		// same bound) would be an asymmetric round trip.
 		if depth+1 > maxDepth {
-			return nil, errors.New("vcvalue: ciphertext is nested too deeply")
+			return nil, errors.New("vcencrypt: ciphertext is nested too deeply")
 		}
 		out = append(out, ctPassthrough)
 		// Encode the plaintext payload as one value node, sharing the
@@ -129,11 +131,11 @@ func encodeCipherText(out []byte, v any, depth int) ([]byte, error) {
 			return nil, st.err
 		}
 		if done != 1 {
-			return nil, fmt.Errorf("vcvalue: passthrough payload must complete exactly one value, completed %d", done)
+			return nil, fmt.Errorf("vcencrypt: passthrough payload must complete exactly one value, completed %d", done)
 		}
 		return st.buf, nil
 	default:
-		return nil, fmt.Errorf("vcvalue: %T is not a ciphertext node — wrap passthrough values in Plain", v)
+		return nil, fmt.Errorf("vcencrypt: %T is not a ciphertext node — wrap passthrough values in vcvalue.Plain", v)
 	}
 }
 
@@ -159,13 +161,13 @@ func decodeCipherText(r *reader, depth int) (any, error) {
 		copy(leaf, s)
 		switch tag {
 		case ctNone:
-			return SealedNone(leaf), nil
+			return vcvalue.SealedNone(leaf), nil
 		case ctEmptySeq:
-			return SealedEmptySeq(leaf), nil
+			return vcvalue.SealedEmptySeq(leaf), nil
 		case ctEmptyMap:
-			return SealedEmptyMap(leaf), nil
+			return vcvalue.SealedEmptyMap(leaf), nil
 		default:
-			return Sealed(leaf), nil
+			return vcvalue.Sealed(leaf), nil
 		}
 	case ctSeq:
 		n, err := r.count()
@@ -208,7 +210,7 @@ func decodeCipherText(r *reader, depth int) (any, error) {
 		if err != nil {
 			return nil, err
 		}
-		return Plain{V: v}, nil
+		return vcvalue.Plain{V: v}, nil
 	default:
 		return nil, errMalformed
 	}

--- a/bindings/go/vcencrypt/client.go
+++ b/bindings/go/vcencrypt/client.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/cipherstash/vitaminc/bindings/go/vcvalue"
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
@@ -191,16 +190,16 @@ func (c *Client) NewCipher(ctx context.Context, key []byte) (*Cipher, error) {
 
 // Encrypt seals v under this cipher. v is encoded through the vcvalue
 // model: builtins, slices, maps and structs are handled by reflection, a
-// type implementing vcvalue.Encryptable controls its own encoding, and a
-// vcvalue.Plain marks a field to travel in the clear (passthrough). aad is
+// type implementing Encryptable controls its own encoding, and a
+// Plain marks a field to travel in the clear (passthrough). aad is
 // authenticated but not encrypted; the same aad must be presented to Decrypt.
 //
 // The ciphertext comes back as ordinary Go values mirroring the plaintext's
-// structure: vcvalue.Sealed leaves where fields were encrypted, vcvalue.Plain
+// structure: Sealed leaves where fields were encrypted, Plain
 // where they passed through, map[string]any for records (directly bindable as
 // database named parameters), []any for sequences.
 func (cph *Cipher) Encrypt(ctx context.Context, v any, aad []byte) (any, error) {
-	encoded, err := vcvalue.Marshal(v)
+	encoded, err := marshal(v)
 	if err != nil {
 		return nil, err
 	}
@@ -208,17 +207,17 @@ func (cph *Cipher) Encrypt(ctx context.Context, v any, aad []byte) (any, error) 
 	if err != nil {
 		return nil, err
 	}
-	return vcvalue.UnmarshalCipherText(out)
+	return unmarshalCipherText(out)
 }
 
 // Decrypt opens a ciphertext produced by Encrypt (in any language) with the
 // same cipher and aad. ct takes the same dynamic shape Encrypt returns —
-// e.g. a map[string]any of vcvalue.Sealed leaves loaded back from database
+// e.g. a map[string]any of Sealed leaves loaded back from database
 // columns; any subset of a record's entries decrypts. The plaintext is
-// returned in vcvalue's decode shape (Go natives, vcvalue.Object for maps,
-// and vcvalue.Plain for passthrough fields).
+// returned in vcvalue's decode shape (Go natives, Object for maps,
+// and Plain for passthrough fields).
 func (cph *Cipher) Decrypt(ctx context.Context, ct any, aad []byte) (any, error) {
-	encoded, err := vcvalue.MarshalCipherText(ct)
+	encoded, err := marshalCipherText(ct)
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +225,7 @@ func (cph *Cipher) Decrypt(ctx context.Context, ct any, aad []byte) (any, error)
 	if err != nil {
 		return nil, err
 	}
-	return vcvalue.Unmarshal(out)
+	return unmarshal(out)
 }
 
 // EncryptElement seals v as a *sequence element* of the logical collection
@@ -235,7 +234,7 @@ func (cph *Cipher) Decrypt(ctx context.Context, ct any, aad []byte) (any, error)
 // rows were (or will be) written by batch-encrypting a slice under the same
 // aad: rows from both paths interchange freely.
 func (cph *Cipher) EncryptElement(ctx context.Context, v any, aad []byte) (any, error) {
-	encoded, err := vcvalue.Marshal(v)
+	encoded, err := marshal(v)
 	if err != nil {
 		return nil, err
 	}
@@ -243,7 +242,7 @@ func (cph *Cipher) EncryptElement(ctx context.Context, v any, aad []byte) (any, 
 	if err != nil {
 		return nil, err
 	}
-	return vcvalue.UnmarshalCipherText(out)
+	return unmarshalCipherText(out)
 }
 
 // DecryptElement opens a ciphertext that was sealed as a sequence element —
@@ -254,7 +253,7 @@ func (cph *Cipher) EncryptElement(ctx context.Context, v any, aad []byte) (any, 
 // As with element order, *which* element (and how many) is a caller
 // obligation, not an authenticated fact.
 func (cph *Cipher) DecryptElement(ctx context.Context, ct any, aad []byte) (any, error) {
-	encoded, err := vcvalue.MarshalCipherText(ct)
+	encoded, err := marshalCipherText(ct)
 	if err != nil {
 		return nil, err
 	}
@@ -262,7 +261,7 @@ func (cph *Cipher) DecryptElement(ctx context.Context, ct any, aad []byte) (any,
 	if err != nil {
 		return nil, err
 	}
-	return vcvalue.Unmarshal(out)
+	return unmarshal(out)
 }
 
 // Close frees the cipher's key schedule inside the guest. Using the Cipher

--- a/bindings/go/vcencrypt/codec_test.go
+++ b/bindings/go/vcencrypt/codec_test.go
@@ -1,8 +1,6 @@
-package vcvalue_test
+package vcencrypt
 
 import (
-	"database/sql"
-	"database/sql/driver"
 	"encoding/binary"
 	"math"
 	"reflect"
@@ -16,11 +14,11 @@ import (
 // transport bytes, decode back to the natives shape.
 func marshalUnmarshal(t *testing.T, v any) any {
 	t.Helper()
-	buf, err := vcvalue.Marshal(v)
+	buf, err := marshal(v)
 	if err != nil {
 		t.Fatalf("Marshal(%#v): %v", v, err)
 	}
-	got, err := vcvalue.Unmarshal(buf)
+	got, err := unmarshal(buf)
 	if err != nil {
 		t.Fatalf("Unmarshal: %v", err)
 	}
@@ -110,7 +108,7 @@ func TestReflectPointerDeref(t *testing.T) {
 // point uses the Encryptable extension point.
 type point struct{ X, Y int64 }
 
-func (p point) EncryptValue(enc vcvalue.Encoder) error {
+func (p point) EncryptValue(enc Encoder) error {
 	m := enc.Map()
 	m.Field("x").Int64(p.X)
 	m.Field("y").Int64(p.Y)
@@ -145,11 +143,11 @@ func TestEncryptableNested(t *testing.T) {
 
 func TestEncoderChannels(t *testing.T) {
 	// Drive the raw Encoder channels directly, including a nested Seq.
-	buf, err := vcvalue.Marshal(seqBuilder{})
+	buf, err := marshal(seqBuilder{})
 	if err != nil {
 		t.Fatalf("Marshal: %v", err)
 	}
-	got, err := vcvalue.Unmarshal(buf)
+	got, err := unmarshal(buf)
 	if err != nil {
 		t.Fatalf("Unmarshal: %v", err)
 	}
@@ -167,7 +165,7 @@ func TestEncoderChannels(t *testing.T) {
 
 type seqBuilder struct{}
 
-func (seqBuilder) EncryptValue(enc vcvalue.Encoder) error {
+func (seqBuilder) EncryptValue(enc Encoder) error {
 	s := enc.Seq()
 	s.Elem().Null()
 	s.Elem().Bool(true)
@@ -183,17 +181,17 @@ func (seqBuilder) EncryptValue(enc vcvalue.Encoder) error {
 }
 
 func TestInvalidUTF8StringRejected(t *testing.T) {
-	if _, err := vcvalue.Marshal(string([]byte{0xff})); err == nil {
+	if _, err := marshal(string([]byte{0xff})); err == nil {
 		t.Fatal("expected invalid UTF-8 string to be rejected")
 	}
 }
 
 func TestUnmarshalRejectsGarbage(t *testing.T) {
-	if _, err := vcvalue.Unmarshal([]byte{0x7f}); err == nil {
+	if _, err := unmarshal([]byte{0x7f}); err == nil {
 		t.Fatal("unknown tag must be rejected")
 	}
 	// Trailing bytes after a complete value.
-	if _, err := vcvalue.Unmarshal([]byte{0x00, 0x00}); err == nil {
+	if _, err := unmarshal([]byte{0x00, 0x00}); err == nil {
 		t.Fatal("trailing bytes must be rejected")
 	}
 }
@@ -227,7 +225,7 @@ func TestPlainPassthroughSubtree(t *testing.T) {
 // The raw Encoder.Passthrough() channel, at root/seq/map positions.
 type passthroughBuilder struct{}
 
-func (passthroughBuilder) EncryptValue(enc vcvalue.Encoder) error {
+func (passthroughBuilder) EncryptValue(enc Encoder) error {
 	s := enc.Seq()
 	s.Elem().Passthrough().Int64(7) // passthrough sequence element
 	s.Elem().String("sealed")
@@ -244,7 +242,7 @@ func TestEncoderPassthroughChannel(t *testing.T) {
 
 func TestUnmarshalRejectsTruncatedPassthrough(t *testing.T) {
 	// A passthrough marker (0x12) with no value node behind it.
-	if _, err := vcvalue.Unmarshal([]byte{0x12}); err == nil {
+	if _, err := unmarshal([]byte{0x12}); err == nil {
 		t.Fatal("truncated passthrough node must be rejected")
 	}
 }
@@ -256,7 +254,7 @@ func TestUnmarshalRejectsPassthroughDepthBomb(t *testing.T) {
 		bytes = append(bytes, 0x12)
 	}
 	bytes = append(bytes, 0x00) // NULL
-	if _, err := vcvalue.Unmarshal(bytes); err == nil {
+	if _, err := unmarshal(bytes); err == nil {
 		t.Fatal("over-deep passthrough nesting must be rejected")
 	}
 }
@@ -269,11 +267,11 @@ func TestCipherTextPassthroughTransportRoundTrip(t *testing.T) {
 		"id":    vcvalue.Plain{V: int64(42)},
 		"email": vcvalue.Sealed{9, 9, 9},
 	}
-	buf, err := vcvalue.MarshalCipherText(ct)
+	buf, err := marshalCipherText(ct)
 	if err != nil {
 		t.Fatalf("MarshalCipherText: %v", err)
 	}
-	got, err := vcvalue.UnmarshalCipherText(buf)
+	got, err := unmarshalCipherText(buf)
 	if err != nil {
 		t.Fatalf("UnmarshalCipherText: %v", err)
 	}
@@ -287,11 +285,11 @@ func TestCipherTextTransportRoundTrip(t *testing.T) {
 		"a": vcvalue.Sealed{9, 9, 9},
 		"b": []any{vcvalue.Sealed{1}, vcvalue.SealedNone{2}},
 	}
-	buf, err := vcvalue.MarshalCipherText(ct)
+	buf, err := marshalCipherText(ct)
 	if err != nil {
 		t.Fatalf("MarshalCipherText: %v", err)
 	}
-	got, err := vcvalue.UnmarshalCipherText(buf)
+	got, err := unmarshalCipherText(buf)
 	if err != nil {
 		t.Fatalf("UnmarshalCipherText: %v", err)
 	}
@@ -303,10 +301,10 @@ func TestCipherTextTransportRoundTrip(t *testing.T) {
 // A bare plaintext value in ciphertext position is rejected: passthrough must
 // be explicit (Plain), so nothing travels unencrypted by accident.
 func TestCipherTextRejectsBarePlaintext(t *testing.T) {
-	if _, err := vcvalue.MarshalCipherText(map[string]any{"x": "oops"}); err == nil {
+	if _, err := marshalCipherText(map[string]any{"x": "oops"}); err == nil {
 		t.Fatal("bare plaintext in ciphertext position must be rejected")
 	}
-	if _, err := vcvalue.MarshalCipherText([]byte{1, 2, 3}); err == nil {
+	if _, err := marshalCipherText([]byte{1, 2, 3}); err == nil {
 		t.Fatal("bare []byte must be rejected (use Sealed or Plain)")
 	}
 }
@@ -317,7 +315,7 @@ func TestMarshalRejectsZeroExportedFieldStruct(t *testing.T) {
 	type opaque struct {
 		hidden int //nolint:unused // unexported on purpose
 	}
-	if _, err := vcvalue.Marshal(opaque{hidden: 1}); err == nil {
+	if _, err := marshal(opaque{hidden: 1}); err == nil {
 		t.Fatal("struct with no exported fields must be rejected")
 	}
 	// An all-vc:"-" struct asked for the empty encoding explicitly and stays
@@ -325,10 +323,10 @@ func TestMarshalRejectsZeroExportedFieldStruct(t *testing.T) {
 	type skipped struct {
 		ID int `vc:"-"`
 	}
-	if _, err := vcvalue.Marshal(skipped{ID: 1}); err != nil {
+	if _, err := marshal(skipped{ID: 1}); err != nil {
 		t.Fatalf("all-skipped struct should encode: %v", err)
 	}
-	if _, err := vcvalue.Marshal(struct{}{}); err != nil {
+	if _, err := marshal(struct{}{}); err != nil {
 		t.Fatalf("empty struct should encode: %v", err)
 	}
 }
@@ -358,11 +356,11 @@ func TestObjectReencodesWithObjectFraming(t *testing.T) {
 // round trip shape-intact (PR review P1).
 func TestCipherTextPassthroughObjectRoundTrip(t *testing.T) {
 	o := vcvalue.Object{{Key: "id", Value: int64(42)}}
-	buf, err := vcvalue.MarshalCipherText(vcvalue.Plain{V: o})
+	buf, err := marshalCipherText(vcvalue.Plain{V: o})
 	if err != nil {
 		t.Fatalf("MarshalCipherText: %v", err)
 	}
-	got, err := vcvalue.UnmarshalCipherText(buf)
+	got, err := unmarshalCipherText(buf)
 	if err != nil {
 		t.Fatalf("UnmarshalCipherText: %v", err)
 	}
@@ -392,7 +390,7 @@ func TestByteArrayEncodesAsBytes(t *testing.T) {
 // the behaviour typed-nil detection must prevent.
 type nilEncryptable struct{ n int }
 
-func (e *nilEncryptable) EncryptValue(enc vcvalue.Encoder) error {
+func (e *nilEncryptable) EncryptValue(enc Encoder) error {
 	enc.Int64(int64(e.n)) // dereferences e
 	return nil
 }
@@ -415,7 +413,7 @@ func TestTypedNilEncryptableEncodesNull(t *testing.T) {
 func TestMarshalRejectsPointerCycle(t *testing.T) {
 	var x any
 	x = &x
-	if _, err := vcvalue.Marshal(x); err == nil {
+	if _, err := marshal(x); err == nil {
 		t.Fatal("pointer cycle must be rejected")
 	}
 }
@@ -429,7 +427,7 @@ func TestMarshalCipherTextRejectsPassthroughBeyondDepthBudget(t *testing.T) {
 	for range 129 {
 		deep = []any{deep}
 	}
-	if _, err := vcvalue.MarshalCipherText(deep); err == nil {
+	if _, err := marshalCipherText(deep); err == nil {
 		t.Fatal("over-deep passthrough must be rejected at encode time")
 	}
 
@@ -438,45 +436,12 @@ func TestMarshalCipherTextRejectsPassthroughBeyondDepthBudget(t *testing.T) {
 	for range 127 {
 		ok = []any{ok}
 	}
-	buf, err := vcvalue.MarshalCipherText(ok)
+	buf, err := marshalCipherText(ok)
 	if err != nil {
 		t.Fatalf("MarshalCipherText at the bound: %v", err)
 	}
-	if _, err := vcvalue.UnmarshalCipherText(buf); err != nil {
+	if _, err := unmarshalCipherText(buf); err != nil {
 		t.Fatalf("UnmarshalCipherText at the bound: %v", err)
-	}
-}
-
-// Every sealed leaf type must survive the database column round trip:
-// Value() then Scan() back into the same type.
-func TestSealedLeafTypesScanValueRoundTrip(t *testing.T) {
-	roundTrip := func(t *testing.T, value driver.Valuer, scan sql.Scanner, got func() []byte, want []byte) {
-		t.Helper()
-		v, err := value.Value()
-		if err != nil {
-			t.Fatalf("Value: %v", err)
-		}
-		if err := scan.Scan(v); err != nil {
-			t.Fatalf("Scan: %v", err)
-		}
-		if !reflect.DeepEqual(got(), want) {
-			t.Fatalf("got %#v, want %#v", got(), want)
-		}
-	}
-
-	leaf := []byte{1, 2, 3}
-	var s vcvalue.Sealed
-	roundTrip(t, vcvalue.Sealed(leaf), &s, func() []byte { return []byte(s) }, leaf)
-	var n vcvalue.SealedNone
-	roundTrip(t, vcvalue.SealedNone(leaf), &n, func() []byte { return []byte(n) }, leaf)
-	var es vcvalue.SealedEmptySeq
-	roundTrip(t, vcvalue.SealedEmptySeq(leaf), &es, func() []byte { return []byte(es) }, leaf)
-	var em vcvalue.SealedEmptyMap
-	roundTrip(t, vcvalue.SealedEmptyMap(leaf), &em, func() []byte { return []byte(em) }, leaf)
-
-	// Non-byte sources are rejected.
-	if err := (&es).Scan("not bytes"); err == nil {
-		t.Fatal("scanning a string into SealedEmptySeq must fail")
 	}
 }
 
@@ -507,7 +472,7 @@ func TestUnmarshalCipherTextRejectsDuplicateKey(t *testing.T) {
 	dup = append(dup, u32le(2)...)
 	dup = append(dup, ctEntry("a")...)
 	dup = append(dup, ctEntry("a")...)
-	if _, err := vcvalue.UnmarshalCipherText(dup); err == nil {
+	if _, err := unmarshalCipherText(dup); err == nil {
 		t.Fatal("duplicate ciphertext map key must be rejected")
 	}
 
@@ -516,7 +481,7 @@ func TestUnmarshalCipherTextRejectsDuplicateKey(t *testing.T) {
 	ok = append(ok, u32le(2)...)
 	ok = append(ok, ctEntry("a")...)
 	ok = append(ok, ctEntry("b")...)
-	if _, err := vcvalue.UnmarshalCipherText(ok); err != nil {
+	if _, err := unmarshalCipherText(ok); err != nil {
 		t.Fatalf("distinct keys should decode: %v", err)
 	}
 }
@@ -532,7 +497,7 @@ func TestUnmarshalRejectsArrayAndObjectBombs(t *testing.T) {
 		deep = append(deep, u32le(1)...)
 	}
 	deep = append(deep, 0x00) // tagNull
-	if _, err := vcvalue.Unmarshal(deep); err == nil {
+	if _, err := unmarshal(deep); err == nil {
 		t.Fatal("array depth bomb must be rejected")
 	}
 
@@ -545,12 +510,12 @@ func TestUnmarshalRejectsArrayAndObjectBombs(t *testing.T) {
 		deepObj = append(deepObj, 'k')
 	}
 	deepObj = append(deepObj, 0x00)
-	if _, err := vcvalue.Unmarshal(deepObj); err == nil {
+	if _, err := unmarshal(deepObj); err == nil {
 		t.Fatal("object depth bomb must be rejected")
 	}
 
 	// Hostile count: an array claiming max-u32 items with no bytes behind it.
-	if _, err := vcvalue.Unmarshal([]byte{0x10, 0xFF, 0xFF, 0xFF, 0xFF}); err == nil {
+	if _, err := unmarshal([]byte{0x10, 0xFF, 0xFF, 0xFF, 0xFF}); err == nil {
 		t.Fatal("hostile array count must be rejected")
 	}
 }
@@ -566,24 +531,24 @@ func TestUnmarshalCipherTextRejectsMalformed(t *testing.T) {
 		deep = append(deep, u32le(1)...)
 	}
 	deep = append(deep, ctEntry("")[4:]...) // a bare ctSingle leaf
-	if _, err := vcvalue.UnmarshalCipherText(deep); err == nil {
+	if _, err := unmarshalCipherText(deep); err == nil {
 		t.Fatal("ciphertext depth bomb must be rejected")
 	}
 
 	// Hostile count.
-	if _, err := vcvalue.UnmarshalCipherText([]byte{0x03, 0xFF, 0xFF, 0xFF, 0xFF}); err == nil {
+	if _, err := unmarshalCipherText([]byte{0x03, 0xFF, 0xFF, 0xFF, 0xFF}); err == nil {
 		t.Fatal("hostile ciphertext count must be rejected")
 	}
 
 	// Trailing bytes after a complete node.
 	leaf := append([]byte{0x01}, u32le(1)...)
 	leaf = append(leaf, 0xAB, 0xFF) // one extra byte
-	if _, err := vcvalue.UnmarshalCipherText(leaf); err == nil {
+	if _, err := unmarshalCipherText(leaf); err == nil {
 		t.Fatal("trailing bytes must be rejected")
 	}
 
 	// Unknown tag.
-	if _, err := vcvalue.UnmarshalCipherText([]byte{0x7F}); err == nil {
+	if _, err := unmarshalCipherText([]byte{0x7F}); err == nil {
 		t.Fatal("unknown ciphertext tag must be rejected")
 	}
 }
@@ -591,13 +556,13 @@ func TestUnmarshalCipherTextRejectsMalformed(t *testing.T) {
 // The encodeReflect default arm: kinds with no encoding (chan/func/complex)
 // error instead of panicking or emitting garbage.
 func TestMarshalRejectsUnsupportedKind(t *testing.T) {
-	if _, err := vcvalue.Marshal(make(chan int)); err == nil {
+	if _, err := marshal(make(chan int)); err == nil {
 		t.Fatal("a channel value has no encoding and must be rejected")
 	}
-	if _, err := vcvalue.Marshal(func() {}); err == nil {
+	if _, err := marshal(func() {}); err == nil {
 		t.Fatal("a func value has no encoding and must be rejected")
 	}
-	if _, err := vcvalue.Marshal(complex(1, 2)); err == nil {
+	if _, err := marshal(complex(1, 2)); err == nil {
 		t.Fatal("a complex value has no encoding and must be rejected")
 	}
 }
@@ -605,7 +570,7 @@ func TestMarshalRejectsUnsupportedKind(t *testing.T) {
 // encodeMap rejects non-string map keys — the transport frames keys as
 // UTF-8 chunks, so there is nothing sound to write for other key types.
 func TestMarshalRejectsNonStringMapKey(t *testing.T) {
-	if _, err := vcvalue.Marshal(map[int]string{1: "a"}); err == nil {
+	if _, err := marshal(map[int]string{1: "a"}); err == nil {
 		t.Fatal("map with non-string keys must be rejected")
 	}
 }
@@ -618,7 +583,7 @@ func TestMarshalRejectsDepthBomb(t *testing.T) {
 	for range 130 { // > maxDepth (128)
 		v = []any{v}
 	}
-	if _, err := vcvalue.Marshal(v); err == nil {
+	if _, err := marshal(v); err == nil {
 		t.Fatal("over-deep value must be rejected at encode time")
 	}
 }
@@ -636,7 +601,7 @@ func TestUnmarshalRejectsDuplicateObjectKey(t *testing.T) {
 	buf = append(buf, 0x00) // Null value
 	buf = append(buf, key...)
 	buf = append(buf, 0x00)
-	if _, err := vcvalue.Unmarshal(buf); err == nil {
+	if _, err := unmarshal(buf); err == nil {
 		t.Fatal("an object with a duplicate key must be rejected")
 	}
 
@@ -645,98 +610,8 @@ func TestUnmarshalRejectsDuplicateObjectKey(t *testing.T) {
 	ok = append(ok, 0x11, 2, 0, 0, 0)
 	ok = append(ok, 1, 0, 0, 0, 'a', 0x00)
 	ok = append(ok, 1, 0, 0, 0, 'b', 0x00)
-	if _, err := vcvalue.Unmarshal(ok); err != nil {
+	if _, err := unmarshal(ok); err != nil {
 		t.Fatalf("distinct keys must decode: %v", err)
-	}
-}
-
-// Every integer kind the encoder accepts must also bind through the driver:
-// Plain{V: user.ID} with ID int encodes fine, so Value() must not reject it.
-func TestPlainValueBindsEveryEncodableIntegerKind(t *testing.T) {
-	cases := []struct {
-		in   any
-		want driver.Value
-	}{
-		{int(7), int64(7)},
-		{int8(-8), int64(-8)},
-		{int16(-16), int64(-16)},
-		{int32(-32), int64(-32)},
-		{int64(-64), int64(-64)},
-		{uint8(8), int64(8)},
-		{uint16(16), int64(16)},
-		{uint32(32), int64(32)},
-		{uint(64), int64(64)},
-		{uint64(64), int64(64)},
-	}
-	for _, c := range cases {
-		got, err := vcvalue.Plain{V: c.in}.Value()
-		if err != nil {
-			t.Fatalf("Value(%T): %v", c.in, err)
-		}
-		if got != c.want {
-			t.Fatalf("Value(%T): got %#v, want %#v", c.in, got, c.want)
-		}
-	}
-
-	// The unsigned kinds that can exceed int64 must fail closed.
-	if _, err := (vcvalue.Plain{V: uint64(math.MaxInt64) + 1}).Value(); err == nil {
-		t.Fatal("uint64 above MaxInt64 must not bind")
-	}
-	if uint64(math.MaxUint) > math.MaxInt64 { // uint is 32-bit on GOARCH=386
-		if _, err := (vcvalue.Plain{V: uint(math.MaxUint)}).Value(); err == nil {
-			t.Fatal("uint above MaxInt64 must not bind")
-		}
-	}
-}
-
-// Plain.Value's driver conversions: width-narrowing, the uint64 overflow
-// error, and the container-has-no-column error.
-func TestPlainValueConversions(t *testing.T) {
-	cases := []struct {
-		in   any
-		want driver.Value
-	}{
-		{nil, nil},
-		{true, true},
-		{int64(7), int64(7)},
-		{"s", "s"},
-		{[]byte{1}, []byte{1}},
-		{int32(-3), int64(-3)},
-		{uint32(9), int64(9)},
-		{float32(0.5), float64(0.5)},
-		{float64(1.5), float64(1.5)},
-		{uint64(11), int64(11)},
-	}
-	for _, c := range cases {
-		got, err := vcvalue.Plain{V: c.in}.Value()
-		if err != nil {
-			t.Fatalf("Value(%#v): %v", c.in, err)
-		}
-		if !reflect.DeepEqual(got, c.want) {
-			t.Fatalf("Value(%#v) = %#v, want %#v", c.in, got, c.want)
-		}
-	}
-
-	if _, err := (vcvalue.Plain{V: uint64(math.MaxInt64) + 1}).Value(); err == nil {
-		t.Fatal("uint64 above MaxInt64 must not silently truncate")
-	}
-	if _, err := (vcvalue.Plain{V: []any{int64(1)}}).Value(); err == nil {
-		t.Fatal("a container passthrough has no single-column form")
-	}
-}
-
-// The remaining Sealed.Scan arms: nil source and the non-byte error arm
-// (the byte round trip is covered with the marker types above).
-func TestSealedScanNilAndErrorArms(t *testing.T) {
-	s := vcvalue.Sealed{1, 2, 3}
-	if err := s.Scan(nil); err != nil {
-		t.Fatalf("Scan(nil): %v", err)
-	}
-	if s != nil {
-		t.Fatalf("Scan(nil) should clear the leaf, got %#v", s)
-	}
-	if err := s.Scan("not bytes"); err == nil {
-		t.Fatal("scanning a string into Sealed must fail")
 	}
 }
 
@@ -745,7 +620,7 @@ func TestSealedScanNilAndErrorArms(t *testing.T) {
 // previously surfaced only as an opaque errMalformed at decode.
 type skipsValue struct{ inSeq bool }
 
-func (s skipsValue) EncryptValue(enc vcvalue.Encoder) error {
+func (s skipsValue) EncryptValue(enc Encoder) error {
 	if s.inSeq {
 		q := enc.Seq()
 		q.Elem() // claimed, never written
@@ -762,7 +637,7 @@ func (s skipsValue) EncryptValue(enc vcvalue.Encoder) error {
 // the one skipped, so no later Field/Elem call can catch it.
 type lastValueMissing struct{ inSeq bool }
 
-func (s lastValueMissing) EncryptValue(enc vcvalue.Encoder) error {
+func (s lastValueMissing) EncryptValue(enc Encoder) error {
 	if s.inSeq {
 		q := enc.Seq()
 		q.Elem().Int64(1)
@@ -780,7 +655,7 @@ func (s lastValueMissing) EncryptValue(enc vcvalue.Encoder) error {
 // value finished, so a per-slot (not global) completion check is required.
 type unclosedNested struct{ inSeq bool }
 
-func (u unclosedNested) EncryptValue(enc vcvalue.Encoder) error {
+func (u unclosedNested) EncryptValue(enc Encoder) error {
 	if u.inSeq {
 		q := enc.Seq()
 		inner := q.Elem().Seq()
@@ -799,7 +674,7 @@ func (u unclosedNested) EncryptValue(enc vcvalue.Encoder) error {
 // producing an extra value node the container's count doesn't account for.
 type doubleWrite struct{ inSeq bool }
 
-func (d doubleWrite) EncryptValue(enc vcvalue.Encoder) error {
+func (d doubleWrite) EncryptValue(enc Encoder) error {
 	if d.inSeq {
 		q := enc.Seq()
 		e := q.Elem()
@@ -817,7 +692,7 @@ func (d doubleWrite) EncryptValue(enc vcvalue.Encoder) error {
 // rootMiscount writes zero or several values at the root slot.
 type rootMiscount struct{ writes int }
 
-func (r rootMiscount) EncryptValue(enc vcvalue.Encoder) error {
+func (r rootMiscount) EncryptValue(enc Encoder) error {
 	for i := 0; i < r.writes; i++ {
 		enc.Int64(int64(i))
 	}
@@ -827,7 +702,7 @@ func (r rootMiscount) EncryptValue(enc vcvalue.Encoder) error {
 // unclosedRoot leaves the root container un-Ended.
 type unclosedRoot struct{}
 
-func (unclosedRoot) EncryptValue(enc vcvalue.Encoder) error {
+func (unclosedRoot) EncryptValue(enc Encoder) error {
 	enc.Seq().Elem().Int64(1) // End() never called
 	return nil
 }
@@ -842,7 +717,7 @@ func TestMarshalCipherTextRejectsPayloadMiscount(t *testing.T) {
 		vcvalue.Plain{V: rootMiscount{writes: 2}},
 		vcvalue.Plain{V: unclosedRoot{}},
 	} {
-		if _, err := vcvalue.MarshalCipherText(v); err == nil {
+		if _, err := marshalCipherText(v); err == nil {
 			t.Fatalf("malformed passthrough payload %#v must fail the encode", v)
 		}
 	}
@@ -852,14 +727,14 @@ func TestMarshalCipherTextRejectsPayloadMiscount(t *testing.T) {
 // but never the wrapped value — the passthrough-specific skipped-value case.
 type missingPassthroughPayload struct{}
 
-func (missingPassthroughPayload) EncryptValue(enc vcvalue.Encoder) error {
+func (missingPassthroughPayload) EncryptValue(enc Encoder) error {
 	s := enc.Seq()
 	s.Elem().Passthrough() // marker written, payload omitted
 	return s.End()
 }
 
 func TestEncoderPassthroughRequiresWrappedValue(t *testing.T) {
-	_, err := vcvalue.Marshal(missingPassthroughPayload{})
+	_, err := marshal(missingPassthroughPayload{})
 	if err == nil {
 		t.Fatal("passthrough without a wrapped value must fail at encode time")
 	}
@@ -881,7 +756,7 @@ type collidingTag struct {
 // duplicateFieldKey is the Encryptable route to the same collision.
 type duplicateFieldKey struct{}
 
-func (duplicateFieldKey) EncryptValue(enc vcvalue.Encoder) error {
+func (duplicateFieldKey) EncryptValue(enc Encoder) error {
 	m := enc.Map()
 	m.Field("a").Int64(1)
 	m.Field("a").Int64(2)
@@ -897,7 +772,7 @@ func TestEncoderRejectsDuplicateMapKeys(t *testing.T) {
 		{"encryptable double field", duplicateFieldKey{}},
 	} {
 		t.Run(c.name, func(t *testing.T) {
-			_, err := vcvalue.Marshal(c.v)
+			_, err := marshal(c.v)
 			if err == nil {
 				t.Fatal("a duplicate map key must fail at encode time")
 			}
@@ -927,7 +802,7 @@ func TestEncoderCatchesSkippedValuesAtEncodeTime(t *testing.T) {
 		{"root unclosed container", unclosedRoot{}, "root"},
 	} {
 		t.Run(c.name, func(t *testing.T) {
-			_, err := vcvalue.Marshal(c.v)
+			_, err := marshal(c.v)
 			if err == nil {
 				t.Fatal("a contract violation must fail the encode")
 			}
@@ -935,5 +810,29 @@ func TestEncoderCatchesSkippedValuesAtEncodeTime(t *testing.T) {
 				t.Fatalf("diagnostic %q does not name the offending slot (want substring %q)", err, c.want)
 			}
 		})
+	}
+}
+
+// innerFailsOuterReports pins the End() error contract: End returns the
+// first error of the whole encode, not one scoped to its own container, so
+// an outer End reports a failure that happened inside a sibling subtree.
+type innerFailsOuterReports struct{}
+
+func (innerFailsOuterReports) EncryptValue(enc Encoder) error {
+	m := enc.Map()
+	inner := m.Field("bad").Map()
+	inner.Field("\xff").Int64(1) // invalid UTF-8 key: the first (and only) error
+	_ = inner.End()
+	m.Field("good").Int64(2)
+	return m.End()
+}
+
+func TestEndReturnsFirstEncodeErrorNotContainerScoped(t *testing.T) {
+	_, err := marshal(innerFailsOuterReports{})
+	if err == nil {
+		t.Fatal("the inner container's error must surface from the outer End")
+	}
+	if !strings.Contains(err.Error(), "UTF-8") {
+		t.Fatalf("outer End should carry the first encode error verbatim, got %q", err)
 	}
 }

--- a/bindings/go/vcencrypt/decode.go
+++ b/bindings/go/vcencrypt/decode.go
@@ -1,23 +1,13 @@
-package vcvalue
+package vcencrypt
 
 import (
 	"encoding/binary"
 	"math"
+
+	"github.com/cipherstash/vitaminc/bindings/go/vcvalue"
 )
 
-// Object is the decode result for a map-mode value: an ordered list of
-// fields mirroring the wire order. Decoding uses this (rather than a Go map)
-// so entry order is preserved and results compare deterministically. Encode
-// takes any/struct/map instead — this type is decode-only.
-type Object []Field
-
-// Field is one entry of a decoded Object.
-type Field struct {
-	Key   string
-	Value any
-}
-
-// Unmarshal decodes value transport bytes into Go natives:
+// unmarshal decodes value transport bytes into Go natives:
 //
 //   - Null and Undefined → nil (Go has no undefined analog);
 //   - Bool               → bool;
@@ -30,16 +20,16 @@ type Field struct {
 //   - String             → string;
 //   - Bytes              → []byte;
 //   - Array              → []any;
-//   - Object             → Object (ordered []Field);
-//   - Passthrough        → Plain{V: <decoded value>} (the clear-field marker).
+//   - vcvalue.Object             → vcvalue.Object (ordered []Field);
+//   - Passthrough        → vcvalue.Plain{V: <decoded value>} (the clear-field marker).
 //
 // Go maps exactly in both directions — the 32-bit tags decode to int32 /
 // uint32 / float32, not widened to 64-bit — unlike JavaScript, which widens
 // every numeric tag to a JS number on decode.
 //
 // This self-describing shape is deliberately spike-scoped. A reflection-based
-// Unmarshal into caller structs (the mirror of Encode) is future work.
-func Unmarshal(buf []byte) (any, error) {
+// unmarshal into caller structs (the mirror of Encode) is future work.
+func unmarshal(buf []byte) (any, error) {
 	r := &reader{buf: buf}
 	v, err := decodeValue(r, 0)
 	if err != nil {
@@ -135,9 +125,9 @@ func decodeValue(r *reader, depth int) (any, error) {
 		if err != nil {
 			return nil, err
 		}
-		fields := make(Object, 0, eagerCap(n))
+		fields := make(vcvalue.Object, 0, eagerCap(n))
 		// Duplicate keys are rejected as on the ciphertext decode path (and
-		// both Rust decoders): an Object with duplicates cannot survive a
+		// both Rust decoders): an vcvalue.Object with duplicates cannot survive a
 		// re-encode through a Go map without silently dropping an entry.
 		seen := make(map[string]struct{}, eagerCap(n))
 		for range n {
@@ -153,18 +143,18 @@ func decodeValue(r *reader, depth int) (any, error) {
 			if err != nil {
 				return nil, err
 			}
-			fields = append(fields, Field{Key: key, Value: value})
+			fields = append(fields, vcvalue.Field{Key: key, Value: value})
 		}
 		return fields, nil
 	case tagPassthrough:
-		// A passthrough value surfaces as Plain{V: <decoded value>}, the
-		// mirror of the Encoder's Plain opt-in, so a caller can tell the
+		// A passthrough value surfaces as vcvalue.Plain{V: <decoded value>}, the
+		// mirror of the Encoder's vcvalue.Plain opt-in, so a caller can tell the
 		// field travelled in the clear.
 		inner, err := decodeValue(r, depth+1)
 		if err != nil {
 			return nil, err
 		}
-		return Plain{V: inner}, nil
+		return vcvalue.Plain{V: inner}, nil
 	default:
 		return nil, errMalformed
 	}

--- a/bindings/go/vcencrypt/doc.go
+++ b/bindings/go/vcencrypt/doc.go
@@ -5,10 +5,10 @@
 // vitaminc-encrypt is a single-static-key cipher BY DESIGN — that is exactly
 // what this package binds. Key management, rotation and ZeroKMS envelope keys
 // belong to the forthcoming stack-encrypt SDK and are out of scope here. This
-// package exists to prove the value model and transport work end-to-end
-// through wasm; it is a reference tool, not the product surface. Application
-// code that wants only the value model and transport codec (with no wasm
-// or crypto dependency) should import the sibling vcvalue module instead.
+// package exists to prove the value model works end-to-end through wasm; it
+// is a reference tool, not the product surface. The value model itself (the
+// types application code touches: Plain, Sealed and the marker leaves,
+// Object) lives in the dependency-free sibling module vcvalue.
 //
 // # Shape
 //
@@ -23,6 +23,32 @@
 // embedded here; wazero runs it in-process — no shared libraries, no cgo
 // toolchain. A process-wide compilation cache means only the first client
 // pays the compile cost.
+//
+// # Encoding
+//
+// Encrypt walks ordinary Go values with encoding/json-style rules: builtins,
+// slices, maps (keys sorted for deterministic structure) and structs (by
+// field name, honoring `vc:"..."` tags). A user type implements Encryptable
+// to control its own sealing (Go's answer to Rust's Encrypt, since Go has no
+// orphan impls); the Encoder it receives is a recorder, not a live cipher
+// handle. Non-secret fields travel in the clear only by explicit opt-in:
+// the vcvalue.Plain{V: ...} marker under reflection, or the Encoder's
+// Passthrough channel — never implicitly.
+//
+// Decrypt returns the self-describing decode shape: Go natives at the exact
+// numeric widths, []any for sequences, the ordered vcvalue.Object for maps,
+// vcvalue.Sealed leaves where fields stay encrypted, and vcvalue.Plain for
+// passthrough fields. Decoding into caller structs (the mirror of the
+// reflection encode) is deliberately future work.
+//
+// # Transport, not storage
+//
+// The wire bytes this package shuttles across the wasm boundary are an FFI
+// detail and are deliberately unexported: the codec is NOT a storage format
+// and carries no compatibility commitment. The only frozen bytes are the
+// sealed leaves inside the AEAD envelope (see vcvalue.Sealed). Durable
+// cross-language database interop is a schema-aware layer's job, which this
+// package knows nothing about.
 //
 // Security notes:
 //   - Buffers inside guest memory are zeroized before being freed, and the

--- a/bindings/go/vcencrypt/encoder.go
+++ b/bindings/go/vcencrypt/encoder.go
@@ -1,4 +1,4 @@
-package vcvalue
+package vcencrypt
 
 import (
 	"encoding/binary"
@@ -9,12 +9,14 @@ import (
 	"slices"
 	"strings"
 	"unicode/utf8"
+
+	"github.com/cipherstash/vitaminc/bindings/go/vcvalue"
 )
 
 // Encryptable is the extension point for user types: a type implements it to
 // control how it is sealed, the way a Rust type implements `Encrypt`. Because
 // Go has no orphan impls, this interface (rather than reflection) is how a
-// type opts into a bespoke encoding. Encode and Marshal consult it before
+// type opts into a bespoke encoding. Encode and marshal consult it before
 // falling back to reflection.
 type Encryptable interface {
 	// EncryptValue records this value into enc. Implementations write
@@ -23,25 +25,11 @@ type Encryptable interface {
 	EncryptValue(enc Encoder) error
 }
 
-// Plain marks a value that must travel through the cipher **unencrypted and
-// unauthenticated** — the reflection-encode opt-in for passthrough. Wrap a
-// non-secret value (Plain{V: id}) and Encode/Marshal records it via the
-// Encoder's Passthrough channel instead of sealing it. Passthrough never
-// happens implicitly: only an explicit Plain (or a direct
-// enc.Passthrough() call) produces it.
-//
-// A decoded passthrough field surfaces back as Plain{V: <decoded value>},
-// so the marking round-trips and a caller can tell which fields were in the
-// clear. See the package docs — non-sensitive fields only.
-type Plain struct {
-	V any
-}
-
 // encState is the buffer and first-error shared by an Encoder and every
 // sub-encoder it hands out. Errors accumulate: once one is recorded, further
 // channel calls are no-ops, so consumer code can chain writes without
 // checking after every call and still surface the first failure from
-// End/Marshal.
+// End/marshal.
 type encState struct {
 	buf []byte
 	err error
@@ -190,7 +178,7 @@ func (e Encoder) String(s string) {
 		return
 	}
 	if !utf8.ValidString(s) {
-		e.st.fail(errors.New("vcvalue: string is not valid UTF-8"))
+		e.st.fail(errors.New("vcencrypt: string is not valid UTF-8"))
 		return
 	}
 	e.push(tagString)
@@ -229,7 +217,7 @@ func (e Encoder) Bytes(b []byte) {
 func (e Encoder) Passthrough() Encoder {
 	if e.st.err == nil {
 		if e.depth+1 > maxDepth {
-			e.st.fail(errors.New("vcvalue: value is nested too deeply"))
+			e.st.fail(errors.New("vcencrypt: value is nested too deeply"))
 		} else {
 			e.push(tagPassthrough)
 		}
@@ -246,7 +234,7 @@ func (e Encoder) Seq() *SeqEncoder {
 		return s
 	}
 	if e.depth+1 > maxDepth {
-		e.st.fail(errors.New("vcvalue: value is nested too deeply"))
+		e.st.fail(errors.New("vcencrypt: value is nested too deeply"))
 		return s
 	}
 	e.push(tagArray)
@@ -263,7 +251,7 @@ func (e Encoder) Map() *MapEncoder {
 		return m
 	}
 	if e.depth+1 > maxDepth {
-		e.st.fail(errors.New("vcvalue: value is nested too deeply"))
+		e.st.fail(errors.New("vcencrypt: value is nested too deeply"))
 		return m
 	}
 	e.push(tagObject)
@@ -292,9 +280,9 @@ type SeqEncoder struct {
 // checkPrev verifies the previous element slot completed exactly once.
 func (s *SeqEncoder) checkPrev() {
 	if s.childDone > s.count {
-		s.st.fail(fmt.Errorf("vcvalue: more than one value was written for sequence element %d", s.count-1))
+		s.st.fail(fmt.Errorf("vcencrypt: more than one value was written for sequence element %d", s.count-1))
 	} else if s.count > 0 && s.childDone < s.count {
-		s.st.fail(fmt.Errorf("vcvalue: sequence element %d was never completed", s.count-1))
+		s.st.fail(fmt.Errorf("vcencrypt: sequence element %d was never completed", s.count-1))
 	}
 }
 
@@ -310,8 +298,15 @@ func (s *SeqEncoder) Elem() Encoder {
 	return Encoder{st: s.st, depth: s.depth, done: &s.childDone}
 }
 
-// End finalizes the sequence, writing its element count, and returns the
-// first error recorded during the whole encode (if any).
+// End finalizes the sequence, writing its element count.
+//
+// Error contract (deliberate, frozen): End returns the first error recorded
+// anywhere in the whole encode so far — not one scoped to this sequence. A
+// nested container's End can therefore surface an error caused elsewhere in
+// the tree. Errors are sticky (later channel calls no-op), so an
+// EncryptValue implementation may chain writes without checking and return
+// the outermost End; inspecting intermediate errors for *which* slot failed
+// is not part of the contract — the error text names the slot instead.
 func (s *SeqEncoder) End() error {
 	if s.st.err == nil {
 		s.checkPrev()
@@ -357,9 +352,9 @@ type MapEncoder struct {
 // checkPrev verifies the previous entry's value slot completed exactly once.
 func (m *MapEncoder) checkPrev() {
 	if m.childDone > m.count {
-		m.st.fail(fmt.Errorf("vcvalue: more than one value was written for key %q", m.lastKey))
+		m.st.fail(fmt.Errorf("vcencrypt: more than one value was written for key %q", m.lastKey))
 	} else if m.count > 0 && m.childDone < m.count {
-		m.st.fail(fmt.Errorf("vcvalue: value for key %q was never completed", m.lastKey))
+		m.st.fail(fmt.Errorf("vcencrypt: value for key %q was never completed", m.lastKey))
 	}
 }
 
@@ -372,9 +367,9 @@ func (m *MapEncoder) Field(key string) Encoder {
 	}
 	if m.st.err == nil {
 		if !utf8.ValidString(key) {
-			m.st.fail(errors.New("vcvalue: object key is not valid UTF-8"))
+			m.st.fail(errors.New("vcencrypt: object key is not valid UTF-8"))
 		} else if _, dup := m.seen[key]; dup {
-			m.st.fail(fmt.Errorf("vcvalue: duplicate key %q in map encoding", key))
+			m.st.fail(fmt.Errorf("vcencrypt: duplicate key %q in map encoding", key))
 		} else if buf, err := appendChunk(m.st.buf, []byte(key)); err != nil {
 			m.st.fail(err)
 		} else {
@@ -390,8 +385,9 @@ func (m *MapEncoder) Field(key string) Encoder {
 	return Encoder{st: m.st, depth: m.depth, done: &m.childDone}
 }
 
-// End finalizes the map, writing its entry count, and returns the first
-// error recorded during the whole encode (if any).
+// End finalizes the map, writing its entry count. Same error contract as
+// SeqEncoder.End: the first error of the whole encode, not one scoped to
+// this map.
 func (m *MapEncoder) End() error {
 	if m.st.err == nil {
 		m.checkPrev()
@@ -411,16 +407,16 @@ func patchLen(st *encState, off, count int) error {
 		return st.err
 	}
 	if count < 0 || uint64(count) > maxUint32 {
-		st.fail(fmt.Errorf("vcvalue: item count %d out of range", count))
+		st.fail(fmt.Errorf("vcencrypt: item count %d out of range", count))
 		return st.err
 	}
 	binary.LittleEndian.PutUint32(st.buf[off:off+4], uint32(count))
 	return nil
 }
 
-// Marshal encodes v into the value transport form the guest expects. It is
-// the encode counterpart of Unmarshal and the path Client.Encrypt uses.
-func Marshal(v any) ([]byte, error) {
+// marshal encodes v into the value transport form the guest expects. It is
+// the encode counterpart of unmarshal and the path Client.Encrypt uses.
+func marshal(v any) ([]byte, error) {
 	st := &encState{}
 	var root int
 	if err := Encode(Encoder{st: st, done: &root}, v); err != nil {
@@ -430,7 +426,7 @@ func Marshal(v any) ([]byte, error) {
 	// Encryptable can leave the root empty (or an un-Ended container) or
 	// write more than once.
 	if root != 1 {
-		return nil, fmt.Errorf("vcvalue: encode must complete exactly one root value, completed %d", root)
+		return nil, fmt.Errorf("vcencrypt: encode must complete exactly one root value, completed %d", root)
 	}
 	return st.buf, nil
 }
@@ -489,9 +485,9 @@ func encodeAny(enc Encoder, v any) {
 // must special-case before any reflection sees them. Returns true when v was
 // fully handled.
 //
-//   - Plain is the explicit passthrough opt-in; checked before Encryptable
+//   - vcvalue.Plain is the explicit passthrough opt-in; checked before Encryptable
 //     and the struct arm so it is never mistaken for a plain struct.
-//   - Object is decode-only in spirit, but a decrypt-then-re-encrypt flow
+//   - vcvalue.Object is decode-only in spirit, but a decrypt-then-re-encrypt flow
 //     legitimately feeds it back in; without interception the reflect slice
 //     arm would encode it as a SEQ of {Key,Value} structs, silently changing
 //     the record's structure.
@@ -500,10 +496,10 @@ func encodeAny(enc Encoder, v any) {
 //     in typical implementations; it encodes as Null like every other nil.
 func interceptMarkers(enc Encoder, v any) bool {
 	switch x := v.(type) {
-	case Plain:
+	case vcvalue.Plain:
 		encodeAny(enc.Passthrough(), x.V)
 		return true
-	case Object:
+	case vcvalue.Object:
 		encodeObject(enc, x)
 		return true
 	}
@@ -520,9 +516,9 @@ func interceptMarkers(enc Encoder, v any) bool {
 	return false
 }
 
-// encodeObject re-encodes a decoded Object with object framing, preserving
-// its field order (Object exists precisely to preserve wire order).
-func encodeObject(enc Encoder, o Object) {
+// encodeObject re-encodes a decoded vcvalue.Object with object framing, preserving
+// its field order (vcvalue.Object exists precisely to preserve wire order).
+func encodeObject(enc Encoder, o vcvalue.Object) {
 	m := enc.Map()
 	for _, f := range o {
 		encodeAny(m.Field(f.Key), f.Value)
@@ -539,7 +535,7 @@ func encodeReflect(enc Encoder, rv reflect.Value) {
 		return
 	}
 	// Re-check the explicit markers for values reached through reflection
-	// (struct fields, slice elements, map values). Plain is itself a struct,
+	// (struct fields, slice elements, map values). vcvalue.Plain is itself a struct,
 	// so it must be intercepted before the reflect.Struct arm below.
 	if rv.CanInterface() && interceptMarkers(enc, rv.Interface()) {
 		return
@@ -597,13 +593,13 @@ func encodeReflect(enc Encoder, rv reflect.Value) {
 		// no container framing, so without this a pointer cycle (x = &x)
 		// would recurse to stack overflow instead of failing cleanly.
 		if enc.depth+1 > maxDepth {
-			enc.st.fail(errors.New("vcvalue: value is nested too deeply"))
+			enc.st.fail(errors.New("vcencrypt: value is nested too deeply"))
 			return
 		}
 		// Same slot: the dereferenced value completes the pointer's counter.
 		encodeReflect(Encoder{st: enc.st, depth: enc.depth + 1, done: enc.done}, rv.Elem())
 	default:
-		enc.st.fail(fmt.Errorf("vcvalue: cannot encode value of kind %s", rv.Kind()))
+		enc.st.fail(fmt.Errorf("vcencrypt: cannot encode value of kind %s", rv.Kind()))
 	}
 }
 
@@ -617,7 +613,7 @@ func encodeSeq(enc Encoder, rv reflect.Value) {
 
 func encodeMap(enc Encoder, rv reflect.Value) {
 	if rv.Type().Key().Kind() != reflect.String {
-		enc.st.fail(fmt.Errorf("vcvalue: map keys must be strings, got %s", rv.Type().Key()))
+		enc.st.fail(fmt.Errorf("vcencrypt: map keys must be strings, got %s", rv.Type().Key()))
 		return
 	}
 	keys := rv.MapKeys()
@@ -660,7 +656,7 @@ func encodeStruct(enc Encoder, rv reflect.Value) {
 	// caller asked for the empty encoding explicitly.
 	if encoded == 0 && unexported > 0 {
 		enc.st.fail(fmt.Errorf(
-			"vcvalue: struct %s has no exported fields to encode — implement Encryptable to control its sealing", t))
+			"vcencrypt: struct %s has no exported fields to encode — implement Encryptable to control its sealing", t))
 		return
 	}
 	_ = m.End()

--- a/bindings/go/vcencrypt/examples/userrecord/main.go
+++ b/bindings/go/vcencrypt/examples/userrecord/main.go
@@ -24,7 +24,7 @@ import (
 	"github.com/cipherstash/vitaminc/bindings/go/vcvalue"
 )
 
-// User controls its own sealing via vcvalue.Encryptable: id and created_at
+// User controls its own sealing via vcencrypt.Encryptable: id and created_at
 // travel in the clear (readable and indexable without the key), email and
 // name are sealed.
 type User struct {
@@ -34,7 +34,7 @@ type User struct {
 	Name      string
 }
 
-func (u User) EncryptValue(enc vcvalue.Encoder) error {
+func (u User) EncryptValue(enc vcencrypt.Encoder) error {
 	m := enc.Map()
 	m.Field("id").Passthrough().Int64(u.ID)
 	m.Field("created_at").Passthrough().String(u.CreatedAt)

--- a/bindings/go/vcencrypt/export_test.go
+++ b/bindings/go/vcencrypt/export_test.go
@@ -1,0 +1,9 @@
+package vcencrypt
+
+// Test-only bridges: the transport codec is deliberately unexported (it is
+// an FFI detail, not a storage format), but the external test package needs
+// raw decode access for the cross-language fixture.
+var (
+	UnmarshalForTest           = unmarshal
+	UnmarshalCipherTextForTest = unmarshalCipherText
+)

--- a/bindings/go/vcencrypt/fuzz_test.go
+++ b/bindings/go/vcencrypt/fuzz_test.go
@@ -1,9 +1,7 @@
-package vcvalue_test
+package vcencrypt
 
 import (
 	"testing"
-
-	"github.com/cipherstash/vitaminc/bindings/go/vcvalue"
 )
 
 // Unmarshal and UnmarshalCipherText are the package's entire hostile-input
@@ -25,11 +23,11 @@ func FuzzUnmarshal(f *testing.F) {
 	f.Add([]byte{0x11, 2, 0, 0, 0, 1, 0, 0, 0, 'a', 0x00}) // short object
 
 	f.Fuzz(func(t *testing.T, data []byte) {
-		v, err := vcvalue.Unmarshal(data)
+		v, err := unmarshal(data)
 		if err != nil {
 			return
 		}
-		if _, err := vcvalue.Marshal(v); err != nil {
+		if _, err := marshal(v); err != nil {
 			t.Fatalf("accepted decode failed to re-encode: %v (value %#v)", err, v)
 		}
 	})
@@ -44,11 +42,11 @@ func FuzzUnmarshalCipherText(f *testing.F) {
 	f.Add([]byte{0x03, 0xFF, 0xFF, 0xFF, 0xFF})                              // hostile count
 
 	f.Fuzz(func(t *testing.T, data []byte) {
-		v, err := vcvalue.UnmarshalCipherText(data)
+		v, err := unmarshalCipherText(data)
 		if err != nil {
 			return
 		}
-		if _, err := vcvalue.MarshalCipherText(v); err != nil {
+		if _, err := marshalCipherText(v); err != nil {
 			t.Fatalf("accepted ciphertext decode failed to re-encode: %v (value %#v)", err, v)
 		}
 	})

--- a/bindings/go/vcencrypt/transport.go
+++ b/bindings/go/vcencrypt/transport.go
@@ -1,4 +1,4 @@
-package vcvalue
+package vcencrypt
 
 import (
 	"encoding/binary"
@@ -66,11 +66,11 @@ func eagerCap(n int) int {
 	return min(n, maxEagerCapacity)
 }
 
-var errMalformed = errors.New("vcvalue: malformed transport bytes")
+var errMalformed = errors.New("vcencrypt: malformed transport bytes")
 
 func appendLen(out []byte, n int) ([]byte, error) {
 	if n < 0 || uint64(n) > maxUint32 {
-		return nil, fmt.Errorf("vcvalue: length %d out of range", n)
+		return nil, fmt.Errorf("vcencrypt: length %d out of range", n)
 	}
 	return binary.LittleEndian.AppendUint32(out, uint32(n)), nil
 }

--- a/bindings/go/vcencrypt/transport_internal_test.go
+++ b/bindings/go/vcencrypt/transport_internal_test.go
@@ -1,4 +1,4 @@
-package vcvalue
+package vcencrypt
 
 import "testing"
 

--- a/bindings/go/vcencrypt/vcencrypt_test.go
+++ b/bindings/go/vcencrypt/vcencrypt_test.go
@@ -191,7 +191,7 @@ type person struct {
 	Age  uint64
 }
 
-func (p person) EncryptValue(enc vcvalue.Encoder) error {
+func (p person) EncryptValue(enc vcencrypt.Encoder) error {
 	m := enc.Map()
 	m.Field("name").String(p.Name)
 	m.Field("age").UInt64(p.Age)
@@ -496,11 +496,11 @@ func TestCrossLanguageFixture(t *testing.T) {
 	}
 	aad, ctBytes, valBytes := chunk(), chunk(), chunk()
 
-	ct, err := vcvalue.UnmarshalCipherText(ctBytes)
+	ct, err := vcencrypt.UnmarshalCipherTextForTest(ctBytes)
 	if err != nil {
 		t.Fatalf("decoding fixture ciphertext: %v", err)
 	}
-	want, err := vcvalue.Unmarshal(valBytes)
+	want, err := vcencrypt.UnmarshalForTest(valBytes)
 	if err != nil {
 		t.Fatalf("decoding fixture expected value: %v", err)
 	}

--- a/bindings/go/vcvalue/README.md
+++ b/bindings/go/vcvalue/README.md
@@ -1,14 +1,15 @@
 # vcvalue — the durable value layer
 
 `vcvalue` is the Go materialization of vitaminc's **frozen data model**: the
-value model (encoder / `Encryptable` / reflection encode, plus a natives
-decode), the transport codec, and the `CipherText` projection.
+value types application code holds and stores — `Plain`, the sealed leaf
+family, and the ordered `Object` decode shape.
 
-It has **zero dependencies** — no wazero, no crypto, nothing. It is the module
-a future stack-encrypt Go SDK is expected to import for its encode/decode
-surface. Keeping it dependency-free is the point: the wasm reference harness
-(`vcencrypt`, next door) is just *one* consumer, and its wazero/crypto
-dependencies must never leak into the layer real applications depend on.
+It has **zero dependencies** — no wazero, no crypto, and (deliberately) no
+wire format. It is the module a future stack-encrypt Go SDK is expected to
+import. Keeping it dependency-free is the point: the wasm reference harness
+(`vcencrypt`, next door) is just *one* consumer, and neither its
+wazero/crypto dependencies nor its FFI wire encoding may leak into the layer
+real applications depend on.
 
 ```
 import "github.com/cipherstash/vitaminc/bindings/go/vcvalue"
@@ -18,48 +19,31 @@ import "github.com/cipherstash/vitaminc/bindings/go/vcvalue"
 
 The cross-language contract is the frozen sealed-leaf tag table
 (`[tag] ++ payload`, sealed **inside** the AEAD envelope, defined in the Rust
-crate `vitaminc-aead-value`) — not any language's types. This package's
-`Encoder` channels and decode natives *implement* that model; they are not the
-contract. A new tag is added only when a value class cannot be represented in
-the existing model, and needs a defined decode mapping in every supported
-language before it ships.
+crate `vitaminc-aead-value`) — not any language's types. This package's types
+*implement* that model; they are not the contract. A new tag is added only
+when a value class cannot be represented in the existing model, and needs a
+defined decode mapping in every supported language before it ships.
 
-The transport encoding used to hand a tree across an FFI boundary in one copy
-(`Marshal` / `Unmarshal`, `MarshalCipherText` / `UnmarshalCipherText`) is
-**transport-only**, not a storage format. Durable cross-language database
-interop is a schema-aware layer's job, which this package knows nothing about.
-
-## Encoding
-
-- Types implement `Encryptable` to control their own sealing (Go's answer to
-  Rust's `Encrypt`, since Go has no orphan impls).
-- Everything else goes through `Encode`/`Marshal` with `encoding/json`-style
-  reflection: builtins, slices, maps (keys sorted for a deterministic
-  structure), and structs (by field name, honoring `vc:"..."` tags).
-- The numeric family stays distinct by signedness **and** width: `int16`→
-  `INT32`, `int`/`int64`→`INT64`, `uint`/`uintptr`→`UINT64`, `float32`→
-  `FLOAT32`, and so on. Go maps **exactly in both directions**.
+The transport codec — the wire encoding that hands a tree across an FFI
+boundary in one copy — is **not part of this module**. It is an unexported
+detail of whichever consumer owns the boundary (`vcencrypt` for the wasm
+harness), because it is transport-only and carries no storage commitment:
+the only bytes an application should ever persist are the sealed leaves.
+The `Encryptable`/`Encoder` encoding extension point lives with the codec in
+`vcencrypt` for the same reason.
 
 ## Passthrough — fields in the clear
 
 Some fields are not secret and should travel unencrypted alongside the sealed
-ones. `vcvalue` carries them as **passthrough**: unencrypted *and*
-unauthenticated, non-sensitive fields only.
-
-Passthrough never happens implicitly — you opt in:
+ones. The model carries them as **passthrough**: unencrypted *and*
+unauthenticated, non-sensitive fields only. Passthrough never happens
+implicitly — you opt in by wrapping the value in `Plain`:
 
 ```go
-// Reflection encode: wrap the value in Plain.
 value := map[string]any{
     "id":    vcvalue.Plain{V: int64(42)}, // in the clear
     "email": "ada@example.com",           // sealed
 }
-
-// Or drive the Encoder channel directly:
-m := enc.Map()
-m.Field("id").Passthrough().Int64(42)
-m.Field("email").String("ada@example.com")
-m.End()
 ```
 
 On decode a passthrough field surfaces back as `Plain{V: <decoded value>}`, so
@@ -99,8 +83,8 @@ bound into its own value's AAD.
 
 ## Decoding
 
-`Unmarshal` turns value transport bytes into Go natives (`nil`, `bool`,
-`int32`, `int64`, `uint32`, `uint64`, `float32`, `float64`, `string`,
-`[]byte`, `[]any`, the ordered `Object` for maps, and `Plain` for passthrough).
-A reflection-based `Unmarshal` into caller structs (the mirror of `Encode`) is
-future work.
+Decryption (in `vcencrypt`) returns Go natives at the exact numeric widths
+(`nil`, `bool`, `int32`, `int64`, `uint32`, `uint64`, `float32`, `float64`,
+`string`, `[]byte`, `[]any`), this package's ordered `Object` for maps, and
+`Plain` for passthrough. A reflection-based decode into caller structs (the
+mirror of the reflection encode) is future work.

--- a/bindings/go/vcvalue/doc.go
+++ b/bindings/go/vcvalue/doc.go
@@ -1,49 +1,38 @@
 // Package vcvalue is the durable, dependency-free module of the vitaminc Go
-// bindings: the value model and its transport codec, with no dependency
-// on wazero or any crypto. A future stack-encrypt Go SDK is expected to
-// import this module for its encode/decode surface; the wasm reference
-// harness (module vcencrypt) is only one consumer of it.
+// bindings: the value model — the types application code holds and stores —
+// with no dependency on wazero, any crypto, or any wire format. A future
+// stack-encrypt Go SDK is expected to import this module; the wasm reference
+// harness (module vcencrypt) is one consumer of it.
 //
-// # The model, not this package
+// # The model
+//
+//   - Plain{V: ...} marks (and surfaces) a field that travels in the clear —
+//     unencrypted and unauthenticated — beside the sealed ones. It is always
+//     an explicit opt-in, never inferred.
+//   - Sealed is one encrypted leaf (version || nonce || ciphertext || tag),
+//     the only frozen byte format in the model. SealedNone, SealedEmptySeq
+//     and SealedEmptyMap are its authenticated marker siblings for absent
+//     values and empty composites.
+//   - Object is the ordered map-decode shape (entry order preserved, so
+//     results compare deterministically); Field is one entry of it.
+//
+// All of the sealed leaf types and Plain implement driver.Valuer (and the
+// leaves sql.Scanner), so a map-shaped ciphertext binds directly as database
+// named parameters and sealed columns load back without conversion.
+//
+// # What is deliberately NOT here
+//
+// The transport codec — the wire encoding that carries a value tree across
+// an FFI boundary — is an unexported detail of the consumer that owns the
+// boundary (module vcencrypt, for the wasm harness). It is not a storage
+// format, so this module does not export it: the only bytes an application
+// should ever persist are the sealed leaves above. The Encryptable/Encoder
+// extension point for custom encodings lives with the codec in vcencrypt
+// for the same reason.
 //
 // The cross-language contract is the frozen tag table plus the sealed leaf
-// encodings ([tag] ++ payload, sealed inside the AEAD envelope) defined in
-// the Rust crate vitaminc-aead-value. This package is Go's materialization
-// of that model — the Encoder channels and the decode natives implement the
-// model; they are not themselves the contract. A new tag is added only when
-// a value class cannot be represented in the existing model, and requires a
-// defined decode mapping for every supported language before it ships.
-//
-// # Encoding
-//
-// User types implement Encryptable to control their own sealing (Go's answer
-// to Rust's Encrypt, since Go has no orphan impls). For everything else,
-// Encode/Marshal walk Go values with encoding/json-style rules — builtins,
-// slices, maps (keys sorted for deterministic structure), and structs (by
-// field name, honoring `vc:"..."` tags). The Encoder is a recorder that
-// writes the transport form; it is not a live cipher handle.
-//
-// # Passthrough
-//
-// Non-secret fields can travel in the clear (unencrypted and unauthenticated)
-// beside the sealed ones. It never happens implicitly: reflection encode
-// requires the Plain{V: ...} marker, and the Encoder exposes an explicit
-// Passthrough() channel. A decoded passthrough field surfaces back as
-// Plain{V: ...}, and a passthrough node in a ciphertext is likewise a Plain
-// with a readable value.
-//
-// # Decoding
-//
-// Unmarshal turns value transport bytes into Go natives (nil, bool, the exact
-// numeric widths, string, []byte, []any, the ordered Object type for maps, and
-// Plain for passthrough). A reflection-based Unmarshal into caller structs is
-// future work.
-//
-// # Transport, not storage
-//
-// The transport encoding here exists to hand a tree across an FFI boundary
-// in one copy. It is NOT a storage format and carries no compatibility
-// commitment; the only frozen bytes are the sealed leaves inside the AEAD
-// envelope. Durable cross-language database interop is a schema-aware layer's
-// job, which this package knows nothing about.
+// encodings defined in the Rust crate vitaminc-aead-value — the model, not
+// any package. A new tag is added only when a value class cannot be
+// represented in the existing model, and requires a defined decode mapping
+// for every supported language before it ships.
 package vcvalue

--- a/bindings/go/vcvalue/model.go
+++ b/bindings/go/vcvalue/model.go
@@ -1,0 +1,27 @@
+package vcvalue
+
+// Plain marks a value that must travel through the cipher **unencrypted and
+// unauthenticated** — the reflection-encode opt-in for passthrough. Wrap a
+// non-secret value (Plain{V: id}) and the vcencrypt
+// encoder records it via its Passthrough channel instead of sealing it. Passthrough never
+// happens implicitly: only an explicit Plain (or a direct
+// enc.Passthrough() call) produces it.
+//
+// A decoded passthrough field surfaces back as Plain{V: <decoded value>},
+// so the marking round-trips and a caller can tell which fields were in the
+// clear. See the package docs — non-sensitive fields only.
+type Plain struct {
+	V any
+}
+
+// Object is the decode result for a map-mode value: an ordered list of
+// fields mirroring the wire order. Decoding uses this (rather than a Go map)
+// so entry order is preserved and results compare deterministically. Encode
+// takes any/struct/map instead — this type is decode-only.
+type Object []Field
+
+// Field is one entry of a decoded Object.
+type Field struct {
+	Key   string
+	Value any
+}

--- a/bindings/go/vcvalue/model_test.go
+++ b/bindings/go/vcvalue/model_test.go
@@ -1,0 +1,134 @@
+package vcvalue_test
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"math"
+	"reflect"
+	"testing"
+
+	"github.com/cipherstash/vitaminc/bindings/go/vcvalue"
+)
+
+// Every sealed leaf type must survive the database column round trip:
+// Value() then Scan() back into the same type.
+func TestSealedLeafTypesScanValueRoundTrip(t *testing.T) {
+	roundTrip := func(t *testing.T, value driver.Valuer, scan sql.Scanner, got func() []byte, want []byte) {
+		t.Helper()
+		v, err := value.Value()
+		if err != nil {
+			t.Fatalf("Value: %v", err)
+		}
+		if err := scan.Scan(v); err != nil {
+			t.Fatalf("Scan: %v", err)
+		}
+		if !reflect.DeepEqual(got(), want) {
+			t.Fatalf("got %#v, want %#v", got(), want)
+		}
+	}
+
+	leaf := []byte{1, 2, 3}
+	var s vcvalue.Sealed
+	roundTrip(t, vcvalue.Sealed(leaf), &s, func() []byte { return []byte(s) }, leaf)
+	var n vcvalue.SealedNone
+	roundTrip(t, vcvalue.SealedNone(leaf), &n, func() []byte { return []byte(n) }, leaf)
+	var es vcvalue.SealedEmptySeq
+	roundTrip(t, vcvalue.SealedEmptySeq(leaf), &es, func() []byte { return []byte(es) }, leaf)
+	var em vcvalue.SealedEmptyMap
+	roundTrip(t, vcvalue.SealedEmptyMap(leaf), &em, func() []byte { return []byte(em) }, leaf)
+
+	// Non-byte sources are rejected.
+	if err := (&es).Scan("not bytes"); err == nil {
+		t.Fatal("scanning a string into SealedEmptySeq must fail")
+	}
+}
+
+// Every integer kind the encoder accepts must also bind through the driver:
+// Plain{V: user.ID} with ID int encodes fine, so Value() must not reject it.
+func TestPlainValueBindsEveryEncodableIntegerKind(t *testing.T) {
+	cases := []struct {
+		in   any
+		want driver.Value
+	}{
+		{int(7), int64(7)},
+		{int8(-8), int64(-8)},
+		{int16(-16), int64(-16)},
+		{int32(-32), int64(-32)},
+		{int64(-64), int64(-64)},
+		{uint8(8), int64(8)},
+		{uint16(16), int64(16)},
+		{uint32(32), int64(32)},
+		{uint(64), int64(64)},
+		{uint64(64), int64(64)},
+	}
+	for _, c := range cases {
+		got, err := vcvalue.Plain{V: c.in}.Value()
+		if err != nil {
+			t.Fatalf("Value(%T): %v", c.in, err)
+		}
+		if got != c.want {
+			t.Fatalf("Value(%T): got %#v, want %#v", c.in, got, c.want)
+		}
+	}
+
+	// The unsigned kinds that can exceed int64 must fail closed.
+	if _, err := (vcvalue.Plain{V: uint64(math.MaxInt64) + 1}).Value(); err == nil {
+		t.Fatal("uint64 above MaxInt64 must not bind")
+	}
+	if uint64(math.MaxUint) > math.MaxInt64 { // uint is 32-bit on GOARCH=386
+		if _, err := (vcvalue.Plain{V: uint(math.MaxUint)}).Value(); err == nil {
+			t.Fatal("uint above MaxInt64 must not bind")
+		}
+	}
+}
+
+// Plain.Value's driver conversions: width-narrowing, the uint64 overflow
+// error, and the container-has-no-column error.
+func TestPlainValueConversions(t *testing.T) {
+	cases := []struct {
+		in   any
+		want driver.Value
+	}{
+		{nil, nil},
+		{true, true},
+		{int64(7), int64(7)},
+		{"s", "s"},
+		{[]byte{1}, []byte{1}},
+		{int32(-3), int64(-3)},
+		{uint32(9), int64(9)},
+		{float32(0.5), float64(0.5)},
+		{float64(1.5), float64(1.5)},
+		{uint64(11), int64(11)},
+	}
+	for _, c := range cases {
+		got, err := vcvalue.Plain{V: c.in}.Value()
+		if err != nil {
+			t.Fatalf("Value(%#v): %v", c.in, err)
+		}
+		if !reflect.DeepEqual(got, c.want) {
+			t.Fatalf("Value(%#v) = %#v, want %#v", c.in, got, c.want)
+		}
+	}
+
+	if _, err := (vcvalue.Plain{V: uint64(math.MaxInt64) + 1}).Value(); err == nil {
+		t.Fatal("uint64 above MaxInt64 must not silently truncate")
+	}
+	if _, err := (vcvalue.Plain{V: []any{int64(1)}}).Value(); err == nil {
+		t.Fatal("a container passthrough has no single-column form")
+	}
+}
+
+// The remaining Sealed.Scan arms: nil source and the non-byte error arm
+// (the byte round trip is covered with the marker types above).
+func TestSealedScanNilAndErrorArms(t *testing.T) {
+	s := vcvalue.Sealed{1, 2, 3}
+	if err := s.Scan(nil); err != nil {
+		t.Fatalf("Scan(nil): %v", err)
+	}
+	if s != nil {
+		t.Fatalf("Scan(nil) should clear the leaf, got %#v", s)
+	}
+	if err := s.Scan("not bytes"); err == nil {
+		t.Fatal("scanning a string into Sealed must fail")
+	}
+}


### PR DESCRIPTION
Stacked on #264 (itself on #257). Settles the three design decisions parked on the #257 review threads, per Dan's direction. Implemented by **Claude Fable** (Anthropic's Claude Fable 5 model) via Claude Code, at Dan's request.

## 1. Codec placement — decided: the codec lives with the FFI boundary

`vcvalue` is the durable, dependency-free module a future stack-encrypt Go SDK will import. It now holds **only the value model**: `Plain`, the sealed leaf family (`Sealed`, `SealedNone`, `SealedEmptySeq`, `SealedEmptyMap` with their `driver.Valuer`/`sql.Scanner` impls), and the ordered `Object`/`Field` decode shape.

The transport codec — reader/writer, reflection encoder, natives decoder, ciphertext projection — moves into `vcencrypt`, which owns the wasm boundary the codec exists for. Its entry points (`marshal`/`unmarshal`/`marshalCipherText`/`unmarshalCipherText`) are now **unexported**: the wire format is transport-only, and not exporting it makes the "no storage commitment" claim structural rather than documentary. The only bytes an application can persist are the sealed leaves.

`Encryptable` and the `Encoder` channels move with the codec (their contract *is* the wire recorder), so custom encodings are implemented against `vcencrypt` — the userrecord example is updated accordingly. The cross-language fixture test reaches the unexported decoders via the standard `export_test.go` bridge.

## 2. Unmarshal into caller structs — decided: deferred

Stays documented as future work (now in `vcencrypt`'s package docs, where decode lives). The spike ships dynamic decode shapes.

## 3. `End()` error semantics — decided: first-error-wins is the contract

`SeqEncoder.End`/`MapEncoder.End` return the first error recorded anywhere in the whole encode, not one scoped to their container. Now documented as deliberate and frozen, with `TestEndReturnsFirstEncodeErrorNotContainerScoped` pinning that an inner container's error surfaces from the outer `End`.

## Mechanics

- Pure move plus renames — no codec logic changed; every test moved with its code (fuzz targets, eagerCap pin, malformed-input suites now internal to `vcencrypt`; the driver/scan model tests stay in `vcvalue`).
- Error prefixes in moved code change `vcvalue:` → `vcencrypt:`.
- CI's 386 step now runs both modules, since the load-bearing u32 guards moved with the codec (wazero falls back to its interpreter on 386).
- Both package docs and READMEs rewritten for the new split.

## Verification

Both module suites, `go vet`, `gofmt`, 386 cross-vet, and the userrecord example run green locally; the 386 test run executes in this PR's CI.