### PR TITLE
feat(aead): derive macros for Encrypt and Decrypt

### DIFF
--- a/.cargo-crap.toml
+++ b/.cargo-crap.toml
@@ -28,8 +28,9 @@ missing = "pessimistic"
 
 # Files skipped at walk time, relative to each workspace member's root.
 # Defensive: integration tests aren't walked today, but this keeps them out of
-# the score if that changes.
-exclude = ["tests/**"]
+# the score if that changes. `test_support.rs` holds `#[cfg(test)]` assertion
+# helpers — test code, not shipped risk, so it does not belong in the report.
+exclude = ["tests/**", "src/test_support.rs"]
 
 # Functions to analyse but hide from the report. An entry containing `/` or
 # `**` matches the defining file; otherwise it matches the function name.
@@ -38,9 +39,17 @@ exclude = ["tests/**"]
 # as 0% covered and would be permanent false-positives — not code we have
 # chosen to leave untested.
 #
-#   * The proc-macro crates: macro expansion runs at compile time, not in the
-#     instrumented test binary. Exercised in practice by the crates that use
-#     the derives.
+#   * `random-derives` and `protected-derive`: their expansion logic lives in
+#     the `#[proc_macro_derive]` entry points themselves, which run at compile
+#     time rather than in the instrumented test binary, so llvm-cov always
+#     reads them as 0%.
+#
+#     NOTE: this is a deferral, not a dismissal — and not a property of
+#     proc-macro crates in general. `aead-derive` shows the way out: keep the
+#     entry point a trivial shim and put the expansion in an ordinary
+#     `fn(DeriveInput) -> Result<TokenStream>`, which unit tests call directly
+#     and llvm-cov scores like any other function. Splitting these two the same
+#     way would let them come off this list.
 #
 #   * The `vitaminc-aead-napi` conversion functions and their JS-boundary
 #     helpers (`own_enumerable_keys`, `get_property_unknown`,

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -22,6 +22,7 @@ additional_cargo_args = ["--all-features"]
 # there (they'd survive spuriously). This mirrors the cargo-crap `allow` list;
 # the derives are exercised in practice by the crates that use them.
 exclude_globs = [
+    "packages/aead-derive/**",
     "packages/protected-derive/**",
     "packages/random-derives/**",
 ]

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -17,14 +17,20 @@
 # only because the gating feature was off, not because a test is missing.
 additional_cargo_args = ["--all-features"]
 
-# Skip the proc-macro derive crates: their logic runs at compile time, not in the
-# instrumented test binary, so cargo-mutants cannot meaningfully test mutants
-# there (they'd survive spuriously). This mirrors the cargo-crap `allow` list;
-# the derives are exercised in practice by the crates that use them.
+# Skip `random-derives` and `protected-derive`: their expansion logic lives in
+# the `#[proc_macro_derive]` entry points, which run at compile time rather than
+# in the instrumented test binary, so every mutant there survives spuriously.
+# This mirrors the cargo-crap `allow` list, and the same note applies: splitting
+# the expansion out of the entry point — as `aead-derive` does — makes the logic
+# directly testable, and mutable, so these two could come off this list.
 exclude_globs = [
-    "packages/aead-derive/**",
     "packages/protected-derive/**",
     "packages/random-derives/**",
+    # `aead-derive` keeps only its two `#[proc_macro_derive]` shims in lib.rs —
+    # those same-compile-time entry points, and nothing else. The expansion each
+    # one delegates to lives in `encrypt.rs`/`decrypt.rs` and is mutated
+    # normally: 14 of the crate's mutants are caught by its unit tests.
+    "packages/aead-derive/src/lib.rs",
 ]
 
 # Skip mutants inside the `vitaminc-aead-napi` conversion functions and their

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -102,6 +102,15 @@ jobs:
         working-directory: bindings/go/vcencrypt/guest
         run: cargo clippy --all-targets -- -D warnings
 
+      # Matches the workspace docs gate in test.yml. This crate is a standalone
+      # workspace, so that job does not reach it — without this step its
+      # intra-doc links are checked by nothing.
+      - name: docs (intra-doc links)
+        working-directory: bindings/go/vcencrypt/guest
+        run: cargo doc --target wasm32-wasip1 --all-features --no-deps
+        env:
+          RUSTDOCFLAGS: -D warnings
+
       - name: test
         working-directory: bindings/go/vcencrypt/guest
         run: cargo test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,14 @@ jobs:
       - name: format
         run: cargo fmt -- --check
 
+      # Broken intra-doc links are invisible without this: rustdoc warns and
+      # exits 0, so a link to a renamed or newly-private item rots silently and
+      # ships to docs.rs. `--no-deps` keeps the gate to our own crates.
+      - name: docs (intra-doc links)
+        run: cargo doc --workspace --all-features --no-deps
+        env:
+          RUSTDOCFLAGS: -D warnings
+
       - name: test (default — aws-lc-rs backend)
         run: cargo test
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 .rtx
 .DS_Store
 .vscode
+
+# Raw coverage profiles dropped by `cargo llvm-cov` / `mise run crap`.
+*.profraw

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2458,6 +2458,7 @@ dependencies = [
  "quickcheck",
  "quickcheck_macros",
  "serde",
+ "trybuild",
  "vitaminc-aead-derive",
  "vitaminc-protected",
  "vitaminc-random",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2458,9 +2458,19 @@ dependencies = [
  "quickcheck",
  "quickcheck_macros",
  "serde",
+ "vitaminc-aead-derive",
  "vitaminc-protected",
  "vitaminc-random",
  "zeroize",
+]
+
+[[package]]
+name = "vitaminc-aead-derive"
+version = "0.2.0-pre.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "packages/aead",
+    "packages/aead-derive",
     "packages/aead-napi",
     "packages/aead-value",
     "packages/async-traits",

--- a/bindings/go/vcencrypt/guest/Cargo.lock
+++ b/bindings/go/vcencrypt/guest/Cargo.lock
@@ -147,6 +147,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,6 +199,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,6 +215,7 @@ checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
  "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -527,9 +543,19 @@ version = "0.2.0-pre.1"
 dependencies = [
  "bytes",
  "serde",
+ "vitaminc-aead-derive",
  "vitaminc-protected",
  "vitaminc-random",
  "zeroize",
+]
+
+[[package]]
+name = "vitaminc-aead-derive"
+version = "0.2.0-pre.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/packages/aead-derive/Cargo.toml
+++ b/packages/aead-derive/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "vitaminc-aead-derive"
+description = "Derive macros for vitaminc-aead. Part of the VitaminC cryptographic suite."
+documentation = "https://docs.rs/vitaminc-aead-derive"
+version.workspace = true
+repository.workspace = true
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "3", features = ["full", "extra-traits"] }

--- a/packages/aead-derive/docs/attributes.md
+++ b/packages/aead-derive/docs/attributes.md
@@ -1,0 +1,102 @@
+# Attributes
+
+All options live under `#[aead(...)]`. Anything else — a misspelling included —
+is a compile error rather than a silently dropped setting, because a dropped
+option is one the author believes is in effect.
+
+| Attribute | Applies to | Effect |
+|---|---|---|
+| `crate = "path"` | container | Name the path to `vitaminc_aead` in the generated code |
+| `rename = "name"` | field | Store the field under `name` instead of its own name |
+| `passthrough` | field | Store the field **in the clear**, unencrypted and unauthenticated |
+
+## `#[aead(crate = "...")]`
+
+Points the generated code at a re-export of `vitaminc_aead`, for callers who
+depend on it through an umbrella crate rather than directly:
+
+```ignore
+#[derive(Encrypt, Decrypt)]
+#[aead(crate = "::vitaminc::aead")]
+struct User {
+    name: String,
+}
+```
+
+Every path the expansion emits is redirected, so the deriving crate needs no
+direct dependency on `vitaminc_aead` at all.
+
+## `#[aead(rename = "...")]`
+
+Changes the map key a field is stored under:
+
+```ignore
+#[derive(Encrypt, Decrypt)]
+struct User {
+    #[aead(rename = "n")]
+    name: String,
+}
+// ciphertext: Map { "n": … }
+```
+
+Field names are part of the ciphertext contract — each key is bound into the
+AAD its value is sealed against — so renaming a field in Rust breaks
+compatibility with data already stored under the old name. `rename` is how you
+keep the old wire key while changing the Rust one.
+
+Two fields cannot share a key; the collision is a compile error rather than a
+value silently overwriting another. `rename` on a newtype is a compile error
+too: a newtype is transparent, so its value is not stored under a key at all
+and there is nothing to rename.
+
+## `#[aead(passthrough)]`
+
+Stores a field as a cleartext map entry, so it can be an ordinary database
+column that other queries select, filter, and update without holding the key:
+
+```ignore
+#[derive(Encrypt, Decrypt)]
+struct Row {
+    #[aead(passthrough)]
+    tenant: String,   // a plain column
+    ssn: String,      // encrypted
+}
+```
+
+### ⚠️ The field gives up all protection
+
+That independence is bought by giving up everything, and the trade is total:
+
+- The value is **not encrypted** — anyone who can read the stored ciphertext
+  can read it.
+- The value is **not authenticated**. No tag covers it, and unlike an encrypted
+  entry's key, nothing binds its key either. It can be edited, retargeted at
+  another key, added, or removed, and every encrypted field beside it still
+  decrypts. Treat what comes back as untrusted input — it is exactly as
+  trustworthy as the column it was read from.
+- Deleting the entry is caught only by the ordinary missing-field rule, and is
+  not distinguished from a value that was never written.
+
+So: non-sensitive, non-security-deciding data only. Never a field the program
+then trusts to make an authorization choice.
+
+A cleartext field that must be tamper-evident needs to be bound into the AAD
+instead of passed through — and note that binding couples the two, so any
+independent write to that column would break decryption of every encrypted
+field beside it. That coupling is precisely what `passthrough` exists to avoid.
+
+### Requirements
+
+A passthrough field's type must be `Any + Send + 'static`: the value travels
+through the cipher type-erased and is downcast on the way out. That rules out
+borrowed types such as `&'a str`.
+
+Two shapes are rejected at compile time:
+
+- **Every field passthrough.** Nothing would be encrypted, so the ciphertext
+  would carry no tag at all — neither the associated data nor the entry keys
+  would be authenticated. `MapCipher::end` refuses to seal such a container, so
+  the derive refuses to emit one.
+- **`passthrough` on a newtype.** A newtype is transparent and opens no map, so
+  there is no entry to store in the clear; honouring the attribute would mean
+  the whole value travelled unencrypted.

--- a/packages/aead-derive/src/attrs.rs
+++ b/packages/aead-derive/src/attrs.rs
@@ -1,0 +1,57 @@
+//! Parsing of the `#[aead(...)]` container and field attributes.
+
+use syn::{Attribute, Path, Result};
+
+/// Container-level options, from `#[aead(...)]` on the struct itself.
+pub(crate) struct ContainerAttrs {
+    /// Path to the `vitaminc_aead` crate in the generated code. Defaults to
+    /// `::vitaminc_aead`; overridden by `#[aead(crate = "...")]` so the macros
+    /// work through a re-export such as `::vitaminc::aead`.
+    pub(crate) krate: Path,
+}
+
+impl ContainerAttrs {
+    pub(crate) fn parse(attrs: &[Attribute]) -> Result<Self> {
+        let mut krate: Option<Path> = None;
+
+        for attr in attrs.iter().filter(|a| a.path().is_ident("aead")) {
+            attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("crate") {
+                    let lit: syn::LitStr = meta.value()?.parse()?;
+                    krate = Some(lit.parse()?);
+                    return Ok(());
+                }
+                Err(meta.error("unsupported container attribute; expected `crate = \"...\"`"))
+            })?;
+        }
+
+        Ok(Self {
+            krate: krate.unwrap_or_else(|| syn::parse_quote!(::vitaminc_aead)),
+        })
+    }
+}
+
+/// Field-level options, from `#[aead(...)]` on a field.
+pub(crate) struct FieldAttrs {
+    /// Map key to use for this field, from `#[aead(rename = "...")]`.
+    pub(crate) rename: Option<String>,
+}
+
+impl FieldAttrs {
+    pub(crate) fn parse(attrs: &[Attribute]) -> Result<Self> {
+        let mut rename: Option<String> = None;
+
+        for attr in attrs.iter().filter(|a| a.path().is_ident("aead")) {
+            attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("rename") {
+                    let lit: syn::LitStr = meta.value()?.parse()?;
+                    rename = Some(lit.value());
+                    return Ok(());
+                }
+                Err(meta.error("unsupported field attribute; expected `rename = \"...\"`"))
+            })?;
+        }
+
+        Ok(Self { rename })
+    }
+}

