### PR TITLE
feat(permutation): batch key derivation API (plan step 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2723,7 +2723,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
  "wasm-bindgen-shared",
 ]
 
@@ -2766,7 +2766,7 @@ checksum = "8c89dcab8b516b6b603baca9d550b7282d68fcc7f367e3956cff7ebf406a3f12"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,6 +626,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "rand_core",
+ "zeroize",
 ]
 
 [[package]]
@@ -2558,6 +2559,7 @@ dependencies = [
  "rand",
  "serde",
  "subtle",
+ "thiserror",
  "vitaminc-protected",
  "vitaminc-random",
  "zeroize",
@@ -2607,6 +2609,7 @@ dependencies = [
 name = "vitaminc-random"
 version = "0.4.0"
 dependencies = [
+ "chacha20",
  "getrandom 0.4.3",
  "rand",
  "thiserror",

--- a/packages/permutation/Cargo.toml
+++ b/packages/permutation/Cargo.toml
@@ -19,4 +19,5 @@ bitvec = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
 subtle = "2.6.1"
+thiserror = { workspace = true }
 zeroize = { workspace = true }

--- a/packages/permutation/src/key.rs
+++ b/packages/permutation/src/key.rs
@@ -11,6 +11,21 @@ use crate::{
 
 pub(crate) type KeyInner<const N: usize> = Exportable<Protected<[u8; N]>>;
 
+/// One seed in a [`PermutationKey::from_seeds`] batch could not derive a key.
+///
+/// `index` is the seed's position in the iterator passed to `from_seeds`.
+/// For [`RandomError::SeedRejected`] that seed can never derive a key:
+/// discard it, provision a fresh one, and derive the batch again.
+#[derive(Debug, thiserror::Error)]
+#[error("seed at index {index} could not derive a key: {source}")]
+pub struct BatchSeedError {
+    /// Position of the failing seed in the batch.
+    pub index: usize,
+    /// Why derivation failed for that seed.
+    #[source]
+    pub source: RandomError,
+}
+
 // NOTE: no `Copy` — `KeyInner` is a `Protected` secret, and the reasons it can
 // never be `Copy` (see the `vitaminc_protected::Protected` docs) apply to any
 // wrapper around it. Use `Clone` where a copy is needed.
@@ -49,6 +64,52 @@ impl<const N: usize> PermutationKey<N> {
     {
         let mut rng = SafeRand::from_seed(seed);
         Generatable::random(&mut rng)
+    }
+
+    /// Derives one key per seed, in order, wiping each seed once its
+    /// generator is built.
+    ///
+    /// Each seed is derived exactly as [`PermutationKey::from_seed`] would:
+    /// independently and deterministically, so the batch is bit-identical to
+    /// calling `from_seed` per seed. Seeds arrive as [`Controlled`] values
+    /// (for instance `Protected<[u8; 32]>`) rather than bare bytes, so a
+    /// batch of retained secrets is never copied around unwiped.
+    ///
+    /// A rejected seed fails the whole call and [`BatchSeedError`] names its
+    /// lane, so the caller discards just that seed and retries with the
+    /// rest. No keys are delivered for the lanes before it: a caller can
+    /// never end up holding a key vector that is out of step with its seeds.
+    ///
+    /// The batch entry point exists for bulk workloads (e.g. deriving the
+    /// per-block permutations for a batch of ORE encryptions): it fixes the
+    /// API shape so a future vectorized backend can derive lanes in parallel
+    /// while remaining bit-identical to per-seed scalar derivation.
+    pub fn from_seeds<C>(seeds: impl IntoIterator<Item = C>) -> Result<Vec<Self>, BatchSeedError>
+    where
+        [u8; N]: IsPermutable,
+        C: Controlled<Inner = [u8; 32]>,
+    {
+        Self::derive_batch(seeds, Generatable::random)
+    }
+
+    /// The batch loop behind [`from_seeds`](Self::from_seeds), with the
+    /// per-lane derivation injected. Exists so tests can drive a rejected
+    /// lane: the natural rate is ≈ 2⁻⁴³ per seed, unreachable by search.
+    fn derive_batch<C>(
+        seeds: impl IntoIterator<Item = C>,
+        mut derive: impl FnMut(&mut SafeRand) -> Result<Self, RandomError>,
+    ) -> Result<Vec<Self>, BatchSeedError>
+    where
+        C: Controlled<Inner = [u8; 32]>,
+    {
+        seeds
+            .into_iter()
+            .enumerate()
+            .map(|(index, seed)| {
+                let mut rng = SafeRand::from_controlled_seed(seed);
+                derive(&mut rng).map_err(|source| BatchSeedError { index, source })
+            })
+            .collect()
     }
 
     /// Returns the inverse of this key.
@@ -131,10 +192,10 @@ mod tests {
         elementwise::Permute,
         key::KeyInner,
         private::{identity, IsPermutable},
-        PermutationKey,
+        BatchSeedError, PermutationKey,
     };
-    use vitaminc_protected::{Controlled, Zeroed};
-    use vitaminc_random::{Generatable, SafeRand, SeedableRng};
+    use vitaminc_protected::{Controlled, Protected, Zeroed};
+    use vitaminc_random::{Generatable, RandomError, SafeRand, SeedableRng};
 
     use crate::tests;
 
@@ -255,6 +316,110 @@ mod tests {
         let chi2 = raw * (N - 1) as f64 / N as f64;
         assert!(chi2 < 85.35, "chi-squared too high: {chi2}");
         Ok(())
+    }
+
+    #[test]
+    fn batch_matches_single_seed_derivation() -> Result<(), Box<dyn std::error::Error>> {
+        // The batch path must be indistinguishable from calling `from_seed`
+        // per seed: same keys, same order. Distinct seeds pin the ordering —
+        // a reordered or repeated lane would produce a mismatched key.
+        let seeds: Vec<[u8; 32]> = (0u8..5).map(|i| [i; 32]).collect();
+        let batch = PermutationKey::<64>::from_seeds(seeds.iter().copied().map(Protected::new))?;
+        assert_eq!(batch.len(), seeds.len());
+        for (seed, key) in seeds.into_iter().zip(batch) {
+            let expected = PermutationKey::<64>::from_seed(seed)?;
+            assert_eq!(
+                key.0.risky_unwrap(),
+                expected.0.risky_unwrap(),
+                "batch lane diverged from from_seed for seed {:?}",
+                seed[0]
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn batch_of_nothing_is_empty() -> Result<(), Box<dyn std::error::Error>> {
+        let none = std::iter::empty::<Protected<[u8; 32]>>();
+        assert!(PermutationKey::<8>::from_seeds(none)?.is_empty());
+        Ok(())
+    }
+
+    /// A rejected seed fails the batch with its own lane index, and no lane
+    /// after it is derived. Natural rejection is ≈ 2⁻⁴³ per seed, so it is
+    /// injected through the private seam rather than found by search.
+    #[test]
+    fn rejected_lane_is_reported_by_index_and_stops_the_batch() {
+        let seeds = (0u8..5).map(|i| Protected::new([i; 32]));
+        let mut calls = 0;
+        let err = PermutationKey::<16>::derive_batch(seeds, |rng| {
+            calls += 1;
+            if calls == 3 {
+                Err(RandomError::SeedRejected)
+            } else {
+                Generatable::random(rng)
+            }
+        })
+        .expect_err("lane 2 was rejected");
+        assert_eq!(err.index, 2);
+        assert!(matches!(err.source, RandomError::SeedRejected));
+        assert_eq!(calls, 3, "lanes after the rejected one must not be derived");
+    }
+
+    /// Fixed-seed golden vectors for every supported `N`, captured on the
+    /// commit before batch derivation landed. `from_seed` is a durable
+    /// contract: a key derived from a retained seed must never change, or
+    /// data permuted under it becomes unrecoverable. The README doctest pins
+    /// only `N = 8`, and the relative tests here (batch vs single,
+    /// determinism, validity) cannot see a change that alters every
+    /// derivation the same way. Each value is the key applied to the
+    /// identity array.
+    #[test]
+    fn from_seed_golden_vectors() -> Result<(), Box<dyn std::error::Error>> {
+        fn check<const N: usize>(expected: [u8; N]) -> Result<(), Box<dyn std::error::Error>>
+        where
+            [u8; N]: IsPermutable + Zeroed,
+        {
+            let key = PermutationKey::<N>::from_seed([0u8; 32])?;
+            let identity: [u8; N] = core::array::from_fn(|i| i as u8);
+            assert_eq!(key.permute(identity), expected, "N = {N}");
+            Ok(())
+        }
+        check::<8>([3, 0, 4, 5, 7, 6, 1, 2])?;
+        check::<16>([9, 3, 8, 13, 0, 4, 5, 15, 12, 10, 7, 11, 6, 1, 2, 14])?;
+        check::<32>([
+            9, 3, 28, 31, 30, 26, 8, 13, 0, 4, 23, 5, 15, 12, 24, 20, 18, 10, 7, 16, 11, 27, 22,
+            17, 6, 29, 19, 21, 1, 25, 2, 14,
+        ])?;
+        check::<64>([
+            58, 9, 47, 3, 28, 56, 36, 31, 43, 30, 33, 57, 26, 41, 53, 8, 13, 0, 60, 40, 4, 23, 5,
+            15, 12, 24, 20, 52, 18, 10, 7, 16, 55, 11, 63, 49, 46, 39, 27, 35, 22, 59, 38, 17, 6,
+            44, 48, 29, 45, 19, 42, 21, 54, 1, 25, 32, 50, 37, 51, 2, 62, 34, 14, 61,
+        ])?;
+        check::<128>([
+            58, 76, 72, 87, 9, 119, 47, 3, 28, 56, 36, 31, 43, 110, 30, 89, 33, 112, 57, 26, 41,
+            73, 117, 68, 53, 8, 13, 0, 97, 60, 115, 40, 4, 23, 5, 15, 12, 123, 69, 24, 103, 111,
+            91, 126, 20, 118, 52, 127, 124, 18, 94, 105, 10, 7, 88, 16, 109, 55, 74, 11, 80, 106,
+            63, 77, 83, 49, 113, 82, 46, 39, 114, 98, 27, 116, 104, 35, 90, 22, 59, 38, 17, 6, 75,
+            81, 44, 92, 48, 93, 29, 45, 120, 100, 19, 78, 42, 21, 54, 1, 95, 84, 25, 125, 107, 71,
+            32, 50, 79, 96, 101, 85, 37, 51, 122, 102, 67, 2, 99, 64, 62, 86, 70, 66, 65, 34, 14,
+            61, 108, 121,
+        ])?;
+        Ok(())
+    }
+
+    /// The error names the lane so a caller can discard exactly that seed.
+    #[test]
+    fn batch_error_reports_the_lane() {
+        let err = BatchSeedError {
+            index: 3,
+            source: RandomError::SeedRejected,
+        };
+        assert_eq!(
+            err.to_string(),
+            "seed at index 3 could not derive a key: The seed produced an unusable batch; discard it and generate a fresh seed"
+        );
+        assert!(std::error::Error::source(&err).is_some());
     }
 
     #[test]

--- a/packages/permutation/src/key.rs
+++ b/packages/permutation/src/key.rs
@@ -14,8 +14,10 @@ pub(crate) type KeyInner<const N: usize> = Exportable<Protected<[u8; N]>>;
 /// One seed in a [`PermutationKey::from_seeds`] batch could not derive a key.
 ///
 /// `index` is the seed's position in the iterator passed to `from_seeds`.
-/// For [`RandomError::SeedRejected`] that seed can never derive a key:
-/// discard it, provision a fresh one, and derive the batch again.
+/// For [`RandomError::SeedRejected`] that seed can never derive a key.
+/// `from_seeds` consumed and wiped the batch, so recovery starts from the
+/// caller's own retained seeds: replace the one at `index` with a fresh
+/// seed and derive the whole batch again.
 #[derive(Debug, thiserror::Error)]
 #[error("seed at index {index} could not derive a key: {source}")]
 pub struct BatchSeedError {
@@ -76,9 +78,18 @@ impl<const N: usize> PermutationKey<N> {
     /// batch of retained secrets is never copied around unwiped.
     ///
     /// A rejected seed fails the whole call and [`BatchSeedError`] names its
-    /// lane, so the caller discards just that seed and retries with the
-    /// rest. No keys are delivered for the lanes before it: a caller can
+    /// lane. No keys are delivered for the lanes before it, so a caller can
     /// never end up holding a key vector that is out of step with its seeds.
+    ///
+    /// The call consumes the seeds, and every one that was unwrapped is
+    /// wiped whether or not the batch succeeds; the error carries only the
+    /// index. Recovery is therefore the caller's, from its own copy of the
+    /// batch: keep the seeds in their [`Controlled`] containers (a
+    /// `Vec<Protected<[u8; 32]>>`, say) and pass `from_seeds` a view of them
+    /// (clones, or a mapping iterator) rather than the originals; on
+    /// [`RandomError::SeedRejected`] replace the seed at the reported index
+    /// with a fresh one and derive the whole batch again. A caller that
+    /// cannot retain or regenerate its seeds has nothing to retry with.
     ///
     /// The batch entry point exists for bulk workloads (e.g. deriving the
     /// per-block permutations for a batch of ORE encryptions): it fixes the

--- a/packages/permutation/src/lib.rs
+++ b/packages/permutation/src/lib.rs
@@ -8,7 +8,7 @@ mod shuffle;
 
 pub use bitwise::BitwisePermute;
 pub use elementwise::{Depermute, Permute};
-pub use key::PermutationKey;
+pub use key::{BatchSeedError, PermutationKey};
 
 mod private {
     use crate::shuffle::{batcher_gate_count, batcher_schedule};

--- a/packages/random/Cargo.toml
+++ b/packages/random/Cargo.toml
@@ -18,6 +18,14 @@ rand = { workspace = true }
 thiserror = { workspace = true }
 zeroize = { workspace = true }
 
+# `rand`'s `chacha` feature pulls in `chacha20` without its `zeroize` feature,
+# which leaves `ChaCha20Rng` with no `ZeroizeOnDrop` impl: the key schedule
+# and buffered keystream would outlive the generator. `SafeRand` wraps that
+# generator and promises to wipe both on drop, so enable the feature here;
+# Cargo's feature unification applies it to the copy `rand` uses.
+# `safe_rand.rs` asserts the impl exists at compile time.
+chacha20 = { version = "0.10", default-features = false, features = ["zeroize"] }
+
 vitaminc-random-derives = { version = "0.4.0", path = "../random-derives" }
 vitaminc-protected = { version = "0.4.0", path = "../protected" }
 

--- a/packages/random/src/safe_rand.rs
+++ b/packages/random/src/safe_rand.rs
@@ -2,15 +2,27 @@
 //! It is intentionally opinionated so that developers don't have to think about what Rng they should use
 //! for cryptographic purposes.
 //!
-//! Internally it uses `ChaCha20Rng` from the RustCrypto `chacha20` crate (via `rand`), which supports zeroization.
+//! Internally it uses `ChaCha20Rng` from the RustCrypto `chacha20` crate (via `rand`), built with
+//! its `zeroize` feature so the generator's key schedule and buffered keystream are wiped on drop.
 use std::convert::Infallible;
 
 use rand::{rngs::SysRng, Rng, SeedableRng, TryCryptoRng, TryRng};
 use vitaminc_protected::Controlled;
-use zeroize::Zeroize;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// A secure random number generator that is safe to use for cryptographic purposes.
+///
+/// Wipes its key schedule and buffered keystream on drop.
 pub struct SafeRand(rand::rngs::ChaCha20Rng);
+
+// `SafeRand` has no `Drop` of its own; the wipe is the field's drop glue,
+// which is `ChaCha20Rng`'s `ZeroizeOnDrop`. That impl exists only when
+// `chacha20` is built with its `zeroize` feature (see this crate's
+// `Cargo.toml`). The bound below fails to compile if the feature ever lapses,
+// so the marker impl can never silently become a lie.
+impl ZeroizeOnDrop for SafeRand {}
+const _: fn() = assert_zeroize_on_drop::<rand::rngs::ChaCha20Rng>;
+fn assert_zeroize_on_drop<T: ZeroizeOnDrop>() {}
 
 impl SafeRand {
     /// A value in `0..n`: at least `0`, strictly below `n`, uniform to

--- a/packages/random/src/safe_rand.rs
+++ b/packages/random/src/safe_rand.rs
@@ -8,7 +8,7 @@ use std::convert::Infallible;
 
 use rand::{rngs::SysRng, Rng, SeedableRng, TryCryptoRng, TryRng};
 use vitaminc_protected::Controlled;
-use zeroize::{Zeroize, ZeroizeOnDrop};
+use zeroize::{ZeroizeOnDrop, Zeroizing};
 
 /// A secure random number generator that is safe to use for cryptographic purposes.
 ///
@@ -88,15 +88,20 @@ impl SafeRand {
         Ok(Self::try_from_rng(&mut SysRng)?)
     }
 
-    /// A safer alternative to `from_seed` that the seed is zeroized after use.
+    /// A safer alternative to `from_seed`: the seed is wiped once the
+    /// generator is built, on every exit from this function.
+    ///
+    /// The unwrapped bytes live in a [`Zeroizing`] wrapper from the moment
+    /// they leave `seed`'s custody, so the wipe is done by drop glue rather
+    /// than by a trailing statement. An unwind between unwrapping and
+    /// returning (e.g. a panic in the generator's constructor) still wipes
+    /// them.
     pub fn from_controlled_seed<C>(seed: C) -> Self
     where
         C: Controlled<Inner = [u8; 32]>,
     {
-        let mut seed = seed.risky_unwrap();
-        let rng = Self(rand::rngs::ChaCha20Rng::from_seed(seed));
-        seed.zeroize();
-        rng
+        let seed = Zeroizing::new(seed.risky_unwrap());
+        Self(rand::rngs::ChaCha20Rng::from_seed(*seed))
     }
 }
 


### PR DESCRIPTION
Closes #328. Step 1 of the batch/SIMD plan for #280 follow-up. Stacked on #282.

## What

- **`PermutationKey::from_seeds`**: derives one key per seed, in order, each lane exactly equivalent to `from_seed`. Exists for bulk workloads (ORE batch encryption per-block permutations) and fixes the API shape so a future vectorized backend can derive lanes in parallel while staying bit-identical to scalar derivation.
  - Seeds are `Controlled<Inner = [u8; 32]>` (e.g. `Protected<[u8; 32]>`), routed through `SafeRand::from_controlled_seed` and zeroized once each generator is built. No second bare-`[u8; 32]` public entry point.
  - Returns `Result<Vec<Self>, BatchSeedError>`. A rejected seed fails the whole call and the error carries `index` + `source`, so the caller discards exactly that seed. No partial vector: a caller can never hold keys out of step with seeds (the `Vec<Result<..>>` shape allowed that via a silent `flatten`).
- **`SafeRand` is now `ZeroizeOnDrop`**: `rand`'s `chacha` feature pulls in `chacha20` without its `zeroize` feature, so `ChaCha20Rng` had no `ZeroizeOnDrop` and the key schedule + buffered keystream outlived every seed-derived generator. `vitaminc-random` now enables the feature directly; a compile-time bound fails the build if it ever lapses.

## Why output is provably unchanged

`from_seed_golden_vectors` pins `from_seed([0; 32])` for N in {8, 16, 32, 64, 128}, captured on the parent commit. Any change to seed-derived output fails it. The README doctests still pass unchanged.

## Tests

- `from_seed_golden_vectors`: fixed-seed vectors per N
- `batch_matches_single_seed_derivation`: batch output equals per-seed `from_seed`, order pinned via distinct seeds
- `rejected_lane_is_reported_by_index_and_stops_the_batch`: injected `SeedRejected` on lane 2 through a private seam; error index is 2, no later lane derived
- `batch_error_reports_the_lane`: `Display` + `source()` on `BatchSeedError`
- `batch_of_nothing_is_empty`

## Not in this PR

- Bulk `Fill for [u64]` packing from an earlier draft: a release micro-benchmark showed no measurable gain over the fused `next_u64` loop (ChaCha20 block generation dominates), and it tied seed stability to a `rand_core` stream property pinned in another crate. Dropped.
- `from_seed` still takes a bare `[u8; 32]` (pre-existing TODO; changing it is a semver break).
- SoA + SIMD lane-parallel backend (feature-flagged, AVX-512/NEON)
- asm-inspection CI (issue #280), prerequisite before SIMD default-on
- `SCHEDULE_256` for 8-bit ORE blocks

https://claude.ai/code/session_012cUAnQ2qY9RD5TaAKyZpUm
https://claude.ai/code/session_01T5TcvQ8sPnpWQ9ptCfVjj6