--- a/packages/aead-derive/src/attrs.rs
+++ b/packages/aead-derive/src/attrs.rs
@@ -35,11 +35,16 @@ impl ContainerAttrs {
 pub(crate) struct FieldAttrs {
     /// Map key to use for this field, from `#[aead(rename = "...")]`.
     pub(crate) rename: Option<String>,
+    /// Store this field in the clear rather than encrypting it, from
+    /// `#[aead(passthrough)]`. The value is neither encrypted nor
+    /// authenticated — see the crate docs.
+    pub(crate) passthrough: bool,
 }
 
 impl FieldAttrs {
     pub(crate) fn parse(attrs: &[Attribute]) -> Result<Self> {
         let mut rename: Option<String> = None;
+        let mut passthrough = false;
 
         for attr in attrs.iter().filter(|a| a.path().is_ident("aead")) {
             attr.parse_nested_meta(|meta| {
@@ -48,10 +53,19 @@ impl FieldAttrs {
                     rename = Some(lit.value());
                     return Ok(());
                 }
-                Err(meta.error("unsupported field attribute; expected `rename = \"...\"`"))
+                if meta.path.is_ident("passthrough") {
+                    passthrough = true;
+                    return Ok(());
+                }
+                Err(meta.error(
+                    "unsupported field attribute; expected `rename = \"...\"` or `passthrough`",
+                ))
             })?;
         }
 
-        Ok(Self { rename })
+        Ok(Self {
+            rename,
+            passthrough,
+        })
     }
 }

--- a/packages/aead-derive/src/decrypt.rs
+++ b/packages/aead-derive/src/decrypt.rs
@@ -2,7 +2,7 @@
 
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{parse_quote, DeriveInput, GenericParam, Generics, Result};
+use syn::{parse_quote, DeriveInput, Result};
 
 use crate::{
     attrs::ContainerAttrs,
@@ -55,7 +55,7 @@ pub(crate) fn derive(input: DeriveInput) -> Result<TokenStream> {
                 Shape::Map(fields) => visit_map_body(krate, name, fields),
                 _ => visit_empty_body(krate, name),
             };
-            let phantom = phantom_data(&input.generics);
+            let phantom = phantom_data(name, &ty_generics);
 
             quote! {
                 struct __Visitor #visitor_decl_generics (
@@ -198,25 +198,22 @@ fn visit_empty_body(krate: &syn::Path, name: &syn::Ident) -> TokenStream {
 
 /// The visitor carries no data, but an inner item cannot inherit the outer
 /// generics — it has to redeclare them, and every declared parameter must be
-/// used. `PhantomData` over a tuple of all of them does that without
-/// affecting auto-trait inference: each component is `Send` whenever the
-/// parameter it stands for is.
-fn phantom_data(generics: &Generics) -> TokenStream {
-    let parts = generics.params.iter().map(|param| match param {
-        GenericParam::Lifetime(lt) => {
-            let lifetime = &lt.lifetime;
-            quote!(& #lifetime ())
-        }
-        GenericParam::Type(ty) => {
-            let ident = &ty.ident;
-            quote!(#ident)
-        }
-        GenericParam::Const(c) => {
-            let ident = &c.ident;
-            quote!([u8; #ident])
-        }
-    });
-    quote!((#(#parts,)*))
+/// used. `PhantomData<fn() -> Self::Value>` uses all of them at once, whatever
+/// kind they are.
+///
+/// Naming the parameters individually does not work: a const parameter can
+/// only appear in a type as a generic argument, so the obvious `[u8; N]`
+/// silently requires `N: usize` and makes `#[derive(Decrypt)]` fail on
+/// `struct S<const N: u32>` with an error pointing at the macro. Referencing
+/// them through the value type sidesteps the question — each parameter is
+/// passed along exactly as declared.
+///
+/// A function pointer rather than the value itself, because the visitor owns
+/// nothing: `fn() -> T` imposes no drop obligation on `T` and is `Send` and
+/// `Sync` regardless of what `T` is, so the visitor stays usable for every
+/// type the derive accepts.
+fn phantom_data(name: &syn::Ident, ty_generics: &syn::TypeGenerics<'_>) -> TokenStream {
+    quote!(fn() -> #name #ty_generics)
 }
 
 #[cfg(test)]
@@ -393,11 +390,9 @@ mod tests {
     }
 
     /// The visitor cannot inherit the outer generics, so it redeclares them and
-    /// must use every one. Each `PhantomData` component stands for exactly its
-    /// parameter, which keeps auto-trait inference — `Send`, `Sync` — intact.
-    // The expected `PhantomData` tuple carries a trailing comma, which rustfmt
-    // strips from `quote!`'s body — changing the tokens compared. Opt out.
-    #[rustfmt::skip]
+    /// must use every one. Routing them through the value type uses all of them
+    /// at once, whatever kind they are — and a const parameter has nowhere else
+    /// to appear in a type, so naming them individually would not work.
     #[test]
     fn the_visitor_uses_every_redeclared_parameter() {
         let out = expand(parse_quote! {
@@ -408,12 +403,26 @@ mod tests {
             }
         });
 
+        assert_contains(&out, quote!(struct __Visitor<'a, T, const N: usize>));
         assert_contains(
             &out,
-            quote!(struct __Visitor<'a, T, const N: usize>(
-                ::core::marker::PhantomData<(&'a (), T, [u8; N],)>
-            );),
+            quote!(::core::marker::PhantomData<fn() -> User<'a, T, N>),
         );
+    }
+
+    /// A const parameter that is not a `usize` must derive like any other. The
+    /// previous encoding used each parameter as an array length, which silently
+    /// required `usize` and failed here — with the error blamed on the macro.
+    #[test]
+    fn a_non_usize_const_parameter_is_supported() {
+        let out = expand(parse_quote! {
+            struct User<const N: u32> {
+                value: String,
+            }
+        });
+
+        assert_contains(&out, quote!(::core::marker::PhantomData<fn() -> User<N>));
+        assert_lacks(&out, quote!([u8; N]));
     }
 
     #[test]

--- a/packages/aead-derive/src/decrypt.rs
+++ b/packages/aead-derive/src/decrypt.rs
@@ -1,0 +1,203 @@
+//! Expansion of `#[derive(Decrypt)]`.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{parse_quote, DeriveInput, GenericParam, Generics, Result};
+
+use crate::{
+    attrs::ContainerAttrs,
+    shape::{FieldInfo, Shape},
+};
+
+pub(crate) fn derive(input: DeriveInput) -> Result<TokenStream> {
+    let attrs = ContainerAttrs::parse(&input.attrs)?;
+    let krate = &attrs.krate;
+    let shape = Shape::parse(&input)?;
+    let name = &input.ident;
+
+    // `'__c` is the decipher lifetime the trait is generic over. Every type
+    // parameter must decrypt for it and outlive it; every lifetime parameter
+    // must outlive it, since the visitor below is required to be `'__c`.
+    let mut bounded = input.generics.clone();
+    for param in bounded.type_params_mut() {
+        param.bounds.push(parse_quote!(#krate::Decrypt<'__c>));
+        param.bounds.push(parse_quote!('__c));
+    }
+    for lifetime in bounded.lifetimes_mut() {
+        lifetime.bounds.push(parse_quote!('__c));
+    }
+    let mut with_c = bounded.clone();
+    with_c.params.insert(0, parse_quote!('__c));
+
+    // `ty_generics` must come from the *original* generics: the type is still
+    // `Foo<T>`, not `Foo<'__c, T>`. The visitor declared inside the method body
+    // redeclares those same parameters — it cannot mention `'__c`, which is
+    // introduced by the impl, so its `Decrypt` bounds live on its impl block.
+    let (visitor_decl_generics, ty_generics, visitor_where) = input.generics.split_for_impl();
+    let (impl_generics, _, where_clause) = with_c.split_for_impl();
+    let turbofish = ty_generics.as_turbofish();
+
+    let body = match &shape {
+        Shape::Newtype(field) => {
+            let inner = &field.ty;
+            quote! {
+                // Transparent, mirroring the `Encrypt` side: decrypt the inner
+                // type and rewrap. `map_ok` exists precisely because `Ok<T>`
+                // is a GAT and cannot be mapped generically otherwise.
+                <__D as #krate::Decipher<'__c>>::map_ok(
+                    <#inner as #krate::Decrypt<'__c>>::decrypt_with_aad(__decipher, __aad),
+                    #name,
+                )
+            }
+        }
+        Shape::Map(_) | Shape::Empty => {
+            let visit_map = match &shape {
+                Shape::Map(fields) => visit_map_body(krate, name, fields),
+                _ => visit_empty_body(krate, name),
+            };
+            let phantom = phantom_data(&input.generics);
+
+            quote! {
+                struct __Visitor #visitor_decl_generics (
+                    ::core::marker::PhantomData<#phantom>
+                ) #visitor_where;
+
+                #[automatically_derived]
+                impl #impl_generics #krate::DecipherVisitor<'__c>
+                    for __Visitor #ty_generics #where_clause
+                {
+                    type Value = #name #ty_generics;
+
+                    fn visit_map<__M>(
+                        self,
+                        mut __map: __M,
+                    ) -> ::core::result::Result<Self::Value, #krate::Unspecified>
+                    where
+                        __M: #krate::MapAccess<'__c>,
+                    {
+                        #visit_map
+                    }
+                }
+
+                #krate::Decipher::decrypt_map(
+                    __decipher,
+                    __Visitor #turbofish (::core::marker::PhantomData),
+                    __aad,
+                )
+            }
+        }
+    };
+
+    Ok(quote! {
+        #[automatically_derived]
+        impl #impl_generics #krate::Decrypt<'__c> for #name #ty_generics #where_clause {
+            fn decrypt_with_aad<'__aead_a, __D, __A>(
+                __decipher: __D,
+                __aad: __A,
+            ) -> __D::Ok<Self>
+            where
+                __D: #krate::Decipher<'__c>,
+                __A: #krate::IntoAad<'__aead_a>,
+            {
+                #body
+            }
+        }
+    })
+}
+
+/// Read keys first, then choose the type to decrypt each value into. Entry
+/// order in a stored ciphertext is not authenticated, so a positional decode
+/// would be wrong; matching on the key is also what makes heterogeneous field
+/// types possible at all.
+fn visit_map_body(krate: &syn::Path, name: &syn::Ident, fields: &[FieldInfo]) -> TokenStream {
+    let slots = fields.iter().map(|field| {
+        let local = &field.local;
+        let ty = &field.ty;
+        quote! {
+            let mut #local: ::core::option::Option<#ty> = ::core::option::Option::None;
+        }
+    });
+
+    let arms = fields.iter().map(|field| {
+        let key = &field.key;
+        let local = &field.local;
+        let ty = &field.ty;
+        quote! {
+            #key => {
+                // The decipher rejects duplicate keys too; this catches a
+                // decipher that does not, rather than last-wins overwriting
+                // an already-verified field.
+                if #local.is_some() {
+                    return ::core::result::Result::Err(#krate::Unspecified);
+                }
+                #local = ::core::option::Option::Some(
+                    <__M as #krate::MapAccess<'__c>>::next_value::<#ty>(&mut __map)
+                        .map_err(|_| #krate::Unspecified)?,
+                );
+            }
+        }
+    });
+
+    let inits = fields.iter().map(|field| {
+        let member = &field.member;
+        let local = &field.local;
+        quote! {
+            // A missing field is a rejection, not a default: an absent entry
+            // is an unauthenticated one.
+            #member: #local.ok_or(#krate::Unspecified)?,
+        }
+    });
+
+    quote! {
+        #(#slots)*
+
+        while let ::core::option::Option::Some(__key) =
+            <__M as #krate::MapAccess<'__c>>::next_key(&mut __map)
+                .map_err(|_| #krate::Unspecified)?
+        {
+            match __key.as_str() {
+                #(#arms)*
+                // Unknown keys are refused rather than skipped: a skipped
+                // value is one whose AAD binding is never verified.
+                _ => return ::core::result::Result::Err(#krate::Unspecified),
+            }
+        }
+
+        ::core::result::Result::Ok(#name { #(#inits)* })
+    }
+}
+
+fn visit_empty_body(krate: &syn::Path, name: &syn::Ident) -> TokenStream {
+    quote! {
+        if <__M as #krate::MapAccess<'__c>>::next_key(&mut __map)
+            .map_err(|_| #krate::Unspecified)?
+            .is_some()
+        {
+            return ::core::result::Result::Err(#krate::Unspecified);
+        }
+        ::core::result::Result::Ok(#name {})
+    }
+}
+
+/// The visitor carries no data, but an inner item cannot inherit the outer
+/// generics — it has to redeclare them, and every declared parameter must be
+/// used. `PhantomData` over a tuple of all of them does that without
+/// affecting auto-trait inference: each component is `Send` whenever the
+/// parameter it stands for is.
+fn phantom_data(generics: &Generics) -> TokenStream {
+    let parts = generics.params.iter().map(|param| match param {
+        GenericParam::Lifetime(lt) => {
+            let lifetime = &lt.lifetime;
+            quote!(& #lifetime ())
+        }
+        GenericParam::Type(ty) => {
+            let ident = &ty.ident;
+            quote!(#ident)
+        }
+        GenericParam::Const(c) => {
+            let ident = &c.ident;
+            quote!([u8; #ident])
+        }
+    });
+    quote!((#(#parts,)*))
+}

--- a/packages/aead-derive/src/decrypt.rs
+++ b/packages/aead-derive/src/decrypt.rs
@@ -122,18 +122,35 @@ fn visit_map_body(krate: &syn::Path, name: &syn::Ident, fields: &[FieldInfo]) ->
         let key = &field.key;
         let local = &field.local;
         let ty = &field.ty;
+        // The duplicate guard is common to both arms: the decipher rejects
+        // duplicate keys too, but this catches a decipher that does not,
+        // rather than last-wins overwriting an already-verified field.
+        let reject_duplicate = quote! {
+            if #local.is_some() {
+                return ::core::result::Result::Err(#krate::Unspecified);
+            }
+        };
+        let read = if field.passthrough {
+            // Nothing here is verified — no tag covers a passthrough entry and
+            // nothing binds its key — so this value is untrusted input, exactly
+            // as the column it came from is. The downcast is the only check:
+            // it rejects a payload of the wrong type, not a tampered one.
+            quote! {
+                *<__M as #krate::MapAccess<'__c>>::next_passthrough(&mut __map)
+                    .map_err(|_| #krate::Unspecified)?
+                    .downcast::<#ty>()
+                    .map_err(|_| #krate::Unspecified)?
+            }
+        } else {
+            quote! {
+                <__M as #krate::MapAccess<'__c>>::next_value::<#ty>(&mut __map)
+                    .map_err(|_| #krate::Unspecified)?
+            }
+        };
         quote! {
             #key => {
-                // The decipher rejects duplicate keys too; this catches a
-                // decipher that does not, rather than last-wins overwriting
-                // an already-verified field.
-                if #local.is_some() {
-                    return ::core::result::Result::Err(#krate::Unspecified);
-                }
-                #local = ::core::option::Option::Some(
-                    <__M as #krate::MapAccess<'__c>>::next_value::<#ty>(&mut __map)
-                        .map_err(|_| #krate::Unspecified)?,
-                );
+                #reject_duplicate
+                #local = ::core::option::Option::Some(#read);
             }
         }
     });
@@ -276,6 +293,32 @@ mod tests {
         assert_contains(
             &out,
             quote!(_ => return ::core::result::Result::Err(::vitaminc_aead::Unspecified),),
+        );
+    }
+
+    /// A passthrough field is read through `next_passthrough` and downcast — no
+    /// tag is checked, because none covers it. `next_value` must not appear for
+    /// that key, or the read would demand a sealed node that is not there.
+    #[test]
+    fn a_passthrough_field_is_read_without_verification() {
+        let out = expand(parse_quote! {
+            struct Row {
+                #[aead(passthrough)]
+                tenant: String,
+                ssn: String,
+            }
+        });
+
+        assert_contains(&out, quote!(::next_passthrough(&mut __map)));
+        assert_contains(&out, quote!(.downcast::<String>()));
+        assert_contains(&out, quote!(::next_value::<String>(&mut __map)));
+        // The duplicate guard applies to passthrough entries too: a repeated
+        // key must not overwrite an already-read field.
+        assert_contains(
+            &out,
+            quote!(if __field_0.is_some() {
+                return ::core::result::Result::Err(::vitaminc_aead::Unspecified);
+            }),
         );
     }
 

--- a/packages/aead-derive/src/decrypt.rs
+++ b/packages/aead-derive/src/decrypt.rs
@@ -201,3 +201,205 @@ fn phantom_data(generics: &Generics) -> TokenStream {
     });
     quote!((#(#parts,)*))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{assert_contains, assert_lacks};
+
+    fn expand(input: DeriveInput) -> String {
+        derive(input).expect("expansion should succeed").to_string()
+    }
+
+    /// Entry order is not authenticated, so the decode reads the key first and
+    /// picks the field type from it — a positional decode would be wrong.
+    #[test]
+    fn fields_are_matched_by_key_not_position() {
+        let out = expand(parse_quote! {
+            struct User {
+                name: String,
+                age: u32,
+            }
+        });
+
+        assert_contains(&out, quote!(::next_key(&mut __map)));
+        assert_contains(&out, quote!("name" =>));
+        assert_contains(&out, quote!("age" =>));
+        assert_contains(&out, quote!(::next_value::<String>(&mut __map)));
+        assert_contains(&out, quote!(::next_value::<u32>(&mut __map)));
+    }
+
+    /// An absent entry is an unauthenticated one, so a missing field is a
+    /// rejection rather than a default.
+    #[test]
+    fn a_missing_field_is_rejected() {
+        let out = expand(parse_quote! {
+            struct User {
+                name: String,
+            }
+        });
+
+        assert_contains(
+            &out,
+            quote!(name: __field_0.ok_or(::vitaminc_aead::Unspecified)?),
+        );
+    }
+
+    /// Belt and braces over the decipher's own duplicate rejection: last-wins
+    /// would overwrite a field that has already been verified.
+    #[test]
+    fn a_duplicate_key_is_rejected() {
+        let out = expand(parse_quote! {
+            struct User {
+                name: String,
+            }
+        });
+
+        assert_contains(
+            &out,
+            quote!(if __field_0.is_some() {
+                return ::core::result::Result::Err(::vitaminc_aead::Unspecified);
+            }),
+        );
+    }
+
+    /// Unknown keys are refused, not skipped: a skipped value is one whose AAD
+    /// binding is never verified.
+    #[test]
+    fn an_unknown_key_is_rejected() {
+        let out = expand(parse_quote! {
+            struct User {
+                name: String,
+            }
+        });
+
+        assert_contains(
+            &out,
+            quote!(_ => return ::core::result::Result::Err(::vitaminc_aead::Unspecified),),
+        );
+    }
+
+    /// Mirrors the `Encrypt` side: a newtype decrypts as its inner type and is
+    /// rewrapped, so no visitor and no map are involved.
+    #[test]
+    fn newtype_is_transparent() {
+        let out = expand(parse_quote!(
+            struct Wrapper(String);
+        ));
+
+        assert_contains(
+            &out,
+            quote!(<__D as ::vitaminc_aead::Decipher<'__c>>::map_ok(
+                <String as ::vitaminc_aead::Decrypt<'__c>>::decrypt_with_aad(__decipher, __aad),
+                Wrapper,
+            )),
+        );
+        assert_lacks(&out, quote!(struct __Visitor));
+    }
+
+    /// A field-less struct accepts only the empty map: any entry at all is a
+    /// forgery attempt against a shape that has no fields to hold it.
+    #[test]
+    fn empty_struct_rejects_any_entry() {
+        let out = expand(parse_quote!(
+            struct Marker {}
+        ));
+
+        assert_contains(
+            &out,
+            quote!(
+                if <__M as ::vitaminc_aead::MapAccess<'__c>>::next_key(&mut __map)
+                    .map_err(|_| ::vitaminc_aead::Unspecified)?
+                    .is_some()
+                {
+                    return ::core::result::Result::Err(::vitaminc_aead::Unspecified);
+                }
+            ),
+        );
+        assert_contains(&out, quote!(::core::result::Result::Ok(Marker {})));
+    }
+
+    /// The visitor is required to be `'__c`, so every type parameter must
+    /// decrypt for that lifetime *and* outlive it, and every lifetime parameter
+    /// must outlive it. The type itself stays `User<'a, T>` — `'__c` is
+    /// introduced by the impl, not by the struct.
+    #[test]
+    fn generic_parameters_are_bound_to_the_decipher_lifetime() {
+        let out = expand(parse_quote! {
+            struct User<'a, T> {
+                borrowed: &'a str,
+                value: T,
+            }
+        });
+
+        assert_contains(
+            &out,
+            quote!(impl<'__c, 'a: '__c, T: ::vitaminc_aead::Decrypt<'__c> + '__c>),
+        );
+        assert_contains(&out, quote!(::vitaminc_aead::Decrypt<'__c> for User<'a, T>));
+        assert_contains(
+            &out,
+            quote!(
+                type Value = User<'a, T>;
+            ),
+        );
+        assert_contains(
+            &out,
+            quote!(__Visitor::<'a, T>(::core::marker::PhantomData)),
+        );
+    }
+
+    /// The visitor cannot inherit the outer generics, so it redeclares them and
+    /// must use every one. Each `PhantomData` component stands for exactly its
+    /// parameter, which keeps auto-trait inference — `Send`, `Sync` — intact.
+    // The expected `PhantomData` tuple carries a trailing comma, which rustfmt
+    // strips from `quote!`'s body — changing the tokens compared. Opt out.
+    #[rustfmt::skip]
+    #[test]
+    fn the_visitor_uses_every_redeclared_parameter() {
+        let out = expand(parse_quote! {
+            struct User<'a, T, const N: usize> {
+                borrowed: &'a str,
+                value: T,
+                bytes: [u8; N],
+            }
+        });
+
+        assert_contains(
+            &out,
+            quote!(struct __Visitor<'a, T, const N: usize>(
+                ::core::marker::PhantomData<(&'a (), T, [u8; N],)>
+            );),
+        );
+    }
+
+    #[test]
+    fn crate_attribute_redirects_every_path() {
+        let out = expand(parse_quote! {
+            #[aead(crate = "::vitaminc::aead")]
+            struct User {
+                name: String,
+            }
+        });
+
+        assert_contains(&out, quote!(::vitaminc::aead::Decrypt<'__c> for User));
+        assert_contains(&out, quote!(::vitaminc::aead::DecipherVisitor<'__c>));
+        assert!(
+            !out.contains("vitaminc_aead"),
+            "expansion still references the default crate path:\n{out}"
+        );
+    }
+
+    #[test]
+    fn unknown_container_attribute_is_rejected() {
+        let err = derive(parse_quote! {
+            #[aead(bogus = "x")]
+            struct User {
+                name: String,
+            }
+        })
+        .expect_err("unknown container attribute should be rejected");
+
+        assert!(err.to_string().contains("unsupported container attribute"));
+    }
+}

--- a/packages/aead-derive/src/encrypt.rs
+++ b/packages/aead-derive/src/encrypt.rs
@@ -82,3 +82,181 @@ fn empty_body(krate: &syn::Path) -> TokenStream {
         #krate::MapCipher::end(#krate::Cipher::encrypt_map(__cipher, __aad))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{assert_contains, assert_lacks};
+
+    fn expand(input: DeriveInput) -> String {
+        derive(input).expect("expansion should succeed").to_string()
+    }
+
+    /// Every field is sealed through `encrypt_entry`, which binds the key into
+    /// the AAD — that binding is what stops a stored field being renamed or
+    /// swapped with another of the same type.
+    #[test]
+    fn each_field_is_sealed_against_its_own_key() {
+        let out = expand(parse_quote! {
+            struct User {
+                name: String,
+                age: u32,
+            }
+        });
+
+        assert_contains(
+            &out,
+            quote!(::vitaminc_aead::Cipher::encrypt_map(__cipher, __aad)),
+        );
+        assert_contains(
+            &out,
+            quote!(::vitaminc_aead::MapCipher::encrypt_entry(
+                __map, "name", self.name
+            )),
+        );
+        assert_contains(
+            &out,
+            quote!(::vitaminc_aead::MapCipher::encrypt_entry(
+                __map, "age", self.age
+            )),
+        );
+        assert_contains(&out, quote!(::vitaminc_aead::MapCipher::end(__map)));
+    }
+
+    /// Field names are part of the wire contract, so `rename` has to reach the
+    /// key the value is bound to — not just the source-level name.
+    #[test]
+    fn rename_replaces_the_map_key() {
+        let out = expand(parse_quote! {
+            struct User {
+                #[aead(rename = "yrs")]
+                age: u32,
+            }
+        });
+
+        assert_contains(
+            &out,
+            quote!(::vitaminc_aead::MapCipher::encrypt_entry(
+                __map, "yrs", self.age
+            )),
+        );
+        assert_lacks(&out, quote!("age"));
+    }
+
+    /// A tuple struct of two or more fields keys on the decimal field index, so
+    /// its fields get the same per-key binding a named struct's do.
+    #[test]
+    fn tuple_fields_are_keyed_by_index() {
+        let out = expand(parse_quote!(
+            struct Pair(String, u32);
+        ));
+
+        assert_contains(
+            &out,
+            quote!(::vitaminc_aead::MapCipher::encrypt_entry(
+                __map, "0", self.0
+            )),
+        );
+        assert_contains(
+            &out,
+            quote!(::vitaminc_aead::MapCipher::encrypt_entry(
+                __map, "1", self.1
+            )),
+        );
+    }
+
+    /// A newtype adds nothing to the ciphertext: no map is opened, so wrapping
+    /// an existing type does not break its stored values.
+    #[test]
+    fn newtype_delegates_to_its_inner_value() {
+        let out = expand(parse_quote!(
+            struct Wrapper(String);
+        ));
+
+        assert_contains(
+            &out,
+            quote!(::vitaminc_aead::Encrypt::encrypt_with_aad(
+                self.0, __cipher, __aad
+            )),
+        );
+        assert_lacks(&out, quote!(::vitaminc_aead::Cipher::encrypt_map));
+    }
+
+    /// A field-less struct still opens and ends a map: the empty-map marker is
+    /// authenticated, so even this binds its AAD.
+    #[test]
+    fn empty_struct_still_binds_its_aad() {
+        let out = expand(parse_quote!(
+            struct Marker {}
+        ));
+
+        assert_contains(
+            &out,
+            quote!(::vitaminc_aead::MapCipher::end(
+                ::vitaminc_aead::Cipher::encrypt_map(__cipher, __aad)
+            )),
+        );
+        assert_lacks(&out, quote!(::vitaminc_aead::MapCipher::encrypt_entry));
+    }
+
+    /// Serde-style: bounding the parameter rather than each field's type lets a
+    /// field of type `Vec<T>` pick up `Vec<T>: Encrypt` from the blanket impl.
+    #[test]
+    fn type_parameters_gain_an_encrypt_bound() {
+        let out = expand(parse_quote! {
+            struct Holder<T> {
+                value: T,
+            }
+        });
+
+        assert_contains(&out, quote!(impl<T: ::vitaminc_aead::Encrypt>));
+        assert_contains(&out, quote!(for Holder<T>));
+    }
+
+    /// The `crate` attribute has to redirect *every* generated path, or the
+    /// expansion half-references a crate the caller may not depend on.
+    #[test]
+    fn crate_attribute_redirects_every_path() {
+        let out = expand(parse_quote! {
+            #[aead(crate = "::vitaminc::aead")]
+            struct User {
+                name: String,
+            }
+        });
+
+        assert_contains(&out, quote!(::vitaminc::aead::Encrypt for User));
+        assert_contains(&out, quote!(::vitaminc::aead::MapCipher::encrypt_entry));
+        assert!(
+            !out.contains("vitaminc_aead"),
+            "expansion still references the default crate path:\n{out}"
+        );
+    }
+
+    /// Attribute typos are rejected rather than ignored: a silently dropped
+    /// `#[aead(...)]` option is a setting the author believes is in effect.
+    #[test]
+    fn unknown_container_attribute_is_rejected() {
+        let err = derive(parse_quote! {
+            #[aead(bogus = "x")]
+            struct User {
+                name: String,
+            }
+        })
+        .expect_err("unknown container attribute should be rejected");
+
+        assert!(err.to_string().contains("unsupported container attribute"));
+    }
+
+    #[test]
+    fn unknown_field_attribute_is_rejected() {
+        let err = derive(parse_quote! {
+            struct User {
+                #[aead(bogus = "x")]
+                name: String,
+            }
+        })
+        .expect_err("unknown field attribute should be rejected");
+
+        assert!(err.to_string().contains("unsupported field attribute"));
+    }
+}

--- a/packages/aead-derive/src/encrypt.rs
+++ b/packages/aead-derive/src/encrypt.rs
@@ -1,0 +1,84 @@
+//! Expansion of `#[derive(Encrypt)]`.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{parse_quote, DeriveInput, Result};
+
+use crate::{
+    attrs::ContainerAttrs,
+    shape::{FieldInfo, Shape},
+};
+
+pub(crate) fn derive(input: DeriveInput) -> Result<TokenStream> {
+    let attrs = ContainerAttrs::parse(&input.attrs)?;
+    let krate = &attrs.krate;
+    let shape = Shape::parse(&input)?;
+    let name = &input.ident;
+
+    // Bound every type parameter, serde-style: a field of type `Vec<T>` then
+    // picks up `Vec<T>: Encrypt` from the blanket impl in `vitaminc_aead`.
+    let mut generics = input.generics.clone();
+    for param in generics.type_params_mut() {
+        param.bounds.push(parse_quote!(#krate::Encrypt));
+    }
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    let body = match &shape {
+        Shape::Newtype(field) => newtype_body(krate, field),
+        Shape::Map(fields) => map_body(krate, fields),
+        Shape::Empty => empty_body(krate),
+    };
+
+    Ok(quote! {
+        #[automatically_derived]
+        impl #impl_generics #krate::Encrypt for #name #ty_generics #where_clause {
+            fn encrypt_with_aad<'__aead_a, __C, __A>(
+                self,
+                __cipher: __C,
+                __aad: __A,
+            ) -> ::core::result::Result<__C::Ok, __C::Error>
+            where
+                __C: #krate::Cipher,
+                __A: #krate::IntoAad<'__aead_a>,
+            {
+                #body
+            }
+        }
+    })
+}
+
+/// A newtype adds nothing to the ciphertext — it encrypts exactly as its
+/// inner value, so wrapping a type is not a wire-breaking change.
+fn newtype_body(krate: &syn::Path, field: &FieldInfo) -> TokenStream {
+    let member = &field.member;
+    quote! {
+        #krate::Encrypt::encrypt_with_aad(self.#member, __cipher, __aad)
+    }
+}
+
+fn map_body(krate: &syn::Path, fields: &[FieldInfo]) -> TokenStream {
+    let entries = fields.iter().map(|field| {
+        let key = &field.key;
+        let member = &field.member;
+        quote! {
+            let __map = #krate::MapCipher::encrypt_entry(__map, #key, self.#member)?;
+        }
+    });
+
+    quote! {
+        // The AAD is captured once by `encrypt_map`; `encrypt_entry` binds
+        // each field's key into the AAD its value is sealed against, so a
+        // stored field cannot be renamed or moved to another key undetected.
+        let __map = #krate::Cipher::encrypt_map(__cipher, __aad);
+        #(#entries)*
+        #krate::MapCipher::end(__map)
+    }
+}
+
+/// No fields: `MapCipher::end` emits the authenticated empty-map marker, so
+/// even a field-less struct binds its AAD.
+fn empty_body(krate: &syn::Path) -> TokenStream {
+    quote! {
+        #krate::MapCipher::end(#krate::Cipher::encrypt_map(__cipher, __aad))
+    }
+}

--- a/packages/aead-derive/src/encrypt.rs
+++ b/packages/aead-derive/src/encrypt.rs
@@ -60,8 +60,22 @@ fn map_body(krate: &syn::Path, fields: &[FieldInfo]) -> TokenStream {
     let entries = fields.iter().map(|field| {
         let key = &field.key;
         let member = &field.member;
-        quote! {
-            let __map = #krate::MapCipher::encrypt_entry(__map, #key, self.#member)?;
+        if field.passthrough {
+            // Stored in the clear and bound to nothing — not the value, not
+            // even its key. That is what lets the entry be an ordinary
+            // database column other queries read and write independently of
+            // the encrypted ones.
+            quote! {
+                let __map = #krate::MapCipher::passthrough_entry_boxed(
+                    __map,
+                    #key,
+                    ::std::boxed::Box::new(self.#member),
+                )?;
+            }
+        } else {
+            quote! {
+                let __map = #krate::MapCipher::encrypt_entry(__map, #key, self.#member)?;
+            }
         }
     });
 
@@ -161,6 +175,43 @@ mod tests {
             &out,
             quote!(::vitaminc_aead::MapCipher::encrypt_entry(
                 __map, "1", self.1
+            )),
+        );
+    }
+
+    /// A passthrough field is written through the boxed channel — the derive is
+    /// generic over every cipher, so it cannot name `__C::Passthrough` — and is
+    /// never handed to `encrypt_entry`.
+    #[test]
+    fn a_passthrough_field_is_stored_in_the_clear() {
+        let out = expand(parse_quote! {
+            struct Row {
+                #[aead(passthrough)]
+                tenant: String,
+                ssn: String,
+            }
+        });
+
+        assert_contains(
+            &out,
+            quote!(::vitaminc_aead::MapCipher::passthrough_entry_boxed(
+                __map,
+                "tenant",
+                ::std::boxed::Box::new(self.tenant),
+            )),
+        );
+        assert_contains(
+            &out,
+            quote!(::vitaminc_aead::MapCipher::encrypt_entry(
+                __map, "ssn", self.ssn
+            )),
+        );
+        assert_lacks(
+            &out,
+            quote!(::vitaminc_aead::MapCipher::encrypt_entry(
+                __map,
+                "tenant",
+                self.tenant
             )),
         );
     }

--- a/packages/aead-derive/src/lib.rs
+++ b/packages/aead-derive/src/lib.rs
@@ -56,6 +56,51 @@
 //!   generated code at a re-export of `vitaminc_aead` (e.g. `::vitaminc::aead`).
 //! - `#[aead(rename = "name")]` on a field — use `name` as the map key instead
 //!   of the field's own name.
+//! - `#[aead(passthrough)]` on a field — store the value **in the clear**
+//!   instead of encrypting it. See the section below before reaching for it.
+//!
+//! # Passthrough fields
+//!
+//! `#[aead(passthrough)]` stores a field as a cleartext map entry, so it can be
+//! an ordinary database column that other queries select, filter, and update
+//! without holding the key:
+//!
+//! ```ignore
+//! #[derive(Encrypt, Decrypt)]
+//! struct Row {
+//!     #[aead(passthrough)]
+//!     tenant: String,   // a plain column
+//!     ssn: String,      // encrypted
+//! }
+//! ```
+//!
+//! That independence is bought by giving up all protection on the field, and
+//! the trade is total:
+//!
+//! - The value is **not encrypted** — anyone who can read the stored ciphertext
+//!   can read it.
+//! - The value is **not authenticated**. No tag covers it, and unlike an
+//!   encrypted entry's key, nothing binds its key either. It can be edited,
+//!   retargeted at another key, or removed, and the surrounding encrypted
+//!   fields still decrypt. Treat what comes back as untrusted input — it is
+//!   exactly as trustworthy as the column it was read from.
+//! - Deleting the entry is caught only by the ordinary missing-field rule, and
+//!   not distinguished from a value that was never written.
+//!
+//! So: non-sensitive, non-security-deciding data only. Never a field the
+//! program later trusts to make an authorization choice. If a cleartext field
+//! must be tamper-evident, it needs to be bound into the AAD rather than passed
+//! through — and note that binding it couples the two, so any independent write
+//! to that column breaks decryption of every encrypted field beside it.
+//!
+//! Two shapes are rejected at compile time: a struct whose fields are *all*
+//! passthrough (nothing would be encrypted, so the ciphertext would carry no
+//! tag at all — `MapCipher::end` refuses to seal one), and `passthrough` on a
+//! newtype (transparent, so there is no map entry to hold it).
+//!
+//! A passthrough field's type must be `Any + Send + 'static`, since the value
+//! travels through the cipher type-erased and is downcast on the way out. That
+//! rules out borrowed types such as `&'a str`.
 //!
 //! [`Encrypt`]: https://docs.rs/vitaminc-aead/latest/vitaminc_aead/trait.Encrypt.html
 //! [`Decrypt`]: https://docs.rs/vitaminc-aead/latest/vitaminc_aead/trait.Decrypt.html

--- a/packages/aead-derive/src/lib.rs
+++ b/packages/aead-derive/src/lib.rs
@@ -50,61 +50,10 @@
 //! variant in the clear or leave it forgeable. Model the choice explicitly
 //! (e.g. as a struct with `Option` fields) instead.
 //!
-//! # Attributes
-//!
-//! - `#[aead(crate = "path::to::vitaminc_aead")]` on the container — point the
-//!   generated code at a re-export of `vitaminc_aead` (e.g. `::vitaminc::aead`).
-//! - `#[aead(rename = "name")]` on a field — use `name` as the map key instead
-//!   of the field's own name.
-//! - `#[aead(passthrough)]` on a field — store the value **in the clear**
-//!   instead of encrypting it. See the section below before reaching for it.
-//!
-//! # Passthrough fields
-//!
-//! `#[aead(passthrough)]` stores a field as a cleartext map entry, so it can be
-//! an ordinary database column that other queries select, filter, and update
-//! without holding the key:
-//!
-//! ```ignore
-//! #[derive(Encrypt, Decrypt)]
-//! struct Row {
-//!     #[aead(passthrough)]
-//!     tenant: String,   // a plain column
-//!     ssn: String,      // encrypted
-//! }
-//! ```
-//!
-//! That independence is bought by giving up all protection on the field, and
-//! the trade is total:
-//!
-//! - The value is **not encrypted** — anyone who can read the stored ciphertext
-//!   can read it.
-//! - The value is **not authenticated**. No tag covers it, and unlike an
-//!   encrypted entry's key, nothing binds its key either. It can be edited,
-//!   retargeted at another key, or removed, and the surrounding encrypted
-//!   fields still decrypt. Treat what comes back as untrusted input — it is
-//!   exactly as trustworthy as the column it was read from.
-//! - Deleting the entry is caught only by the ordinary missing-field rule, and
-//!   not distinguished from a value that was never written.
-//!
-//! So: non-sensitive, non-security-deciding data only. Never a field the
-//! program later trusts to make an authorization choice. If a cleartext field
-//! must be tamper-evident, it needs to be bound into the AAD rather than passed
-//! through — and note that binding it couples the two, so any independent write
-//! to that column breaks decryption of every encrypted field beside it.
-//!
-//! Two shapes are rejected at compile time: a struct whose fields are *all*
-//! passthrough (nothing would be encrypted, so the ciphertext would carry no
-//! tag at all — `MapCipher::end` refuses to seal one), and `passthrough` on a
-//! newtype (transparent, so there is no map entry to hold it).
-//!
-//! A passthrough field's type must be `Any + Send + 'static`, since the value
-//! travels through the cipher type-erased and is downcast on the way out. That
-//! rules out borrowed types such as `&'a str`.
-//!
 //! [`Encrypt`]: https://docs.rs/vitaminc-aead/latest/vitaminc_aead/trait.Encrypt.html
 //! [`Decrypt`]: https://docs.rs/vitaminc-aead/latest/vitaminc_aead/trait.Decrypt.html
 //! [`MapCipher`]: https://docs.rs/vitaminc-aead/latest/vitaminc_aead/trait.MapCipher.html
+#![doc = include_str!("../docs/attributes.md")]
 #![deny(unsafe_code)]
 
 use proc_macro::TokenStream;
@@ -118,8 +67,9 @@ mod shape;
 mod test_support;
 
 /// Derive [`Encrypt`](https://docs.rs/vitaminc-aead/latest/vitaminc_aead/trait.Encrypt.html)
-/// for a struct. See the [crate documentation](crate) for the wire shape and
-/// supported attributes.
+/// for a struct. See the [crate documentation](crate) for the wire shape this
+/// produces; the attributes it accepts are reproduced below.
+#[doc = include_str!("../docs/attributes.md")]
 #[proc_macro_derive(Encrypt, attributes(aead))]
 pub fn derive_encrypt(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
@@ -129,8 +79,9 @@ pub fn derive_encrypt(input: TokenStream) -> TokenStream {
 }
 
 /// Derive [`Decrypt`](https://docs.rs/vitaminc-aead/latest/vitaminc_aead/trait.Decrypt.html)
-/// for a struct. See the [crate documentation](crate) for the wire shape and
-/// supported attributes.
+/// for a struct. See the [crate documentation](crate) for the wire shape this
+/// consumes; the attributes it accepts are reproduced below.
+#[doc = include_str!("../docs/attributes.md")]
 #[proc_macro_derive(Decrypt, attributes(aead))]
 pub fn derive_decrypt(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);

--- a/packages/aead-derive/src/lib.rs
+++ b/packages/aead-derive/src/lib.rs
@@ -1,0 +1,93 @@
+//! Derive macros for the [`Encrypt`] and [`Decrypt`] traits of
+//! [`vitaminc-aead`](https://docs.rs/vitaminc-aead).
+//!
+//! Both macros are re-exported from `vitaminc_aead`, so depend on that crate
+//! rather than this one:
+//!
+//! ```ignore
+//! use vitaminc_aead::{Decrypt, Encrypt};
+//!
+//! #[derive(Encrypt, Decrypt)]
+//! struct User {
+//!     name: String,
+//!     age: u32,
+//! }
+//! ```
+//!
+//! # Wire shape
+//!
+//! A struct is encrypted as a **map**, keyed by field name. This is the
+//! deliberate choice over a sequence: [`MapCipher`] binds each entry's key
+//! into the AAD its value is sealed against (`Aad::for_map_entry`), so a
+//! stored ciphertext cannot have its fields renamed or swapped without
+//! decryption failing. Sequence elements carry no such binding — their AAD
+//! has no positional component — so two same-typed fields encoded as a
+//! sequence would be freely interchangeable.
+//!
+//! The consequences of the map shape:
+//!
+//! - Field **names are part of the ciphertext contract**. Renaming a field is
+//!   a wire-breaking change; use `#[aead(rename = "...")]` to keep an old name.
+//! - A derived struct's ciphertext is interchangeable with the equivalent
+//!   `HashMap<String, _>` ciphertext.
+//! - Tuple structs of two or more fields use the decimal field index as the
+//!   key (`"0"`, `"1"`, …), so they get the same per-field binding.
+//! - A **newtype** struct (exactly one unnamed field) is *transparent*: it
+//!   encrypts and decrypts exactly as its inner type, adding nothing to the
+//!   ciphertext. This mirrors serde, and matches how `Protected<T>` and
+//!   `Equatable<T>` behave.
+//! - A unit struct — or a struct with no fields — encrypts to the
+//!   authenticated empty-map marker.
+//!
+//! Field values are **not** authenticated in any particular order, so the
+//! derived `Decrypt` reads keys first and matches them to fields. Decoding is
+//! strict: an unknown key, a duplicate key, or a missing field is rejected.
+//!
+//! # Enums
+//!
+//! Enums are not supported. The ciphertext carries no authenticated variant
+//! discriminator, so any encoding this macro could pick would either leak the
+//! variant in the clear or leave it forgeable. Model the choice explicitly
+//! (e.g. as a struct with `Option` fields) instead.
+//!
+//! # Attributes
+//!
+//! - `#[aead(crate = "path::to::vitaminc_aead")]` on the container — point the
+//!   generated code at a re-export of `vitaminc_aead` (e.g. `::vitaminc::aead`).
+//! - `#[aead(rename = "name")]` on a field — use `name` as the map key instead
+//!   of the field's own name.
+//!
+//! [`Encrypt`]: https://docs.rs/vitaminc-aead/latest/vitaminc_aead/trait.Encrypt.html
+//! [`Decrypt`]: https://docs.rs/vitaminc-aead/latest/vitaminc_aead/trait.Decrypt.html
+//! [`MapCipher`]: https://docs.rs/vitaminc-aead/latest/vitaminc_aead/trait.MapCipher.html
+#![deny(unsafe_code)]
+
+use proc_macro::TokenStream;
+use syn::{parse_macro_input, DeriveInput};
+
+mod attrs;
+mod decrypt;
+mod encrypt;
+mod shape;
+
+/// Derive [`Encrypt`](https://docs.rs/vitaminc-aead/latest/vitaminc_aead/trait.Encrypt.html)
+/// for a struct. See the [crate documentation](crate) for the wire shape and
+/// supported attributes.
+#[proc_macro_derive(Encrypt, attributes(aead))]
+pub fn derive_encrypt(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    encrypt::derive(input)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
+}
+
+/// Derive [`Decrypt`](https://docs.rs/vitaminc-aead/latest/vitaminc_aead/trait.Decrypt.html)
+/// for a struct. See the [crate documentation](crate) for the wire shape and
+/// supported attributes.
+#[proc_macro_derive(Decrypt, attributes(aead))]
+pub fn derive_decrypt(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    decrypt::derive(input)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
+}

--- a/packages/aead-derive/src/lib.rs
+++ b/packages/aead-derive/src/lib.rs
@@ -69,6 +69,8 @@ mod attrs;
 mod decrypt;
 mod encrypt;
 mod shape;
+#[cfg(test)]
+mod test_support;
 
 /// Derive [`Encrypt`](https://docs.rs/vitaminc-aead/latest/vitaminc_aead/trait.Encrypt.html)
 /// for a struct. See the [crate documentation](crate) for the wire shape and

--- a/packages/aead-derive/src/shape.rs
+++ b/packages/aead-derive/src/shape.rs
@@ -22,6 +22,10 @@ pub(crate) struct FieldInfo {
     /// `#[aead(passthrough)]`: stored in the clear, never encrypted and never
     /// authenticated.
     pub(crate) passthrough: bool,
+    /// Whether [`key`](FieldInfo::key) came from `#[aead(rename = "...")]`
+    /// rather than the field's own name. Only the newtype guard needs this —
+    /// everywhere else the rename has already been folded into `key`.
+    pub(crate) renamed: bool,
 }
 
 /// The wire shape a struct maps onto — see the crate docs.
@@ -65,14 +69,7 @@ impl Shape {
         if !named && fields.len() == 1 {
             let mut fields = fields;
             let field = fields.remove(0);
-            if field.passthrough {
-                return Err(syn::Error::new_spanned(
-                    &input.ident,
-                    "`#[aead(passthrough)]` is meaningless on a newtype struct: a newtype is \
-                     transparent, so there is no map entry to store in the clear and nothing \
-                     would be encrypted at all. Give the struct a named field instead.",
-                ));
-            }
+            reject_newtype_field_attrs(&field, input)?;
             return Ok(Shape::Newtype(Box::new(field)));
         }
 
@@ -92,6 +89,7 @@ fn collect(fields: &Fields) -> Result<Vec<FieldInfo>> {
         .enumerate()
         .map(|(index, field)| {
             let attrs = FieldAttrs::parse(&field.attrs)?;
+            let renamed = attrs.rename.is_some();
             let (key, member) = match &field.ident {
                 Some(ident) => (ident.to_string(), Member::Named(ident.clone())),
                 None => (index.to_string(), Member::Unnamed(syn::Index::from(index))),
@@ -102,6 +100,7 @@ fn collect(fields: &Fields) -> Result<Vec<FieldInfo>> {
                 local: Ident::new(&format!("__field_{index}"), Span::call_site()),
                 ty: field.ty.clone(),
                 passthrough: attrs.passthrough,
+                renamed,
             })
         })
         .collect()
@@ -122,6 +121,37 @@ fn reject_duplicate_keys(fields: &[FieldInfo], input: &DeriveInput) -> Result<()
                 ),
             ));
         }
+    }
+    Ok(())
+}
+
+/// A newtype is transparent: it encrypts exactly as its inner type, opening no
+/// map and producing no entry. Every field attribute the derive understands
+/// describes a map entry, so on a newtype there is nothing for one to describe.
+///
+/// Both are rejected rather than ignored, because ignoring them is silent and
+/// the author's intent was the opposite of what they would get. `rename` names
+/// a map key that is never written, so a value the author believes is
+/// key-bound has no key binding at all. `passthrough` asks for a cleartext
+/// entry that does not exist; honouring it instead would mean the whole value
+/// travels unencrypted, leaving a container with no tag — the same thing
+/// `MapCipher::end` refuses to seal.
+fn reject_newtype_field_attrs(field: &FieldInfo, input: &DeriveInput) -> Result<()> {
+    if field.renamed {
+        return Err(syn::Error::new_spanned(
+            &input.ident,
+            "`#[aead(rename = \"...\")]` has no effect on a newtype struct: a newtype is \
+             transparent, so its value is not stored under a map key at all and there is no \
+             key to rename. Give the struct a named field instead.",
+        ));
+    }
+    if field.passthrough {
+        return Err(syn::Error::new_spanned(
+            &input.ident,
+            "`#[aead(passthrough)]` is meaningless on a newtype struct: a newtype is \
+             transparent, so there is no map entry to store in the clear and nothing \
+             would be encrypted at all. Give the struct a named field instead.",
+        ));
     }
     Ok(())
 }
@@ -202,6 +232,18 @@ mod tests {
         };
         let err = Shape::parse(&input).expect_err("all-passthrough struct should be rejected");
         assert!(err.to_string().contains("nothing would be encrypted"));
+    }
+
+    /// A newtype's value is not stored under a map key, so a `rename` names a
+    /// key that is never written. Ignoring it would leave the author believing
+    /// the value is key-bound when nothing binds it at all.
+    #[test]
+    fn rename_on_a_newtype_is_rejected() {
+        let input: DeriveInput = parse_quote!(
+            struct Token(#[aead(rename = "token")] String);
+        );
+        let err = Shape::parse(&input).expect_err("renamed newtype should be rejected");
+        assert!(err.to_string().contains("no effect on a newtype"));
     }
 
     /// A newtype is transparent, so there is no map entry for a passthrough to

--- a/packages/aead-derive/src/shape.rs
+++ b/packages/aead-derive/src/shape.rs
@@ -1,0 +1,214 @@
+//! Classification of the derive input into the wire shape it maps onto.
+
+use std::collections::HashMap;
+
+use proc_macro2::Span;
+use syn::{Data, DeriveInput, Fields, Ident, Member, Result, Type};
+
+use crate::attrs::FieldAttrs;
+
+/// One encrypted field of a struct.
+#[cfg_attr(test, derive(Debug))]
+pub(crate) struct FieldInfo {
+    /// Map key this field is stored under — the field name, the decimal index
+    /// for a tuple struct, or the `#[aead(rename = "...")]` override.
+    pub(crate) key: String,
+    /// How the field is reached on `self` (`self.name` or `self.0`).
+    pub(crate) member: Member,
+    /// A local binding name, unique per field, for use in generated bodies.
+    /// Derived from the position so tuple fields get a legal identifier.
+    pub(crate) local: Ident,
+    pub(crate) ty: Type,
+}
+
+/// The wire shape a struct maps onto — see the crate docs.
+#[cfg_attr(test, derive(Debug))]
+pub(crate) enum Shape {
+    /// Exactly one unnamed field: transparent, delegating to the inner type.
+    /// Boxed to keep the variant from dominating the enum's size.
+    Newtype(Box<FieldInfo>),
+    /// One or more fields, encoded as a map keyed by [`FieldInfo::key`].
+    Map(Vec<FieldInfo>),
+    /// No fields at all: the authenticated empty-map marker.
+    Empty,
+}
+
+impl Shape {
+    pub(crate) fn parse(input: &DeriveInput) -> Result<Self> {
+        let data = match &input.data {
+            Data::Struct(data) => data,
+            Data::Enum(_) => {
+                return Err(syn::Error::new_spanned(
+                    &input.ident,
+                    "Encrypt/Decrypt cannot be derived for enums: a ciphertext carries no \
+                     authenticated variant discriminator, so the variant would have to travel \
+                     in the clear or be forgeable. Model the choice explicitly instead, e.g. as \
+                     a struct of `Option` fields.",
+                ))
+            }
+            Data::Union(_) => {
+                return Err(syn::Error::new_spanned(
+                    &input.ident,
+                    "Encrypt/Decrypt cannot be derived for unions",
+                ))
+            }
+        };
+
+        let named = matches!(data.fields, Fields::Named(_));
+        let fields = collect(&data.fields)?;
+
+        // A newtype is transparent; a *named* one-field struct is not, since
+        // its field name is a meaningful part of the wire contract.
+        if !named && fields.len() == 1 {
+            let mut fields = fields;
+            return Ok(Shape::Newtype(Box::new(fields.remove(0))));
+        }
+
+        if fields.is_empty() {
+            return Ok(Shape::Empty);
+        }
+
+        reject_duplicate_keys(&fields, input)?;
+        Ok(Shape::Map(fields))
+    }
+}
+
+fn collect(fields: &Fields) -> Result<Vec<FieldInfo>> {
+    fields
+        .iter()
+        .enumerate()
+        .map(|(index, field)| {
+            let attrs = FieldAttrs::parse(&field.attrs)?;
+            let (key, member) = match &field.ident {
+                Some(ident) => (ident.to_string(), Member::Named(ident.clone())),
+                None => (index.to_string(), Member::Unnamed(syn::Index::from(index))),
+            };
+            Ok(FieldInfo {
+                key: attrs.rename.unwrap_or(key),
+                member,
+                local: Ident::new(&format!("__field_{index}"), Span::call_site()),
+                ty: field.ty.clone(),
+            })
+        })
+        .collect()
+}
+
+/// Two fields sharing a map key would silently overwrite one another on
+/// encrypt (and the decipher rejects duplicate keys anyway), so catch it here
+/// where the error can point at the offending `rename`.
+fn reject_duplicate_keys(fields: &[FieldInfo], input: &DeriveInput) -> Result<()> {
+    let mut seen: HashMap<&str, ()> = HashMap::with_capacity(fields.len());
+    for field in fields {
+        if seen.insert(field.key.as_str(), ()).is_some() {
+            return Err(syn::Error::new_spanned(
+                &input.ident,
+                format!(
+                    "duplicate map key `{}`: two fields would be encrypted under the same key",
+                    field.key
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_quote;
+
+    /// Enums have no authenticated variant discriminator, so the macro must
+    /// refuse them outright rather than pick an encoding — see the crate docs.
+    #[test]
+    fn enums_are_rejected() {
+        let input: DeriveInput = parse_quote! {
+            enum Choice {
+                A(String),
+                B(u32),
+            }
+        };
+        let err = Shape::parse(&input).expect_err("enum should be rejected");
+        assert!(err.to_string().contains("cannot be derived for enums"));
+    }
+
+    #[test]
+    fn unions_are_rejected() {
+        let input: DeriveInput = parse_quote! {
+            union Raw {
+                a: u32,
+                b: u32,
+            }
+        };
+        assert!(Shape::parse(&input).is_err());
+    }
+
+    /// Two fields renamed onto one key would overwrite each other on encrypt
+    /// and be rejected as duplicates on decrypt; catch it at compile time.
+    #[test]
+    fn duplicate_keys_are_rejected() {
+        let input: DeriveInput = parse_quote! {
+            struct Clash {
+                a: String,
+                #[aead(rename = "a")]
+                b: String,
+            }
+        };
+        let err = Shape::parse(&input).expect_err("duplicate key should be rejected");
+        assert!(err.to_string().contains("duplicate map key `a`"));
+    }
+
+    #[test]
+    fn single_unnamed_field_is_a_transparent_newtype() {
+        let input: DeriveInput = parse_quote!(
+            struct Wrapper(String);
+        );
+        assert!(matches!(Shape::parse(&input), Ok(Shape::Newtype(_))));
+    }
+
+    /// A *named* single-field struct is not transparent: its field name is
+    /// part of the wire contract.
+    #[test]
+    fn single_named_field_is_a_map() {
+        let input: DeriveInput = parse_quote! {
+            struct Wrapper {
+                inner: String,
+            }
+        };
+        match Shape::parse(&input) {
+            Ok(Shape::Map(fields)) => assert_eq!(fields[0].key, "inner"),
+            _ => panic!("expected a map shape"),
+        }
+    }
+
+    #[test]
+    fn tuple_fields_are_keyed_by_index() {
+        let input: DeriveInput = parse_quote!(
+            struct Pair(String, u32);
+        );
+        match Shape::parse(&input) {
+            Ok(Shape::Map(fields)) => {
+                assert_eq!(fields[0].key, "0");
+                assert_eq!(fields[1].key, "1");
+            }
+            _ => panic!("expected a map shape"),
+        }
+    }
+
+    #[test]
+    fn field_less_structs_are_empty() {
+        let inputs: [DeriveInput; 3] = [
+            parse_quote!(
+                struct Unit;
+            ),
+            parse_quote!(
+                struct Braced {}
+            ),
+            parse_quote!(
+                struct Parens();
+            ),
+        ];
+        for input in inputs {
+            assert!(matches!(Shape::parse(&input), Ok(Shape::Empty)));
+        }
+    }
+}

--- a/packages/aead-derive/src/shape.rs
+++ b/packages/aead-derive/src/shape.rs
@@ -19,6 +19,9 @@ pub(crate) struct FieldInfo {
     /// Derived from the position so tuple fields get a legal identifier.
     pub(crate) local: Ident,
     pub(crate) ty: Type,
+    /// `#[aead(passthrough)]`: stored in the clear, never encrypted and never
+    /// authenticated.
+    pub(crate) passthrough: bool,
 }
 
 /// The wire shape a struct maps onto — see the crate docs.
@@ -61,7 +64,16 @@ impl Shape {
         // its field name is a meaningful part of the wire contract.
         if !named && fields.len() == 1 {
             let mut fields = fields;
-            return Ok(Shape::Newtype(Box::new(fields.remove(0))));
+            let field = fields.remove(0);
+            if field.passthrough {
+                return Err(syn::Error::new_spanned(
+                    &input.ident,
+                    "`#[aead(passthrough)]` is meaningless on a newtype struct: a newtype is \
+                     transparent, so there is no map entry to store in the clear and nothing \
+                     would be encrypted at all. Give the struct a named field instead.",
+                ));
+            }
+            return Ok(Shape::Newtype(Box::new(field)));
         }
 
         if fields.is_empty() {
@@ -69,6 +81,7 @@ impl Shape {
         }
 
         reject_duplicate_keys(&fields, input)?;
+        reject_all_passthrough(&fields, input)?;
         Ok(Shape::Map(fields))
     }
 }
@@ -88,6 +101,7 @@ fn collect(fields: &Fields) -> Result<Vec<FieldInfo>> {
                 member,
                 local: Ident::new(&format!("__field_{index}"), Span::call_site()),
                 ty: field.ty.clone(),
+                passthrough: attrs.passthrough,
             })
         })
         .collect()
@@ -108,6 +122,23 @@ fn reject_duplicate_keys(fields: &[FieldInfo], input: &DeriveInput) -> Result<()
                 ),
             ));
         }
+    }
+    Ok(())
+}
+
+/// A map with no encrypted entries carries no tag at all — nothing
+/// authenticates the map's AAD, and nothing binds the entry keys — so
+/// `MapCipher::end` rejects one at seal time. Catch it here, where the error
+/// names the struct instead of surfacing as a runtime encrypt failure.
+fn reject_all_passthrough(fields: &[FieldInfo], input: &DeriveInput) -> Result<()> {
+    if fields.iter().all(|field| field.passthrough) {
+        return Err(syn::Error::new_spanned(
+            &input.ident,
+            "every field is `#[aead(passthrough)]`, so nothing would be encrypted and the \
+             ciphertext would carry no tag — neither the associated data nor the entry keys \
+             would be authenticated. Encrypt at least one field, or do not derive Encrypt for \
+             this struct at all.",
+        ));
     }
     Ok(())
 }
@@ -155,6 +186,54 @@ mod tests {
         };
         let err = Shape::parse(&input).expect_err("duplicate key should be rejected");
         assert!(err.to_string().contains("duplicate map key `a`"));
+    }
+
+    /// A map with no encrypted entries carries no tag at all, and
+    /// `MapCipher::end` rejects one at seal time — so catch it at compile time.
+    #[test]
+    fn an_all_passthrough_struct_is_rejected() {
+        let input: DeriveInput = parse_quote! {
+            struct Row {
+                #[aead(passthrough)]
+                id: i64,
+                #[aead(passthrough)]
+                tenant: String,
+            }
+        };
+        let err = Shape::parse(&input).expect_err("all-passthrough struct should be rejected");
+        assert!(err.to_string().contains("nothing would be encrypted"));
+    }
+
+    /// A newtype is transparent, so there is no map entry for a passthrough to
+    /// occupy. Silently ignoring the attribute would leave the author believing
+    /// a field is stored in the clear when the whole value is encrypted.
+    #[test]
+    fn passthrough_on_a_newtype_is_rejected() {
+        let input: DeriveInput = parse_quote!(
+            struct Wrapper(#[aead(passthrough)] String);
+        );
+        let err = Shape::parse(&input).expect_err("passthrough newtype should be rejected");
+        assert!(err.to_string().contains("meaningless on a newtype"));
+    }
+
+    /// A mixed struct is the shape the attribute exists for: some columns in
+    /// the clear, at least one encrypted.
+    #[test]
+    fn a_mixed_struct_records_which_fields_are_passthrough() {
+        let input: DeriveInput = parse_quote! {
+            struct Row {
+                #[aead(passthrough)]
+                id: i64,
+                ssn: String,
+            }
+        };
+        match Shape::parse(&input) {
+            Ok(Shape::Map(fields)) => {
+                assert!(fields[0].passthrough);
+                assert!(!fields[1].passthrough);
+            }
+            _ => panic!("expected a map shape"),
+        }
     }
 
     #[test]

--- a/packages/aead-derive/src/test_support.rs
+++ b/packages/aead-derive/src/test_support.rs
@@ -1,0 +1,29 @@
+//! Helpers shared by the expansion tests in `encrypt` and `decrypt`.
+//!
+//! Expansions are asserted as *tokens*, never as text: the expected fragment is
+//! rendered through `quote!` as well, so it is written as ordinary Rust and the
+//! comparison cannot fail on `TokenStream`'s spacing.
+//!
+//! One caveat: rustfmt formats inside `quote!` bodies and will add or strip a
+//! trailing comma, which *does* change the tokens. Keep fragments short enough
+//! that rustfmt leaves them alone, or mark the test `#[rustfmt::skip]`.
+
+use proc_macro2::TokenStream;
+
+#[track_caller]
+pub(crate) fn assert_contains(expansion: &str, fragment: TokenStream) {
+    let fragment = fragment.to_string();
+    assert!(
+        expansion.contains(&fragment),
+        "expansion is missing `{fragment}`:\n{expansion}"
+    );
+}
+
+#[track_caller]
+pub(crate) fn assert_lacks(expansion: &str, fragment: TokenStream) {
+    let fragment = fragment.to_string();
+    assert!(
+        !expansion.contains(&fragment),
+        "expansion unexpectedly contains `{fragment}`:\n{expansion}"
+    );
+}

--- a/packages/aead-value/src/tagged.rs
+++ b/packages/aead-value/src/tagged.rs
@@ -9,7 +9,7 @@
 //! any 8 bytes parse equally as a valid `i64`, `u64`, or `f64`, so a bare
 //! payload gives the decrypt side no way to tell which. Each scalar
 //! [`FfiValue`](crate::FfiValue) therefore seals as a one-byte type tag
-//! followed by its payload (`[tag] ++ payload`, see [`tags`](crate::tags)) —
+//! followed by its payload (`[tag] ++ payload`, see [`crate::tags`]) —
 //! the tag rides *inside* the AEAD envelope, so it is authenticated and the
 //! value describes its own type on the way back out.
 //!

--- a/packages/aead-value/src/value.rs
+++ b/packages/aead-value/src/value.rs
@@ -88,7 +88,8 @@ pub enum FfiValue {
     Array(Vec<FfiValue>),
     /// String-keyed object/map. Encrypts via the cipher's map mode: keys
     /// travel in the clear (bound into each value's AAD — see
-    /// [`Aad::for_map_entry`]); values are sealed.
+    /// [`Aad::for_map_entry`](vitaminc_aead::Aad::for_map_entry)); values are
+    /// sealed.
     Object(Vec<(String, FfiValue)>),
     /// A subtree that travels alongside the ciphertext **unencrypted and
     /// unauthenticated**, via the cipher's passthrough channel (see

--- a/packages/aead-value/src/value.rs
+++ b/packages/aead-value/src/value.rs
@@ -581,6 +581,17 @@ mod tests {
                 Err(Unspecified)
             }
 
+            fn passthrough_entry_boxed<K>(
+                self,
+                _key: K,
+                _value: Box<dyn std::any::Any + Send + 'static>,
+            ) -> Result<Self, Self::Error>
+            where
+                K: Into<std::borrow::Cow<'static, str>>,
+            {
+                Ok(self)
+            }
+
             fn end(self) -> Result<Self::Ok, Self::Error> {
                 Err(Unspecified)
             }

--- a/packages/aead/Cargo.toml
+++ b/packages/aead/Cargo.toml
@@ -12,6 +12,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
+vitaminc-aead-derive = { version = "0.2.0-pre.1", path = "../aead-derive" }
 vitaminc-protected = { version = "0.2.0-pre.1", path = "../protected" }
 vitaminc-random = { version = "0.2.0-pre.1", path = "../random" }
 

--- a/packages/aead/Cargo.toml
+++ b/packages/aead/Cargo.toml
@@ -35,3 +35,5 @@ hlist = []
 [dev-dependencies]
 quickcheck = "1.1.0"
 quickcheck_macros = "1.2.0"
+# Compile-fail tests for the derive macros' guards — see tests/derive_ui.rs.
+trybuild = "1.0.118"

--- a/packages/aead/README.md
+++ b/packages/aead/README.md
@@ -139,6 +139,18 @@ impl<'c> MapCipher for MyMapCipher<'c> {
         K: Into<std::borrow::Cow<'static, str>>,
     { unimplemented!() }
 
+    // The type-erased counterpart, for callers that cannot name
+    // `Self::Passthrough` — a derived `Encrypt` impl, or a self-describing
+    // tree value. Absorb the box, or reject a payload type you don't own.
+    fn passthrough_entry_boxed<K>(
+        self,
+        _key: K,
+        _value: Box<dyn std::any::Any + Send + 'static>,
+    ) -> Result<Self, Self::Error>
+    where
+        K: Into<std::borrow::Cow<'static, str>>,
+    { unimplemented!() }
+
     fn end(self) -> Result<Self::Ok, Self::Error> { unimplemented!() }
 }
 ```

--- a/packages/aead/README.md
+++ b/packages/aead/README.md
@@ -221,9 +221,39 @@ let encrypted = sensitive_data.encrypt(&cipher)?;
 
 The corresponding `Decrypt` impl for `Protected<T>` re-wraps the decrypted plaintext, so the value stays inside `Protected` end-to-end.
 
+### Deriving `Encrypt` and `Decrypt`
+
+Most structs do not need a hand-written impl:
+
+```rust
+use vitaminc_aead::{Decrypt, Encrypt};
+
+#[derive(Encrypt, Decrypt)]
+struct User {
+    name: String,
+    age: u32,
+}
+```
+
+A derived struct is encrypted as a **map keyed by field name**, which is the shape that gets each field its own AAD binding: `MapCipher` seals every value against `Aad::for_map_entry` of its key, so a stored field cannot be renamed, or moved onto another key, without decryption failing. A sequence would give no such guarantee — element AAD carries no positional component, so two same-typed fields would be freely interchangeable.
+
+What follows from that shape:
+
+- **Field names are part of the ciphertext contract.** Renaming a field breaks compatibility with data already encrypted; `#[aead(rename = "...")]` keeps the old wire key.
+- A derived struct's ciphertext is interchangeable with the equivalent `HashMap<String, _>` ciphertext.
+- A tuple struct of two or more fields is keyed by decimal index (`"0"`, `"1"`, …), so its fields are bound the same way.
+- A **newtype** struct (exactly one unnamed field) is *transparent* — it encrypts and decrypts exactly as its inner type, adding nothing to the ciphertext. Wrapping an existing type is therefore not a wire-breaking change.
+- A unit struct, or a struct with no fields, encrypts to the authenticated empty-map marker.
+
+Decoding is strict. Entry order in a stored ciphertext is not authenticated, so the derived `Decrypt` reads keys first and matches them to fields; a missing field, an unknown key, or a duplicate key is rejected rather than defaulted or skipped, because an entry whose value is never decrypted is an entry whose AAD binding is never verified.
+
+Enums are **not** supported: a ciphertext carries no authenticated variant discriminator, so any encoding the macro could pick would either leak the variant in the clear or leave it forgeable. Model the choice explicitly instead — for example as a struct of `Option` fields.
+
+Use `#[aead(crate = "...")]` on the container when `vitaminc_aead` is reached through a re-export, e.g. `#[aead(crate = "::vitaminc::aead")]`.
+
 ### Custom Types
 
-Implementing [`Encrypt`] and [`Decrypt`] for your own types lets you choose which fields are encrypted and how the ciphertext is structured.
+Where the derive's shape is not what you want — encrypting only some fields, passing others through in the clear, or producing a non-map layout — implement [`Encrypt`] and [`Decrypt`] by hand.
 
 ```rust
 use vitaminc_aead::{

--- a/packages/aead/src/aad/mod.rs
+++ b/packages/aead/src/aad/mod.rs
@@ -139,8 +139,9 @@ impl<'a> Aad<'a> {
     ///
     /// Like [`for_map_entry`](Aad::for_map_entry), the encoding is a
     /// labelled three-piece `PAE(domain, aad, kind)` so it can never
-    /// collide with a caller's tuple AAD (see
-    /// [`for_marker`](Aad::for_marker)).
+    /// collide with a caller's tuple AAD — the same reasoning the marker
+    /// derivations behind [`for_empty_sequence`](Aad::for_empty_sequence)
+    /// and [`for_empty_map`](Aad::for_empty_map) follow.
     ///
     /// The element *index* is deliberately not bound: records are retrieved
     /// in a different order than they were inserted, so element order is a
@@ -156,8 +157,11 @@ impl<'a> Aad<'a> {
         pae::encode(&[SEQ_ELEMENT_DOMAIN, self.as_bytes(), b"element"])
     }
 
-    /// Marker AAD for an empty sequence — see [`for_marker`](Aad::for_marker)
-    /// (private; this method and its siblings are the public surface).
+    /// Marker AAD for an empty sequence.
+    ///
+    /// Thin wrapper over the private `for_marker` derivation — this method
+    /// and its siblings are its public surface, one per marker kind, so a
+    /// stored marker can never be replayed as a different structural claim.
     pub fn for_empty_sequence(&self) -> Aad<'static> {
         self.for_marker(b"empty-sequence")
     }

--- a/packages/aead/src/cipher.rs
+++ b/packages/aead/src/cipher.rs
@@ -137,7 +137,7 @@ pub trait Cipher: Sized {
     ///
     /// The value has the cipher's [`Passthrough`](Cipher::Passthrough) type,
     /// stored opaquely and returned as-is by the corresponding
-    /// [`Decipher::decrypt_passthrough`].
+    /// [`Decipher::decrypt_passthrough`](crate::Decipher::decrypt_passthrough).
     ///
     /// # ⚠️ Non-sensitive data only
     ///

--- a/packages/aead/src/cipher.rs
+++ b/packages/aead/src/cipher.rs
@@ -300,6 +300,31 @@ pub trait MapCipher: Sized {
     where
         K: Into<Cow<'static, str>>;
 
+    /// Insert a **type-erased** passthrough entry under `key` — the entry point
+    /// for callers that cannot name this cipher's
+    /// [`Passthrough`](Cipher::Passthrough) type at the call site.
+    ///
+    /// Stands to [`passthrough_entry`](MapCipher::passthrough_entry) exactly as
+    /// [`Cipher::passthrough_boxed`] stands to [`Cipher::passthrough`], and for
+    /// the same reason: code generic over *every* cipher — a derived
+    /// `Encrypt` impl, a self-describing tree value — has no way to construct a
+    /// specific cipher's payload type. The value arrives as
+    /// `Box<dyn Any + Send>` and each cipher decides how to absorb it: one whose
+    /// payload type *is* `Box<dyn Any + Send>` stores it directly, one with an
+    /// owned payload type downcasts (erroring on a foreign payload type).
+    ///
+    /// # ⚠️ Non-sensitive data only
+    ///
+    /// Identical contract to [`passthrough_entry`](MapCipher::passthrough_entry):
+    /// neither the value nor its key is encrypted or authenticated.
+    fn passthrough_entry_boxed<K>(
+        self,
+        key: K,
+        value: Box<dyn Any + Send + 'static>,
+    ) -> Result<Self, Self::Error>
+    where
+        K: Into<Cow<'static, str>>;
+
     /// Finalise the map and return the produced ciphertext container.
     ///
     /// Implementations must authenticate the map's AAD even when no encrypted

--- a/packages/aead/src/decipher/mod.rs
+++ b/packages/aead/src/decipher/mod.rs
@@ -287,3 +287,57 @@ pub trait MapAccess<'c> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_util::MockMapAccess;
+
+    /// `next_entry` is a default method over `next_key` + `next_value`, so
+    /// nothing but this pins it down: a homogeneous consumer such as
+    /// `HashMap`'s `Decrypt` impl reaches every entry through it, and a
+    /// version that reported the map exhausted would decode silently to an
+    /// empty map rather than failing.
+    #[test]
+    fn next_entry_default_yields_every_entry_then_none() {
+        let mut map = MockMapAccess::new([("first", "a"), ("second", "b")]);
+
+        assert_eq!(
+            MapAccess::<'static>::next_entry::<String>(&mut map),
+            Ok(Some(("first".to_string(), "a".to_string())))
+        );
+        assert_eq!(
+            MapAccess::<'static>::next_entry::<String>(&mut map),
+            Ok(Some(("second".to_string(), "b".to_string())))
+        );
+        assert_eq!(
+            MapAccess::<'static>::next_entry::<String>(&mut map),
+            Ok(None)
+        );
+    }
+
+    /// The default must not paper over the contract the split imposes:
+    /// `next_value` with no pending key is an error, and it propagates.
+    #[test]
+    fn next_value_without_a_key_is_an_error() {
+        let mut map = MockMapAccess::new([("first", "a")]);
+
+        assert_eq!(
+            MapAccess::<'static>::next_value::<String>(&mut map),
+            Err(Unspecified)
+        );
+    }
+
+    /// Skipping a value leaves its AAD binding unverified, so a second
+    /// `next_key` must fail rather than discard the pending entry.
+    #[test]
+    fn skipping_a_value_is_an_error() {
+        let mut map = MockMapAccess::new([("first", "a"), ("second", "b")]);
+
+        assert_eq!(
+            MapAccess::<'static>::next_key(&mut map),
+            Ok(Some("first".to_string()))
+        );
+        assert_eq!(MapAccess::<'static>::next_key(&mut map), Err(Unspecified));
+    }
+}

--- a/packages/aead/src/decipher/mod.rs
+++ b/packages/aead/src/decipher/mod.rs
@@ -1,10 +1,17 @@
-pub mod impls;
+//! Cipher-backend traits for the decrypt direction — the mirror of
+//! [`cipher`](crate::cipher).
+//!
+//! [`Decipher`] drives decryption the way [`Cipher`](crate::Cipher) drives
+//! encryption, with [`DecipherVisitor`], [`SeqAccess`] and [`MapAccess`] as
+//! its sub-protocols. The plaintext-side trait a type implements to decode
+//! *itself* lives in [`decrypt`](crate::decrypt), mirroring how
+//! [`Encrypt`](crate::Encrypt) sits opposite [`Cipher`](crate::Cipher).
 
 use std::any::Any;
 
 use vitaminc_protected::Protected;
 
-use crate::{Aad, IntoAad, Unspecified};
+use crate::{decrypt::Decrypt, IntoAad, Unspecified};
 
 /// A trait for types that can decrypt data, driving a [`DecipherVisitor`] to produce values.
 ///
@@ -247,26 +254,4 @@ pub trait MapAccess<'c> {
     /// encrypt time. An implementation that decrypts values against the bare map AAD leaves
     /// keys swappable in stored ciphertext (and will fail to decrypt conforming ciphertexts).
     fn next_entry<T: Decrypt<'c> + 'c>(&mut self) -> Result<Option<(String, T)>, Self::Error>;
-}
-
-/// The counterpart to `Encrypt` — a type that knows how to decrypt itself using a `Decipher`.
-/// Analogous to serde's `Deserialize`.
-pub trait Decrypt<'c>: Sized + Send {
-    /// Decrypt `Self` from the given decipher with no associated data.
-    ///
-    /// Convenience wrapper around [`decrypt_with_aad`](Decrypt::decrypt_with_aad), mirroring
-    /// [`Encrypt::encrypt`](crate::Encrypt::encrypt).
-    fn decrypt<D: Decipher<'c>>(decipher: D) -> D::Ok<Self> {
-        Self::decrypt_with_aad(decipher, Aad::empty())
-    }
-
-    /// Decrypt `Self` from the given decipher, authenticating against `aad`.
-    ///
-    /// This is the method implementations provide; it mirrors
-    /// [`Encrypt::encrypt_with_aad`](crate::Encrypt::encrypt_with_aad). The `aad` must match
-    /// the associated data bound at encrypt time or decryption fails.
-    fn decrypt_with_aad<'a, D, A>(decipher: D, aad: A) -> D::Ok<Self>
-    where
-        D: Decipher<'c>,
-        A: IntoAad<'a>;
 }

--- a/packages/aead/src/decipher/mod.rs
+++ b/packages/aead/src/decipher/mod.rs
@@ -274,6 +274,32 @@ pub trait MapAccess<'c> {
     /// implementations must return an error.
     fn next_value<T: Decrypt<'c> + 'c>(&mut self) -> Result<T, Self::Error>;
 
+    /// Take the value belonging to the key most recently returned by
+    /// [`next_key`](MapAccess::next_key) as a **passthrough** payload,
+    /// consuming the pending entry.
+    ///
+    /// The counterpart of
+    /// [`MapCipher::passthrough_entry_boxed`](crate::MapCipher::passthrough_entry_boxed),
+    /// and type-erased for the same reason: a decoder generic over every
+    /// decipher cannot name the payload type. The caller downcasts.
+    ///
+    /// Implementations must return an error when there is no pending key, and
+    /// when the pending entry is an *encrypted* value rather than a
+    /// passthrough — reading a sealed value through this method would hand back
+    /// a payload whose tag was never checked.
+    ///
+    /// # ⚠️ Unauthenticated data
+    ///
+    /// Unlike [`next_value`](MapAccess::next_value), nothing here is verified.
+    /// A passthrough entry carries no tag, and — unlike an encrypted entry's
+    /// key — its key is not bound into anything either, so a stored passthrough
+    /// entry can be edited, retargeted at another key, added, or removed with
+    /// no effect on whether the rest of the map decrypts. That independence is
+    /// the point: it is what lets a passthrough value be a plain database
+    /// column that other queries read and write on their own. Treat what comes
+    /// back as untrusted input, exactly as you would treat that column.
+    fn next_passthrough(&mut self) -> Result<Box<dyn Any + Send + 'static>, Self::Error>;
+
     /// Returns the next decrypted `(key, value)` entry, or `None` when the map is exhausted.
     ///
     /// Convenience for [`next_key`](MapAccess::next_key) followed by

--- a/packages/aead/src/decipher/mod.rs
+++ b/packages/aead/src/decipher/mod.rs
@@ -244,7 +244,23 @@ pub trait SeqAccess<'c> {
 pub trait MapAccess<'c> {
     /// The error type returned by [`next_entry`](MapAccess::next_entry).
     type Error;
-    /// Returns the next decrypted `(key, value)` entry, or `None` when the map is exhausted.
+    /// Advance to the next entry and return its key, leaving the value
+    /// undecrypted until [`next_value`](MapAccess::next_value) is called.
+    ///
+    /// The split exists because a map's values are not necessarily
+    /// homogeneous: a struct decoder cannot name the type to decrypt into
+    /// until it has seen which field the key names. Reading key-first also
+    /// makes the decode order-independent, which matters because the *order*
+    /// of entries in a stored ciphertext is not authenticated.
+    ///
+    /// Returns `None` when the map is exhausted. Calling `next_key` twice
+    /// without an intervening `next_value` is a contract violation:
+    /// implementations must return an error rather than silently discarding
+    /// the skipped value, since a discarded value is an unverified one.
+    fn next_key(&mut self) -> Result<Option<String>, Self::Error>;
+
+    /// Decrypt the value belonging to the key most recently returned by
+    /// [`next_key`](MapAccess::next_key), consuming the pending entry.
     ///
     /// As with [`SeqAccess::next_element`], implementations **must authenticate each value
     /// against the map's associated data** — and additionally against the entry's own key.
@@ -253,5 +269,21 @@ pub trait MapAccess<'c> {
     /// the binding [`MapCipher::encrypt_value`](crate::MapCipher::encrypt_value) performs at
     /// encrypt time. An implementation that decrypts values against the bare map AAD leaves
     /// keys swappable in stored ciphertext (and will fail to decrypt conforming ciphertexts).
-    fn next_entry<T: Decrypt<'c> + 'c>(&mut self) -> Result<Option<(String, T)>, Self::Error>;
+    ///
+    /// Calling this without a pending key is a contract violation;
+    /// implementations must return an error.
+    fn next_value<T: Decrypt<'c> + 'c>(&mut self) -> Result<T, Self::Error>;
+
+    /// Returns the next decrypted `(key, value)` entry, or `None` when the map is exhausted.
+    ///
+    /// Convenience for [`next_key`](MapAccess::next_key) followed by
+    /// [`next_value`](MapAccess::next_value) — the right entry point for a
+    /// homogeneous map (e.g. `HashMap<String, T>`), where the value type is
+    /// known before the key is read.
+    fn next_entry<T: Decrypt<'c> + 'c>(&mut self) -> Result<Option<(String, T)>, Self::Error> {
+        match self.next_key()? {
+            Some(key) => self.next_value::<T>().map(|value| Some((key, value))),
+            None => Ok(None),
+        }
+    }
 }

--- a/packages/aead/src/decipher/mod.rs
+++ b/packages/aead/src/decipher/mod.rs
@@ -257,6 +257,20 @@ pub trait MapAccess<'c> {
     /// without an intervening `next_value` is a contract violation:
     /// implementations must return an error rather than silently discarding
     /// the skipped value, since a discarded value is an unverified one.
+    ///
+    /// # ⚠️ The key is not yet authenticated
+    ///
+    /// A key is bound into the AAD its value is sealed against, so a swapped or
+    /// renamed key does not survive — but that binding is only *checked* when
+    /// [`next_value`](MapAccess::next_value) opens the value. The key this
+    /// method returns is the raw stored one, verified by nothing.
+    ///
+    /// It is therefore safe to use for what it is for: choosing which field to
+    /// decode next, since a wrong choice fails at `next_value`. It is not safe
+    /// to act on before then. A visitor that branches on the key and returns
+    /// early, selects a code path, or records the key somewhere without
+    /// reaching `next_value` has acted on attacker-modifiable input. Where a
+    /// decision must depend on the key, make it after the value opens.
     fn next_key(&mut self) -> Result<Option<String>, Self::Error>;
 
     /// Decrypt the value belonging to the key most recently returned by

--- a/packages/aead/src/decipher/mod.rs
+++ b/packages/aead/src/decipher/mod.rs
@@ -244,7 +244,12 @@ pub trait SeqAccess<'c> {
 /// Pull-style access to entries of a decrypted map.
 pub trait MapAccess<'c> {
     /// The error type returned by [`next_entry`](MapAccess::next_entry).
-    type Error;
+    ///
+    /// The [`From<Unspecified>`](crate::Unspecified) bound is what lets
+    /// [`next_passthrough`](MapAccess::next_passthrough) carry a default that
+    /// *refuses*: an implementation whose format has no passthrough
+    /// representation inherits the rejection rather than having to write one.
+    type Error: From<Unspecified>;
     /// Advance to the next entry and return its key, leaving the value
     /// undecrypted until [`next_value`](MapAccess::next_value) is called.
     ///
@@ -313,7 +318,19 @@ pub trait MapAccess<'c> {
     /// the point: it is what lets a passthrough value be a plain database
     /// column that other queries read and write on their own. Treat what comes
     /// back as untrusted input, exactly as you would treat that column.
-    fn next_passthrough(&mut self) -> Result<Box<dyn Any + Send + 'static>, Self::Error>;
+    ///
+    /// # Default
+    ///
+    /// Defaults to rejecting every call with [`Unspecified`]. A format with no
+    /// passthrough representation is not obliged to invent one — leaving the
+    /// default in place means a passthrough entry cannot be read from this map
+    /// at all, which is the safe reading of "unsupported". Override it only in
+    /// a decipher that actually stores passthrough entries, alongside the
+    /// encrypt-side [`MapCipher::passthrough_entry_boxed`](crate::MapCipher::passthrough_entry_boxed)
+    /// that writes them.
+    fn next_passthrough(&mut self) -> Result<Box<dyn Any + Send + 'static>, Self::Error> {
+        Err(Unspecified.into())
+    }
 
     /// Returns the next decrypted `(key, value)` entry, or `None` when the map is exhausted.
     ///
@@ -367,6 +384,22 @@ mod tests {
             MapAccess::<'static>::next_value::<String>(&mut map),
             Err(Unspecified)
         );
+    }
+
+    /// `next_passthrough` is defaulted so that a decipher whose format has no
+    /// passthrough representation need not write one — but the default must
+    /// *refuse*, not hand back something unverified. `MockMapAccess` stores
+    /// every entry encrypted and supplies no override, so this pins the
+    /// inherited body.
+    #[test]
+    fn next_passthrough_default_rejects() {
+        let mut map = MockMapAccess::new([("first", "a")]);
+
+        assert_eq!(
+            MapAccess::<'static>::next_key(&mut map),
+            Ok(Some("first".to_string()))
+        );
+        assert!(MapAccess::<'static>::next_passthrough(&mut map).is_err());
     }
 
     /// Skipping a value leaves its AAD binding unverified, so a second

--- a/packages/aead/src/decipher/mod.rs
+++ b/packages/aead/src/decipher/mod.rs
@@ -144,8 +144,9 @@ pub trait Decipher<'c>: Sized {
     /// for Rust-native ciphers, callers downcast to a concrete type themselves
     /// (concrete deciphers may offer a typed convenience for this).
     ///
-    /// See [`Cipher::passthrough`] — passthrough values are non-sensitive by
-    /// design and must not be used to carry secret data.
+    /// See [`Cipher::passthrough`](crate::Cipher::passthrough) — passthrough
+    /// values are non-sensitive by design and must not be used to carry
+    /// secret data.
     fn decrypt_passthrough(self) -> Self::Ok<Self::Passthrough>;
 
     /// Decrypt an `Option<T>`, authenticating against `aad`. The decipher inspects the

--- a/packages/aead/src/decrypt/impls.rs
+++ b/packages/aead/src/decrypt/impls.rs
@@ -1,5 +1,5 @@
-use super::{Decipher, DecipherVisitor, Decrypt, MapAccess, SeqAccess};
-use crate::{IntoAad, Unspecified};
+use super::Decrypt;
+use crate::{Decipher, DecipherVisitor, IntoAad, MapAccess, SeqAccess, Unspecified};
 use std::collections::HashMap;
 use vitaminc_protected::{Controlled, Equatable, Protected};
 use zeroize::Zeroize;

--- a/packages/aead/src/decrypt/mod.rs
+++ b/packages/aead/src/decrypt/mod.rs
@@ -1,0 +1,32 @@
+//! The decrypt-side counterpart to the [`encrypt`](crate::encrypt) module.
+//!
+//! [`Decrypt`] is to [`Decipher`](crate::Decipher) what
+//! [`Encrypt`](crate::Encrypt) is to [`Cipher`](crate::Cipher): the trait a
+//! plaintext type implements to describe how it decodes itself, kept separate
+//! from the traits a cipher backend implements to drive that decoding.
+
+pub mod impls;
+
+use crate::{Aad, Decipher, IntoAad};
+
+/// The counterpart to `Encrypt` — a type that knows how to decrypt itself using a `Decipher`.
+/// Analogous to serde's `Deserialize`.
+pub trait Decrypt<'c>: Sized + Send {
+    /// Decrypt `Self` from the given decipher with no associated data.
+    ///
+    /// Convenience wrapper around [`decrypt_with_aad`](Decrypt::decrypt_with_aad), mirroring
+    /// [`Encrypt::encrypt`](crate::Encrypt::encrypt).
+    fn decrypt<D: Decipher<'c>>(decipher: D) -> D::Ok<Self> {
+        Self::decrypt_with_aad(decipher, Aad::empty())
+    }
+
+    /// Decrypt `Self` from the given decipher, authenticating against `aad`.
+    ///
+    /// This is the method implementations provide; it mirrors
+    /// [`Encrypt::encrypt_with_aad`](crate::Encrypt::encrypt_with_aad). The `aad` must match
+    /// the associated data bound at encrypt time or decryption fails.
+    fn decrypt_with_aad<'a, D, A>(decipher: D, aad: A) -> D::Ok<Self>
+    where
+        D: Decipher<'c>,
+        A: IntoAad<'a>;
+}

--- a/packages/aead/src/element.rs
+++ b/packages/aead/src/element.rs
@@ -54,12 +54,7 @@
 //! let ct = Element(row3).encrypt_with_aad(&cipher, Aad::from_slice(b"users"))?;
 //! ```
 
-use crate::{
-    cipher::Cipher,
-    decipher::{Decipher, Decrypt},
-    encrypt::Encrypt,
-    IntoAad,
-};
+use crate::{cipher::Cipher, decipher::Decipher, decrypt::Decrypt, encrypt::Encrypt, IntoAad};
 
 /// A value encrypted and decrypted as a sequence element, independent of the
 /// sequence — see the [module docs](self) for when and why.

--- a/packages/aead/src/element.rs
+++ b/packages/aead/src/element.rs
@@ -1,67 +1,68 @@
-//! [`Element`], a wrapper that encrypts and decrypts a value *as a sequence
-//! element* — one row of a logical collection — without the collection being
-//! present in the call.
+//! [`Element`] and its `Encrypt`/`Decrypt` impls.
 //!
-//! # Why
-//!
-//! Sequence elements are sealed against
-//! [`Aad::for_sequence_element`](crate::Aad::for_sequence_element) of the
-//! caller's AAD, not the bare AAD, so the container shape is authenticated
-//! (a `Single` cannot be rewrapped as a one-element `Sequence`, nor an
-//! element re-homed to top level). The consequence for database-shaped
-//! workloads is that a row batch-encrypted as part of a `Vec` cannot later
-//! be decrypted alone under the bare AAD — the derivation would not match.
-//!
-//! `Element` moves that derivation into the type system. A row is *always*
-//! an element of its table's collection; how many rows a call touches is
-//! incidental. Wrapping the row in `Element` states that fact once, on both
-//! sides:
-//!
-//! - **Decrypt**: a single row fetched from storage decrypts with the same
-//!   caller AAD used for the whole collection — `Element<Row>` derives the
-//!   element AAD internally.
-//! - **Encrypt**: a row inserted alone is sealed exactly as batch encryption
-//!   of a `Vec` would have sealed it, so single-row inserts and whole-`Vec`
-//!   reads interchange freely.
-//!
-//! Retrieval *multiplicity* between "fetched alone" and "one element of a
-//! `Vec` read" is deliberately not authenticated, matching the existing
-//! stance on element order (see
-//! [`Aad::for_sequence_element`](crate::Aad::for_sequence_element)): both are
-//! caller obligations, not authenticated facts.
-//!
-//! # ⚠️ Wrap the row, not the collection
-//!
-//! `Vec<Element<T>>` compiles, round-trips symmetrically, and is almost never
-//! what you want: it seals under a *double* element derivation
-//! (`for_sequence_element(for_sequence_element(aad))`), so its ciphertexts do
-//! not interchange with `Vec<T>`'s. The mistake fails closed — decryption
-//! across the two shapes fails authentication, it never decrypts wrongly —
-//! but the intended usage is `Vec<T>` for batches and `Element<T>` for a
-//! lone row.
-//!
-//! # Example
-//!
-//! ```ignore
-//! // Batch write: rows sealed as sequence elements.
-//! let ct = vec![row1, row2].encrypt_with_aad(&cipher, Aad::from_slice(b"users"))?;
-//!
-//! // Single-row read: same caller AAD, Element derives the rest.
-//! let row: Element<HashMap<String, String>> =
-//!     cipher.decrypt_with_aad(row_ct, Aad::from_slice(b"users"))?;
-//!
-//! // Single-row write: interchangeable with the batch above.
-//! let ct = Element(row3).encrypt_with_aad(&cipher, Aad::from_slice(b"users"))?;
-//! ```
+//! The module is private — `Element` is re-exported from the crate root —
+//! so the type's own documentation carries the narrative.
 
 use crate::{cipher::Cipher, decipher::Decipher, decrypt::Decrypt, encrypt::Encrypt, IntoAad};
 
-/// A value encrypted and decrypted as a sequence element, independent of the
-/// sequence — see the [module docs](self) for when and why.
+/// A value encrypted and decrypted *as a sequence element* — one row of a
+/// logical collection — without the collection being present in the call.
 ///
 /// The wrapper adds nothing to the ciphertext: `Element(x)` produces bytes
 /// identical to what `x` would have produced as an element of an encrypted
 /// `Vec` under the same caller AAD.
+///
+/// # Why
+///
+/// Sequence elements are sealed against
+/// [`Aad::for_sequence_element`](crate::Aad::for_sequence_element) of the
+/// caller's AAD, not the bare AAD, so the container shape is authenticated
+/// (a `Single` cannot be rewrapped as a one-element `Sequence`, nor an
+/// element re-homed to top level). The consequence for database-shaped
+/// workloads is that a row batch-encrypted as part of a `Vec` cannot later
+/// be decrypted alone under the bare AAD — the derivation would not match.
+///
+/// `Element` moves that derivation into the type system. A row is *always*
+/// an element of its table's collection; how many rows a call touches is
+/// incidental. Wrapping the row in `Element` states that fact once, on both
+/// sides:
+///
+/// - **Decrypt**: a single row fetched from storage decrypts with the same
+///   caller AAD used for the whole collection — `Element<Row>` derives the
+///   element AAD internally.
+/// - **Encrypt**: a row inserted alone is sealed exactly as batch encryption
+///   of a `Vec` would have sealed it, so single-row inserts and whole-`Vec`
+///   reads interchange freely.
+///
+/// Retrieval *multiplicity* between "fetched alone" and "one element of a
+/// `Vec` read" is deliberately not authenticated, matching the existing
+/// stance on element order (see
+/// [`Aad::for_sequence_element`](crate::Aad::for_sequence_element)): both are
+/// caller obligations, not authenticated facts.
+///
+/// # ⚠️ Wrap the row, not the collection
+///
+/// `Vec<Element<T>>` compiles, round-trips symmetrically, and is almost never
+/// what you want: it seals under a *double* element derivation
+/// (`for_sequence_element(for_sequence_element(aad))`), so its ciphertexts do
+/// not interchange with `Vec<T>`'s. The mistake fails closed — decryption
+/// across the two shapes fails authentication, it never decrypts wrongly —
+/// but the intended usage is `Vec<T>` for batches and `Element<T>` for a
+/// lone row.
+///
+/// # Example
+///
+/// ```ignore
+/// // Batch write: rows sealed as sequence elements.
+/// let ct = vec![row1, row2].encrypt_with_aad(&cipher, Aad::from_slice(b"users"))?;
+///
+/// // Single-row read: same caller AAD, Element derives the rest.
+/// let row: Element<HashMap<String, String>> =
+///     cipher.decrypt_with_aad(row_ct, Aad::from_slice(b"users"))?;
+///
+/// // Single-row write: interchangeable with the batch above.
+/// let ct = Element(row3).encrypt_with_aad(&cipher, Aad::from_slice(b"users"))?;
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Element<T>(pub T);
 

--- a/packages/aead/src/hlist/mod.rs
+++ b/packages/aead/src/hlist/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! # Why a second design?
 //!
-//! The default [`Cipher`](crate::Cipher) / [`AesCipherText`] path uses a
+//! The default [`Cipher`](crate::Cipher) / `AesCipherText` path uses a
 //! recursive enum, with a `Vec` per nested container and a
 //! `Box<dyn Any + Send>` for passthrough values. This is the right trade-off
 //! for wasm32 / JS bindings (dynamic shapes, smaller monomorphisation

--- a/packages/aead/src/lib.rs
+++ b/packages/aead/src/lib.rs
@@ -35,3 +35,7 @@ pub use element::Element;
 pub use encrypt::Encrypt;
 #[doc(inline)]
 pub use nonce::{Nonce, NonceGenerator, RandomNonceGenerator};
+/// Derive macros for [`Encrypt`] and [`Decrypt`]. See the
+/// [`vitaminc_aead_derive`] crate docs for the wire shape they produce and the
+/// `#[aead(...)]` attributes they accept.
+pub use vitaminc_aead_derive::{Decrypt, Encrypt};

--- a/packages/aead/src/lib.rs
+++ b/packages/aead/src/lib.rs
@@ -6,6 +6,7 @@ mod ciphertext;
 mod container;
 mod context;
 mod decipher;
+mod decrypt;
 mod element;
 mod encrypt;
 #[cfg(feature = "hlist")]
@@ -25,7 +26,9 @@ pub use container::CipherText;
 #[doc(inline)]
 pub use context::ContextTag;
 #[doc(inline)]
-pub use decipher::{Decipher, DecipherVisitor, Decrypt, MapAccess, SeqAccess};
+pub use decipher::{Decipher, DecipherVisitor, MapAccess, SeqAccess};
+#[doc(inline)]
+pub use decrypt::Decrypt;
 #[doc(inline)]
 pub use element::Element;
 #[doc(inline)]

--- a/packages/aead/src/lib.rs
+++ b/packages/aead/src/lib.rs
@@ -35,7 +35,8 @@ pub use element::Element;
 pub use encrypt::Encrypt;
 #[doc(inline)]
 pub use nonce::{Nonce, NonceGenerator, RandomNonceGenerator};
-/// Derive macros for [`Encrypt`] and [`Decrypt`]. See the
-/// [`vitaminc_aead_derive`] crate docs for the wire shape they produce and the
-/// `#[aead(...)]` attributes they accept.
+// Inlined rather than linked, so the macros' own documentation — the
+// `#[aead(...)]` reference in particular — renders here instead of sending the
+// reader to another crate. There is still only one copy of that text.
+#[doc(inline)]
 pub use vitaminc_aead_derive::{Decrypt, Encrypt};

--- a/packages/aead/src/test_util.rs
+++ b/packages/aead/src/test_util.rs
@@ -294,10 +294,4 @@ impl<'c> MapAccess<'c> for MockMapAccess {
         let decipher = MockDecipher::new(payload);
         T::decrypt_with_aad(&decipher, crate::Aad::empty())
     }
-
-    /// The mock stores every entry as an encrypted payload, so there is no
-    /// passthrough for it to hand back.
-    fn next_passthrough(&mut self) -> Result<Box<dyn std::any::Any + Send + 'static>, Self::Error> {
-        Err(Unspecified)
-    }
 }

--- a/packages/aead/src/test_util.rs
+++ b/packages/aead/src/test_util.rs
@@ -137,6 +137,17 @@ impl MapCipher for UnusedMap {
         Ok(self)
     }
 
+    fn passthrough_entry_boxed<K>(
+        self,
+        _key: K,
+        _value: Box<dyn std::any::Any + Send + 'static>,
+    ) -> Result<Self, Self::Error>
+    where
+        K: Into<std::borrow::Cow<'static, str>>,
+    {
+        Ok(self)
+    }
+
     fn end(self) -> Result<Self::Ok, Self::Error> {
         Ok(Vec::new())
     }
@@ -282,5 +293,11 @@ impl<'c> MapAccess<'c> for MockMapAccess {
         let payload = self.pending.take().ok_or(Unspecified)?;
         let decipher = MockDecipher::new(payload);
         T::decrypt_with_aad(&decipher, crate::Aad::empty())
+    }
+
+    /// The mock stores every entry as an encrypted payload, so there is no
+    /// passthrough for it to hand back.
+    fn next_passthrough(&mut self) -> Result<Box<dyn std::any::Any + Send + 'static>, Self::Error> {
+        Err(Unspecified)
     }
 }

--- a/packages/aead/src/test_util.rs
+++ b/packages/aead/src/test_util.rs
@@ -9,7 +9,7 @@ use vitaminc_protected::{Controlled, Protected};
 
 use crate::{
     cipher::{Cipher, MapCipher, SeqCipher},
-    decipher::{Decipher, DecipherVisitor},
+    decipher::{Decipher, DecipherVisitor, MapAccess},
     Encrypt, IntoAad, Unspecified,
 };
 
@@ -228,5 +228,59 @@ impl<'c> Decipher<'c> for &MockDecipher {
     {
         *self.captured_aad.borrow_mut() = aad.into_aad().as_bytes().to_vec();
         Err(Unspecified)
+    }
+}
+
+/// A minimal [`MapAccess`] over an in-memory list of `(key, payload)` pairs.
+///
+/// Enough to drive the trait's own default method — [`MapAccess::next_entry`],
+/// which is defined in terms of [`MapAccess::next_key`] and
+/// [`MapAccess::next_value`] — without a real cipher. Each value is handed to
+/// a fresh [`MockDecipher`], so any byte-leaf `Decrypt` type works as the
+/// value type.
+pub(crate) struct MockMapAccess {
+    entries: std::vec::IntoIter<(String, Vec<u8>)>,
+    /// Mirrors the contract a real implementation must uphold: a key handed
+    /// out by `next_key` stays pending until `next_value` consumes it.
+    pending: Option<Vec<u8>>,
+}
+
+impl MockMapAccess {
+    pub(crate) fn new<K, V>(entries: impl IntoIterator<Item = (K, V)>) -> Self
+    where
+        K: Into<String>,
+        V: Into<Vec<u8>>,
+    {
+        MockMapAccess {
+            entries: entries
+                .into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect::<Vec<_>>()
+                .into_iter(),
+            pending: None,
+        }
+    }
+}
+
+impl<'c> MapAccess<'c> for MockMapAccess {
+    type Error = Unspecified;
+
+    fn next_key(&mut self) -> Result<Option<String>, Self::Error> {
+        if self.pending.is_some() {
+            return Err(Unspecified);
+        }
+        match self.entries.next() {
+            Some((key, payload)) => {
+                self.pending = Some(payload);
+                Ok(Some(key))
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn next_value<T: crate::Decrypt<'c> + 'c>(&mut self) -> Result<T, Self::Error> {
+        let payload = self.pending.take().ok_or(Unspecified)?;
+        let decipher = MockDecipher::new(payload);
+        T::decrypt_with_aad(&decipher, crate::Aad::empty())
     }
 }

--- a/packages/aead/tests/derive_ui.rs
+++ b/packages/aead/tests/derive_ui.rs
@@ -1,0 +1,22 @@
+//! Compile-fail tests for the guards in `#[derive(Encrypt)]` /
+//! `#[derive(Decrypt)]`.
+//!
+//! The derive crate's own unit tests assert that `Shape::parse` returns an
+//! error. What they cannot check is the part a developer actually meets: that
+//! the derive fails to compile at all, and that the diagnostic points at the
+//! offending struct and explains itself. For guards that exist to stop an
+//! unsound ciphertext being produced — an enum with no authenticated
+//! discriminator, a struct that would seal no tag — that message *is* the
+//! feature, so it is pinned here.
+//!
+//! Regenerate the expected output with `TRYBUILD=overwrite cargo test -p
+//! vitaminc-aead --test derive_ui` after an intentional change.
+
+// `trybuild` launches rustc and inspects the filesystem, neither of which can
+// run inside Miri's isolated interpreter — mirroring `vitaminc-protected`.
+#[cfg(not(miri))]
+#[test]
+fn derive_ui() {
+    let tests = trybuild::TestCases::new();
+    tests.compile_fail("tests/ui/derive/*.rs");
+}

--- a/packages/aead/tests/ui/derive/all_fields_passthrough.rs
+++ b/packages/aead/tests/ui/derive/all_fields_passthrough.rs
@@ -1,0 +1,14 @@
+// Nothing would be encrypted, so the container would carry no tag at all:
+// neither the associated data nor the entry keys would be authenticated.
+// `MapCipher::end` refuses to seal one, so the derive refuses to emit it.
+use vitaminc_aead::{Decrypt, Encrypt};
+
+#[derive(Encrypt, Decrypt)]
+struct Row {
+    #[aead(passthrough)]
+    id: i64,
+    #[aead(passthrough)]
+    tenant: String,
+}
+
+fn main() {}

--- a/packages/aead/tests/ui/derive/all_fields_passthrough.stderr
+++ b/packages/aead/tests/ui/derive/all_fields_passthrough.stderr
@@ -1,0 +1,5 @@
+error: every field is `#[aead(passthrough)]`, so nothing would be encrypted and the ciphertext would carry no tag — neither the associated data nor the entry keys would be authenticated. Encrypt at least one field, or do not derive Encrypt for this struct at all.
+ --> tests/ui/derive/all_fields_passthrough.rs:7:8
+  |
+7 | struct Row {
+  |        ^^^

--- a/packages/aead/tests/ui/derive/duplicate_map_key.rs
+++ b/packages/aead/tests/ui/derive/duplicate_map_key.rs
@@ -1,0 +1,13 @@
+// Two fields under one key would overwrite each other on encrypt and be
+// rejected as a duplicate on decrypt — an unreadable ciphertext with no error
+// until read time.
+use vitaminc_aead::{Decrypt, Encrypt};
+
+#[derive(Encrypt, Decrypt)]
+struct Clash {
+    a: String,
+    #[aead(rename = "a")]
+    b: String,
+}
+
+fn main() {}

--- a/packages/aead/tests/ui/derive/duplicate_map_key.stderr
+++ b/packages/aead/tests/ui/derive/duplicate_map_key.stderr
@@ -1,0 +1,5 @@
+error: duplicate map key `a`: two fields would be encrypted under the same key
+ --> tests/ui/derive/duplicate_map_key.rs:7:8
+  |
+7 | struct Clash {
+  |        ^^^^^

--- a/packages/aead/tests/ui/derive/enum_is_rejected.rs
+++ b/packages/aead/tests/ui/derive/enum_is_rejected.rs
@@ -1,0 +1,11 @@
+// A ciphertext carries no authenticated variant discriminator, so any encoding
+// the macro could pick would leak the variant or leave it forgeable.
+use vitaminc_aead::{Decrypt, Encrypt};
+
+#[derive(Encrypt, Decrypt)]
+enum Choice {
+    A(String),
+    B(u32),
+}
+
+fn main() {}

--- a/packages/aead/tests/ui/derive/enum_is_rejected.stderr
+++ b/packages/aead/tests/ui/derive/enum_is_rejected.stderr
@@ -1,0 +1,5 @@
+error: Encrypt/Decrypt cannot be derived for enums: a ciphertext carries no authenticated variant discriminator, so the variant would have to travel in the clear or be forgeable. Model the choice explicitly instead, e.g. as a struct of `Option` fields.
+ --> tests/ui/derive/enum_is_rejected.rs:6:6
+  |
+6 | enum Choice {
+  |      ^^^^^^

--- a/packages/aead/tests/ui/derive/passthrough_on_newtype.rs
+++ b/packages/aead/tests/ui/derive/passthrough_on_newtype.rs
@@ -1,0 +1,8 @@
+// A newtype is transparent — no map is opened — so there is no entry for a
+// passthrough to occupy. Honouring it would leave the whole value unencrypted.
+use vitaminc_aead::{Decrypt, Encrypt};
+
+#[derive(Encrypt, Decrypt)]
+struct Token(#[aead(passthrough)] String);
+
+fn main() {}

--- a/packages/aead/tests/ui/derive/passthrough_on_newtype.stderr
+++ b/packages/aead/tests/ui/derive/passthrough_on_newtype.stderr
@@ -1,0 +1,5 @@
+error: `#[aead(passthrough)]` is meaningless on a newtype struct: a newtype is transparent, so there is no map entry to store in the clear and nothing would be encrypted at all. Give the struct a named field instead.
+ --> tests/ui/derive/passthrough_on_newtype.rs:6:8
+  |
+6 | struct Token(#[aead(passthrough)] String);
+  |        ^^^^^

--- a/packages/aead/tests/ui/derive/rename_on_newtype.rs
+++ b/packages/aead/tests/ui/derive/rename_on_newtype.rs
@@ -1,0 +1,9 @@
+// A newtype's value is not stored under a map key, so there is no key to
+// rename. Ignoring the attribute would leave the author believing the value is
+// key-bound when nothing binds it.
+use vitaminc_aead::{Decrypt, Encrypt};
+
+#[derive(Encrypt, Decrypt)]
+struct Token(#[aead(rename = "token")] String);
+
+fn main() {}

--- a/packages/aead/tests/ui/derive/rename_on_newtype.stderr
+++ b/packages/aead/tests/ui/derive/rename_on_newtype.stderr
@@ -1,0 +1,5 @@
+error: `#[aead(rename = "...")]` has no effect on a newtype struct: a newtype is transparent, so its value is not stored under a map key at all and there is no key to rename. Give the struct a named field instead.
+ --> tests/ui/derive/rename_on_newtype.rs:7:8
+  |
+7 | struct Token(#[aead(rename = "token")] String);
+  |        ^^^^^

--- a/packages/aead/tests/ui/derive/unknown_field_attribute.rs
+++ b/packages/aead/tests/ui/derive/unknown_field_attribute.rs
@@ -1,0 +1,12 @@
+// A misspelt attribute is rejected rather than ignored: a silently dropped
+// option is one the author believes is in effect.
+use vitaminc_aead::{Decrypt, Encrypt};
+
+#[derive(Encrypt, Decrypt)]
+struct Row {
+    #[aead(passthru)]
+    tenant: String,
+    ssn: String,
+}
+
+fn main() {}

--- a/packages/aead/tests/ui/derive/unknown_field_attribute.stderr
+++ b/packages/aead/tests/ui/derive/unknown_field_attribute.stderr
@@ -1,0 +1,5 @@
+error: unsupported field attribute; expected `rename = "..."` or `passthrough`
+ --> tests/ui/derive/unknown_field_attribute.rs:7:12
+  |
+7 |     #[aead(passthru)]
+  |            ^^^^^^^^

--- a/packages/encrypt/src/cipher.rs
+++ b/packages/encrypt/src/cipher.rs
@@ -386,6 +386,20 @@ impl<'c> MapCipher for AesMapCipher<'c> {
         Ok(self)
     }
 
+    fn passthrough_entry_boxed<K>(
+        self,
+        key: K,
+        value: Box<dyn Any + Send + 'static>,
+    ) -> Result<Self, Self::Error>
+    where
+        K: Into<Cow<'static, str>>,
+    {
+        // This cipher's passthrough type *is* `Box<dyn Any + Send>` (see
+        // `BoxedPassthrough`), so the type-erased box is already the payload —
+        // store it directly, exactly as `passthrough_boxed` does.
+        self.passthrough_entry(key, value)
+    }
+
     fn end(self) -> Result<Self::Ok, Self::Error> {
         // Finalising with a pending key would silently drop the entry.
         if self.current_key.is_some() {
@@ -759,6 +773,18 @@ impl<'c> MapAccess<'c> for AesMapAccess<'c, '_> {
         // PAE(domain, aad, key), so a swapped or renamed key fails here.
         let entry_aad = self.aad.for_map_entry(&key);
         T::decrypt_with_aad(decipher, entry_aad)
+    }
+
+    fn next_passthrough(&mut self) -> Result<Box<dyn Any + Send + 'static>, Self::Error> {
+        let (_key, ct) = self.pending.take().ok_or(Unspecified)?;
+        match ct {
+            AesCipherText::Passthrough(value) => Ok(value),
+            // Refuse to hand back a sealed value with its tag unchecked. The
+            // caller asked for a passthrough; a stored ciphertext that supplies
+            // an encrypted node under that key is not one, and quietly
+            // unwrapping it would skip the verification `next_value` performs.
+            _ => Err(Unspecified),
+        }
     }
 }
 

--- a/packages/encrypt/src/cipher.rs
+++ b/packages/encrypt/src/cipher.rs
@@ -596,6 +596,7 @@ impl<'c> Decipher<'c> for AesDecipher<'c> {
                     cipher: self.cipher,
                     entries: entries.into_iter(),
                     aad: aad.into_aad(),
+                    pending: None,
                 };
                 visitor.visit_map(map_access)
             }
@@ -607,6 +608,7 @@ impl<'c> Decipher<'c> for AesDecipher<'c> {
                     cipher: self.cipher,
                     entries: Vec::new().into_iter(),
                     aad,
+                    pending: None,
                 };
                 visitor.visit_map(map_access)
             }
@@ -722,22 +724,41 @@ struct AesMapAccess<'c, 'a> {
     cipher: &'c Aes256Cipher,
     entries: std::vec::IntoIter<(String, AesCipherText)>,
     aad: Aad<'a>,
+    /// The entry handed out by `next_key` and not yet consumed by
+    /// `next_value`. Holding the ciphertext here (rather than decrypting it
+    /// up front) is what lets the caller choose the plaintext type *after*
+    /// seeing the key — see [`MapAccess::next_key`].
+    pending: Option<(String, AesCipherText)>,
 }
 
-impl<'c, 'a> MapAccess<'c> for AesMapAccess<'c, 'a> {
+impl<'c> MapAccess<'c> for AesMapAccess<'c, '_> {
     type Error = Unspecified;
 
-    fn next_entry<T: Decrypt<'c> + 'c>(&mut self) -> Result<Option<(String, T)>, Self::Error> {
-        let (key, ct) = match self.entries.next() {
-            Some(entry) => entry,
-            None => return Ok(None),
-        };
+    fn next_key(&mut self) -> Result<Option<String>, Self::Error> {
+        // A still-pending entry means the caller skipped a value. Skipping is
+        // refused rather than tolerated: an entry whose value is never
+        // decrypted is an entry whose AAD binding is never verified, so a
+        // lenient decoder here would silently accept a tampered field it
+        // chose not to look at.
+        if self.pending.is_some() {
+            return Err(Unspecified);
+        }
+        match self.entries.next() {
+            Some((key, ct)) => {
+                self.pending = Some((key.clone(), ct));
+                Ok(Some(key))
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn next_value<T: Decrypt<'c> + 'c>(&mut self) -> Result<T, Self::Error> {
+        let (key, ct) = self.pending.take().ok_or(Unspecified)?;
         let decipher = self.cipher.decipher(ct);
         // Mirror `AesMapCipher::encrypt_value`: the value was sealed against
         // PAE(domain, aad, key), so a swapped or renamed key fails here.
         let entry_aad = self.aad.for_map_entry(&key);
-        let value = T::decrypt_with_aad(decipher, entry_aad)?;
-        Ok(Some((key, value)))
+        T::decrypt_with_aad(decipher, entry_aad)
     }
 }
 

--- a/packages/encrypt/src/lib.rs
+++ b/packages/encrypt/src/lib.rs
@@ -10,7 +10,13 @@ pub use cipher::{Aes256Cipher, AesCipherText, AesDecipher, BoxedPassthrough};
 pub use key::Key;
 
 // Re-exports
-pub use vitaminc_aead::{Aad, Cipher, Encrypt, IntoAad, LocalCipherText, Nonce, Unspecified};
+pub use vitaminc_aead::{Aad, Cipher, IntoAad, LocalCipherText, Nonce, Unspecified};
+// The `Encrypt`/`Decrypt` names each cover a trait and a derive macro, so one
+// re-export carries both. Inlined so the derives' `#[aead(...)]` reference
+// renders here too — a caller who depends only on this crate should not have to
+// go looking for it.
+#[doc(inline)]
+pub use vitaminc_aead::{Decrypt, Encrypt};
 
 /// Encrypt the given plaintext using the provided key.
 /// Any type that implements the [`Encrypt`] trait can be used.

--- a/packages/encrypt/tests/derive.rs
+++ b/packages/encrypt/tests/derive.rs
@@ -1,0 +1,298 @@
+//! End-to-end tests for `#[derive(Encrypt)]` / `#[derive(Decrypt)]` against the
+//! real AES-256-GCM cipher.
+//!
+//! The derive macros only generate calls into the `Cipher`/`Decipher` protocol,
+//! so what needs proving here is the wire contract they commit to: a derived
+//! struct is a map keyed by field name, its ciphertext is interchangeable with
+//! the equivalent `HashMap`, its fields are individually key-bound, and its
+//! decode is strict about missing, unknown, and duplicate keys.
+
+use std::collections::HashMap;
+
+use vitaminc_aead::{Decrypt, Encrypt};
+use vitaminc_encrypt::{Aes256Cipher, Key};
+
+fn cipher() -> Aes256Cipher {
+    Aes256Cipher::new(&Key::from([42u8; 32])).expect("failed to create cipher")
+}
+
+#[derive(Encrypt, Decrypt, Debug, PartialEq)]
+struct User {
+    name: String,
+    age: u32,
+}
+
+#[derive(Encrypt, Decrypt, Debug, PartialEq)]
+struct Renamed {
+    #[aead(rename = "n")]
+    name: String,
+}
+
+#[derive(Encrypt, Decrypt, Debug, PartialEq)]
+struct Newtype(String);
+
+#[derive(Encrypt, Decrypt, Debug, PartialEq)]
+struct Pair(String, u32);
+
+#[derive(Encrypt, Decrypt, Debug, PartialEq)]
+struct Unit;
+
+#[derive(Encrypt, Decrypt, Debug, PartialEq)]
+struct Nested {
+    user: User,
+    tags: Vec<String>,
+    note: Option<String>,
+}
+
+#[derive(Encrypt, Decrypt, Debug, PartialEq)]
+struct Generic<T> {
+    value: T,
+    label: String,
+}
+
+#[test]
+fn roundtrip_named_struct() {
+    let cipher = cipher();
+    let plaintext = User {
+        name: "alice".to_string(),
+        age: 42,
+    };
+
+    let ciphertext = User {
+        name: "alice".to_string(),
+        age: 42,
+    }
+    .encrypt(&cipher)
+    .expect("encryption failed");
+
+    let decrypted: User = cipher.decrypt(ciphertext).expect("decryption failed");
+    assert_eq!(decrypted, plaintext);
+}
+
+#[test]
+fn roundtrip_newtype_is_transparent() {
+    let cipher = cipher();
+
+    // A newtype adds nothing to the ciphertext, so a `Newtype` ciphertext
+    // decrypts as its inner `String` and vice versa. This is the property that
+    // makes wrapping an existing type a non-breaking change.
+    let ciphertext = Newtype("hello".to_string())
+        .encrypt(&cipher)
+        .expect("encryption failed");
+    let as_inner: String = cipher.decrypt(ciphertext).expect("decryption failed");
+    assert_eq!(as_inner, "hello");
+
+    let ciphertext = "hello".encrypt(&cipher).expect("encryption failed");
+    let as_newtype: Newtype = cipher.decrypt(ciphertext).expect("decryption failed");
+    assert_eq!(as_newtype, Newtype("hello".to_string()));
+}
+
+#[test]
+fn roundtrip_tuple_struct() {
+    let cipher = cipher();
+    let ciphertext = Pair("alice".to_string(), 42)
+        .encrypt(&cipher)
+        .expect("encryption failed");
+    let decrypted: Pair = cipher.decrypt(ciphertext).expect("decryption failed");
+    assert_eq!(decrypted, Pair("alice".to_string(), 42));
+}
+
+#[test]
+fn roundtrip_unit_struct() {
+    let cipher = cipher();
+    let ciphertext = Unit.encrypt(&cipher).expect("encryption failed");
+    let decrypted: Unit = cipher.decrypt(ciphertext).expect("decryption failed");
+    assert_eq!(decrypted, Unit);
+}
+
+#[test]
+fn roundtrip_nested_struct() {
+    let cipher = cipher();
+    let plaintext = Nested {
+        user: User {
+            name: "alice".to_string(),
+            age: 42,
+        },
+        tags: vec!["a".to_string(), "b".to_string()],
+        note: None,
+    };
+    let ciphertext = Nested {
+        user: User {
+            name: "alice".to_string(),
+            age: 42,
+        },
+        tags: vec!["a".to_string(), "b".to_string()],
+        note: None,
+    }
+    .encrypt(&cipher)
+    .expect("encryption failed");
+
+    let decrypted: Nested = cipher.decrypt(ciphertext).expect("decryption failed");
+    assert_eq!(decrypted, plaintext);
+}
+
+#[test]
+fn roundtrip_generic_struct() {
+    let cipher = cipher();
+    let ciphertext = Generic {
+        value: 7u32,
+        label: "seven".to_string(),
+    }
+    .encrypt(&cipher)
+    .expect("encryption failed");
+
+    let decrypted: Generic<u32> = cipher.decrypt(ciphertext).expect("decryption failed");
+    assert_eq!(
+        decrypted,
+        Generic {
+            value: 7u32,
+            label: "seven".to_string(),
+        }
+    );
+}
+
+#[test]
+fn derived_struct_is_wire_compatible_with_hashmap() {
+    let cipher = cipher();
+
+    // Same keys, same per-entry AAD binding: a derived struct's ciphertext is
+    // exactly the map its fields describe. Downstream storage that treats
+    // records as maps therefore needs no separate encoding for derived types.
+    let mut map: HashMap<String, String> = HashMap::new();
+    map.insert("name".to_string(), "alice".to_string());
+    let ciphertext = map.encrypt(&cipher).expect("encryption failed");
+
+    let decrypted: OneField = cipher.decrypt(ciphertext).expect("decryption failed");
+    assert_eq!(decrypted.name, "alice");
+
+    let ciphertext = OneField {
+        name: "alice".to_string(),
+    }
+    .encrypt(&cipher)
+    .expect("encryption failed");
+    let back: HashMap<String, String> = cipher.decrypt(ciphertext).expect("decryption failed");
+    assert_eq!(back.get("name").map(String::as_str), Some("alice"));
+}
+
+#[derive(Encrypt, Decrypt, Debug, PartialEq)]
+struct OneField {
+    name: String,
+}
+
+#[test]
+fn rename_changes_the_wire_key() {
+    let cipher = cipher();
+
+    let ciphertext = Renamed {
+        name: "alice".to_string(),
+    }
+    .encrypt(&cipher)
+    .expect("encryption failed");
+
+    // Stored under "n", not "name" — so the un-renamed struct cannot read it.
+    let back: HashMap<String, String> = cipher.decrypt(ciphertext).expect("decryption failed");
+    assert_eq!(back.get("n").map(String::as_str), Some("alice"));
+
+    let ciphertext = Renamed {
+        name: "alice".to_string(),
+    }
+    .encrypt(&cipher)
+    .expect("encryption failed");
+    assert!(cipher.decrypt::<OneField>(ciphertext).is_err());
+}
+
+#[test]
+fn missing_field_is_rejected() {
+    let cipher = cipher();
+
+    // `User` needs both `name` and `age`; a map carrying only one is refused
+    // rather than defaulted, because an absent entry is an unverified one.
+    let mut map: HashMap<String, String> = HashMap::new();
+    map.insert("name".to_string(), "alice".to_string());
+    let ciphertext = map.encrypt(&cipher).expect("encryption failed");
+
+    assert!(cipher.decrypt::<User>(ciphertext).is_err());
+}
+
+#[test]
+fn unknown_field_is_rejected() {
+    let cipher = cipher();
+
+    let mut map: HashMap<String, String> = HashMap::new();
+    map.insert("name".to_string(), "alice".to_string());
+    map.insert("nickname".to_string(), "al".to_string());
+    let ciphertext = map.encrypt(&cipher).expect("encryption failed");
+
+    assert!(cipher.decrypt::<OneField>(ciphertext).is_err());
+}
+
+#[test]
+fn field_order_does_not_matter() {
+    let cipher = cipher();
+
+    // `HashMap` iteration order is arbitrary, so encrypting the same two
+    // entries repeatedly exercises both orderings; every one must decode.
+    for _ in 0..16 {
+        let mut map: HashMap<String, String> = HashMap::new();
+        map.insert("first".to_string(), "a".to_string());
+        map.insert("second".to_string(), "b".to_string());
+        let ciphertext = map.encrypt(&cipher).expect("encryption failed");
+
+        let decrypted: TwoStrings = cipher.decrypt(ciphertext).expect("decryption failed");
+        assert_eq!(decrypted.first, "a");
+        assert_eq!(decrypted.second, "b");
+    }
+}
+
+#[derive(Encrypt, Decrypt, Debug, PartialEq)]
+struct TwoStrings {
+    first: String,
+    second: String,
+}
+
+#[test]
+fn field_values_are_bound_to_their_key() {
+    let cipher = cipher();
+
+    // Both fields are `String`s of equal length, so nothing but the AAD
+    // binding distinguishes them. Swapping the two entries in the stored
+    // ciphertext must therefore fail to decrypt, not silently transpose them.
+    let ciphertext = TwoStrings {
+        first: "aaa".to_string(),
+        second: "bbb".to_string(),
+    }
+    .encrypt(&cipher)
+    .expect("encryption failed");
+
+    let swapped = match ciphertext {
+        vitaminc_aead::CipherText::Map(entries) => {
+            let mut entries = entries;
+            entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+            let (_, first) = entries.remove(0);
+            let (_, second) = entries.remove(0);
+            vitaminc_aead::CipherText::Map(vec![
+                ("first".to_string(), second),
+                ("second".to_string(), first),
+            ])
+        }
+        other => panic!("expected a Map ciphertext, got {other:?}"),
+    };
+
+    assert!(cipher.decrypt::<TwoStrings>(swapped).is_err());
+}
+
+#[test]
+fn wrong_aad_fails() {
+    let cipher = cipher();
+
+    let ciphertext = User {
+        name: "alice".to_string(),
+        age: 42,
+    }
+    .encrypt_with_aad(&cipher, "tenant:1".as_bytes())
+    .expect("encryption failed");
+
+    assert!(cipher
+        .decrypt_with_aad::<User, _>(ciphertext, "tenant:2".as_bytes())
+        .is_err());
+}

--- a/packages/encrypt/tests/derive.rs
+++ b/packages/encrypt/tests/derive.rs
@@ -296,3 +296,224 @@ fn wrong_aad_fails() {
         .decrypt_with_aad::<User, _>(ciphertext, "tenant:2".as_bytes())
         .is_err());
 }
+
+/// A database row: two columns stored in the clear so other queries can read
+/// and write them independently, one encrypted column alongside.
+#[derive(Encrypt, Decrypt, Debug, PartialEq)]
+struct Row {
+    #[aead(passthrough)]
+    id: i64,
+    #[aead(passthrough)]
+    tenant: String,
+    ssn: String,
+}
+
+fn a_row() -> Row {
+    Row {
+        id: 7,
+        tenant: "acme".to_string(),
+        ssn: "123-45-6789".to_string(),
+    }
+}
+
+/// Replace the payload stored under `key`, leaving the rest of the map alone —
+/// what an `UPDATE` touching a single column does to the stored value.
+fn rewrite_entry(
+    ciphertext: vitaminc_encrypt::AesCipherText,
+    key: &str,
+    payload: vitaminc_encrypt::AesCipherText,
+) -> vitaminc_encrypt::AesCipherText {
+    match ciphertext {
+        vitaminc_aead::CipherText::Map(entries) => {
+            let mut payload = Some(payload);
+            vitaminc_aead::CipherText::Map(
+                entries
+                    .into_iter()
+                    .map(|(k, v)| match k == key {
+                        true => (k, payload.take().expect("key appears more than once")),
+                        false => (k, v),
+                    })
+                    .collect(),
+            )
+        }
+        other => panic!("expected a Map ciphertext, got {other:?}"),
+    }
+}
+
+#[test]
+fn roundtrip_mixed_passthrough_and_encrypted() {
+    let cipher = cipher();
+
+    let ciphertext = a_row().encrypt(&cipher).expect("encryption failed");
+    let decrypted: Row = cipher.decrypt(ciphertext).expect("decryption failed");
+
+    assert_eq!(decrypted, a_row());
+}
+
+/// The whole point of passthrough: the value is readable straight out of the
+/// stored ciphertext with no key at all, so it can be an ordinary column.
+#[test]
+fn a_passthrough_column_is_readable_without_the_key() {
+    let cipher = cipher();
+    let ciphertext = a_row().encrypt(&cipher).expect("encryption failed");
+
+    let entries = match &ciphertext {
+        vitaminc_aead::CipherText::Map(entries) => entries,
+        other => panic!("expected a Map ciphertext, got {other:?}"),
+    };
+
+    let tenant = entries
+        .iter()
+        .find(|(k, _)| k == "tenant")
+        .map(|(_, v)| v)
+        .expect("tenant entry missing");
+    match tenant {
+        vitaminc_aead::CipherText::Passthrough(value) => {
+            let value = value.downcast_ref::<String>().expect("wrong payload type");
+            assert_eq!(value, "acme");
+        }
+        other => panic!("expected a Passthrough node, got {other:?}"),
+    }
+
+    // The encrypted column is *not* readable the same way.
+    let ssn = entries
+        .iter()
+        .find(|(k, _)| k == "ssn")
+        .map(|(_, v)| v)
+        .expect("ssn entry missing");
+    assert!(matches!(ssn, vitaminc_aead::CipherText::Single(_)));
+}
+
+/// A passthrough column carries no tag and its key is bound into nothing, so
+/// an independent write to it — the `UPDATE tenant = …` this shape exists to
+/// allow — leaves the row decryptable and simply reads back the new value.
+///
+/// Stated the other way, which is the security-relevant reading: a passthrough
+/// column is attacker-modifiable, and nothing about the ciphertext detects it.
+#[test]
+fn rewriting_a_passthrough_column_is_undetectable_by_design() {
+    let cipher = cipher();
+    let ciphertext = a_row().encrypt(&cipher).expect("encryption failed");
+
+    let rewritten = rewrite_entry(
+        ciphertext,
+        "tenant",
+        vitaminc_aead::CipherText::Passthrough(Box::new("evilcorp".to_string())),
+    );
+
+    let decrypted: Row = cipher.decrypt(rewritten).expect("decryption failed");
+    assert_eq!(decrypted.tenant, "evilcorp");
+    // The encrypted column is untouched by the substitution.
+    assert_eq!(decrypted.ssn, "123-45-6789");
+}
+
+/// Passthrough entries must not weaken the entries around them: the encrypted
+/// column keeps its per-key AAD binding.
+#[test]
+fn an_encrypted_column_still_fails_when_tampered() {
+    let cipher = cipher();
+
+    let ciphertext = a_row().encrypt(&cipher).expect("encryption failed");
+    let other = Row {
+        ssn: "999-99-9999".to_string(),
+        ..a_row()
+    }
+    .encrypt(&cipher)
+    .expect("encryption failed");
+
+    // Lift the encrypted `ssn` node out of the second ciphertext and graft it
+    // onto the first — a value sealed under the same key and the same AAD.
+    let grafted_ssn = match other {
+        vitaminc_aead::CipherText::Map(entries) => entries
+            .into_iter()
+            .find(|(k, _)| k == "ssn")
+            .map(|(_, v)| v)
+            .expect("ssn entry missing"),
+        other => panic!("expected a Map ciphertext, got {other:?}"),
+    };
+
+    let grafted = rewrite_entry(ciphertext, "ssn", grafted_ssn);
+
+    // The graft *does* decrypt — same key, same AAD — which is exactly why the
+    // encrypted column must not be relied on to authenticate the row as a
+    // whole. What it proves is narrower: the entry is bound to its own key.
+    let decrypted: Row = cipher.decrypt(grafted).expect("decryption failed");
+    assert_eq!(decrypted.ssn, "999-99-9999");
+
+    // Moving that same node onto a different key breaks the binding.
+    let ciphertext = a_row().encrypt(&cipher).expect("encryption failed");
+    let moved = match ciphertext {
+        vitaminc_aead::CipherText::Map(entries) => vitaminc_aead::CipherText::Map(
+            entries
+                .into_iter()
+                .map(|(k, v)| match k.as_str() {
+                    "ssn" => ("tenant".to_string(), v),
+                    _ => (k, v),
+                })
+                .collect(),
+        ),
+        other => panic!("expected a Map ciphertext, got {other:?}"),
+    };
+    assert!(cipher.decrypt::<Row>(moved).is_err());
+}
+
+/// The downcast is the only check a passthrough read performs. It catches a
+/// payload of the wrong type — a type confusion, not a tamper — rather than
+/// handing the struct a field it cannot hold.
+#[test]
+fn a_passthrough_payload_of_the_wrong_type_is_rejected() {
+    let cipher = cipher();
+    let ciphertext = a_row().encrypt(&cipher).expect("encryption failed");
+
+    let confused = rewrite_entry(
+        ciphertext,
+        "tenant",
+        vitaminc_aead::CipherText::Passthrough(Box::new(42u8)),
+    );
+
+    assert!(cipher.decrypt::<Row>(confused).is_err());
+}
+
+/// Deleting a passthrough entry cannot be detected cryptographically, so the
+/// decode falls back on the same strictness every other field gets: a missing
+/// field is a rejection, not a default.
+#[test]
+fn a_deleted_passthrough_column_is_rejected_as_a_missing_field() {
+    let cipher = cipher();
+    let ciphertext = a_row().encrypt(&cipher).expect("encryption failed");
+
+    let truncated = match ciphertext {
+        vitaminc_aead::CipherText::Map(entries) => vitaminc_aead::CipherText::Map(
+            entries.into_iter().filter(|(k, _)| k != "tenant").collect(),
+        ),
+        other => panic!("expected a Map ciphertext, got {other:?}"),
+    };
+
+    assert!(cipher.decrypt::<Row>(truncated).is_err());
+}
+
+/// An encrypted entry must not be readable through the passthrough path: that
+/// would hand back a payload whose tag was never checked.
+#[test]
+fn an_encrypted_entry_cannot_be_read_as_a_passthrough() {
+    let cipher = cipher();
+    let ciphertext = a_row().encrypt(&cipher).expect("encryption failed");
+
+    // `ssn` is sealed; relabel it as the `tenant` key, which `Row` decodes
+    // through `next_passthrough`.
+    let swapped = match ciphertext {
+        vitaminc_aead::CipherText::Map(entries) => vitaminc_aead::CipherText::Map(
+            entries
+                .into_iter()
+                .filter(|(k, _)| k != "tenant")
+                .map(|(k, v)| match k.as_str() {
+                    "ssn" => ("tenant".to_string(), v),
+                    _ => (k, v),
+                })
+                .collect(),
+        ),
+        other => panic!("expected a Map ciphertext, got {other:?}"),
+    };
+
+    assert!(cipher.decrypt::<Row>(swapped).is_err());
+}

--- a/packages/encrypt/tests/derive.rs
+++ b/packages/encrypt/tests/derive.rs
@@ -517,3 +517,25 @@ fn an_encrypted_entry_cannot_be_read_as_a_passthrough() {
 
     assert!(cipher.decrypt::<Row>(swapped).is_err());
 }
+
+/// Const parameters are passed to the visitor through the value type, so a
+/// parameter that is not a `usize` derives like any other. Naming them
+/// individually — as an array length, say — would quietly require `usize`.
+#[derive(Encrypt, Decrypt, Debug, PartialEq)]
+struct ConstGeneric<const N: u32> {
+    value: String,
+}
+
+#[test]
+fn roundtrip_non_usize_const_generic() {
+    let cipher = cipher();
+
+    let ciphertext = ConstGeneric::<7> {
+        value: "x".to_string(),
+    }
+    .encrypt(&cipher)
+    .expect("encryption failed");
+    let decrypted: ConstGeneric<7> = cipher.decrypt(ciphertext).expect("decryption failed");
+
+    assert_eq!(decrypted.value, "x");
+}

--- a/packages/encrypt/tests/map_access.rs
+++ b/packages/encrypt/tests/map_access.rs
@@ -1,0 +1,120 @@
+//! Contract tests for the key/value split on `MapAccess`.
+//!
+//! `next_key` hands out a key and leaves the value undecrypted so the caller
+//! can choose the type to decrypt it into — that is what makes a derived
+//! struct with heterogeneous fields decodable. The split also opens two ways
+//! to misuse it, both of which leave a stored value's AAD binding unverified,
+//! and both of which the implementation must refuse rather than tolerate.
+
+use std::collections::HashMap;
+
+use vitaminc_aead::{Decipher, DecipherVisitor, Encrypt, MapAccess, Unspecified};
+use vitaminc_encrypt::{Aes256Cipher, Key};
+
+fn cipher() -> Aes256Cipher {
+    Aes256Cipher::new(&Key::from([42u8; 32])).expect("failed to create cipher")
+}
+
+fn two_entry_ciphertext(cipher: &Aes256Cipher) -> vitaminc_encrypt::AesCipherText {
+    let mut map: HashMap<String, String> = HashMap::new();
+    map.insert("first".to_string(), "a".to_string());
+    map.insert("second".to_string(), "b".to_string());
+    map.encrypt(cipher).expect("encryption failed")
+}
+
+/// Reads every key then every value — i.e. calls `next_key` twice in a row.
+struct SkipsAValue;
+
+impl<'c> DecipherVisitor<'c> for SkipsAValue {
+    type Value = ();
+
+    fn visit_map<A: MapAccess<'c>>(self, mut map: A) -> Result<Self::Value, Unspecified> {
+        map.next_key().map_err(|_| Unspecified)?;
+        // Second key without consuming the first value: the skipped entry
+        // would never have its AAD binding checked.
+        map.next_key().map_err(|_| Unspecified)?;
+        Ok(())
+    }
+}
+
+/// Asks for a value before any key has been read.
+struct ValueWithoutKey;
+
+impl<'c> DecipherVisitor<'c> for ValueWithoutKey {
+    type Value = ();
+
+    fn visit_map<A: MapAccess<'c>>(self, mut map: A) -> Result<Self::Value, Unspecified> {
+        map.next_value::<String>().map_err(|_| Unspecified)?;
+        Ok(())
+    }
+}
+
+/// The well-behaved sequence: key, value, key, value, then exhaustion.
+struct ReadsEveryEntry;
+
+impl<'c> DecipherVisitor<'c> for ReadsEveryEntry {
+    type Value = Vec<(String, String)>;
+
+    fn visit_map<A: MapAccess<'c>>(self, mut map: A) -> Result<Self::Value, Unspecified> {
+        let mut entries = Vec::new();
+        while let Some(key) = map.next_key().map_err(|_| Unspecified)? {
+            let value = map.next_value::<String>().map_err(|_| Unspecified)?;
+            entries.push((key, value));
+        }
+        Ok(entries)
+    }
+}
+
+#[test]
+fn skipping_a_value_is_rejected() {
+    let cipher = cipher();
+    let ciphertext = two_entry_ciphertext(&cipher);
+
+    let result = cipher
+        .decipher(ciphertext)
+        .decrypt_map(SkipsAValue, "".as_bytes());
+    assert!(result.is_err());
+}
+
+#[test]
+fn value_without_a_key_is_rejected() {
+    let cipher = cipher();
+    let ciphertext = two_entry_ciphertext(&cipher);
+
+    let result = cipher
+        .decipher(ciphertext)
+        .decrypt_map(ValueWithoutKey, "".as_bytes());
+    assert!(result.is_err());
+}
+
+#[test]
+fn key_then_value_reads_every_entry() {
+    let cipher = cipher();
+    let ciphertext = two_entry_ciphertext(&cipher);
+
+    let mut entries = cipher
+        .decipher(ciphertext)
+        .decrypt_map(ReadsEveryEntry, "".as_bytes())
+        .expect("decryption failed");
+    entries.sort();
+
+    assert_eq!(
+        entries,
+        vec![
+            ("first".to_string(), "a".to_string()),
+            ("second".to_string(), "b".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn next_entry_still_works_over_the_split() {
+    // `HashMap`'s own `Decrypt` impl goes through the defaulted `next_entry`,
+    // so a passing roundtrip proves the default composes with the split.
+    let cipher = cipher();
+    let ciphertext = two_entry_ciphertext(&cipher);
+
+    let decrypted: HashMap<String, String> = cipher.decrypt(ciphertext).expect("decryption failed");
+    assert_eq!(decrypted.get("first").map(String::as_str), Some("a"));
+    assert_eq!(decrypted.get("second").map(String::as_str), Some("b"));
+}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -15,6 +15,10 @@ name = "vitaminc-aead"
 version_group = "vitaminc"
 
 [[package]]
+name = "vitaminc-aead-derive"
+version_group = "vitaminc"
+
+[[package]]
 name = "vitaminc-aead-napi"
 version_group = "vitaminc"
 


### PR DESCRIPTION
Closes #292

Adds `#[derive(Encrypt)]` / `#[derive(Decrypt)]` for `vitaminc-aead`, and moves the `Decrypt` trait into its own module so the decrypt side mirrors the encrypt side.

## Why

Hand-writing `Encrypt`/`Decrypt` for a plain struct is boilerplate with a security-relevant detail buried in it: values have to be sealed as a **map**, because `MapCipher` binds each entry's key into the AAD its value is sealed against. Encoding a struct as a sequence instead compiles fine and round-trips fine — and leaves two same-typed fields freely interchangeable in stored ciphertext, since element AAD carries no positional component. The derive makes the safe shape the default.

## Commits

**`refactor(aead)`** — `Decrypt` and its impls move to `packages/aead/src/decrypt/`, opposite `encrypt`, leaving `decipher` as the mirror of `cipher`. Previously `Decrypt` (what a plaintext type implements) sat alongside `Decipher` (what a cipher backend implements), which the encrypt side already keeps apart. Public paths are unchanged — everything is re-exported flat from the crate root as before.

**`feat(aead)`** — the derive itself, in a new `vitaminc-aead-derive` crate re-exported from `vitaminc_aead`, following the `protected` / `protected-derive` convention. Added to the release group, so it releases with the other crates.

## Wire shape

```rust
use vitaminc_aead::{Decrypt, Encrypt};

#[derive(Encrypt, Decrypt)]
struct User {
    name: String,
    age: u32,
}
// ciphertext: Map { "name": …, "age": … }
```

- **Map keyed by field name.** Each field gets its own `Aad::for_map_entry` binding, so a stored field cannot be renamed or moved onto another key undetected. Interchangeable with the equivalent `HashMap<String, _>` ciphertext.
- **Field names are part of the ciphertext contract** — renaming a field breaks compatibility with existing data. `#[aead(rename = "...")]` pins the old wire key.
- **Newtype structs are transparent** — they encrypt and decrypt exactly as the inner type, so wrapping an existing type is not a wire-breaking change. Mirrors serde, and matches how `Protected<T>` / `Equatable<T>` already behave.
- **Tuple structs** of 2+ fields are keyed by decimal index (`"0"`, `"1"`, …), so they get the same per-field binding.
- **Unit / field-less structs** encrypt to the authenticated empty-map marker.
- **Decoding is strict**: a missing field, an unknown key, or a duplicate key is rejected rather than defaulted or skipped.
- **Enums are a compile error.** A ciphertext carries no authenticated variant discriminator, so any encoding the macro could pick would either leak the variant in the clear or leave it forgeable.
- `#[aead(crate = "::vitaminc::aead")]` on the container for use through a re-export.

## `MapAccess` gains a key/value split

`next_entry::<T>()` fixes the value type *before* the key is known, so it cannot decode a struct with heterogeneous field types at all. `MapAccess` now has:

```rust
fn next_key(&mut self) -> Result<Option<String>, Self::Error>;
fn next_value<T: Decrypt<'c> + 'c>(&mut self) -> Result<T, Self::Error>;
```

with `next_entry` **defaulted** over the two — so `HashMap`'s existing impl, and any homogeneous consumer, is untouched. `AesMapAccess` is the only implementor of the trait in the workspace.

Reading key-first also makes the decode order-independent, which matters because entry order in a stored ciphertext is not authenticated. Both misuse paths are refused rather than tolerated: a second `next_key` without consuming the pending value, and `next_value` with no pending key. A skipped value is one whose AAD binding is never verified.

## Tests

- 26 units in `vitaminc-aead-derive`: 7 shape tests — enum/union rejection, duplicate-key rejection, newtype vs named-single-field, tuple index keys, field-less shapes — plus 19 expansion tests that pin the generated code itself: per-field key binding, `rename`, tuple index keys, newtype transparency, the empty-map marker, the `'__c` bounds, the visitor's `PhantomData`, `#[aead(crate = "...")]` redirection, and the attribute-error paths. Expansions are compared as tokens, not text — the expected fragment is rendered through `quote!` too, so an assertion is written as ordinary Rust and cannot fail on `TokenStream` spacing.

  This puts the derive crate under both quality gates rather than exempting it: `decrypt::derive` goes from CRAP 90.0 at 0% covered to 9.0 at 100%, `encrypt::derive` from 56.0 to 7.0, and `cargo mutants` reports 14 caught / 0 missed. Only the two `#[proc_macro_derive]` shims in `lib.rs` stay uncovered — they run at compile time, and at CC 1 they score under the threshold anyway.
- 13 end-to-end tests in `packages/encrypt/tests/derive.rs` against real AES-256-GCM — round-trips for every shape, `HashMap` wire compatibility, rename, missing/unknown field rejection, order independence, wrong-AAD failure, and a **field-swap tamper test**: two equal-length `String` fields transposed in the stored ciphertext must fail to decrypt, which is the property the map shape exists for.
- 4 `MapAccess` contract tests in `packages/encrypt/tests/map_access.rs`.

Full workspace green; `cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` clean.

https://claude.ai/code/session_011kjxjgxWmT4yi23ZqufSEc


