### PR TITLE
feat(aead): Passthrough<T> wrapper for unencrypted fields

### DIFF
--- a/packages/aead/README.md
+++ b/packages/aead/README.md
@@ -333,6 +333,65 @@ impl<'c> Decrypt<'c> for User {
 
 The visitor pattern keeps the cipher and the type independent: the cipher decides how the ciphertext is laid out and how AAD is enforced, while the type decides how its fields are reassembled.
 
+### Passing fields through in the clear
+
+Not every field of a record is sensitive. Wrap a field in [`Passthrough`] to carry it through the ciphertext container **unencrypted and unauthenticated** — routing or display data such as identifiers and schema versions. Because a custom type's impl is generic over every cipher, it cannot name a particular cipher's passthrough payload type; `Passthrough<T>` drives the type-erased channel for it, through the same `encrypt_entry` / `next_entry` calls as any encrypted field:
+
+```rust
+use vitaminc_aead::{
+    Cipher, Decipher, DecipherVisitor, Decrypt, Encrypt, IntoAad, MapAccess, MapCipher,
+    Passthrough, Unspecified,
+};
+
+struct User {
+    id: u32,       // stored in the clear
+    email: String, // encrypted
+}
+
+impl Encrypt for User {
+    fn encrypt_with_aad<'a, C, A>(self, cipher: C, aad: A) -> Result<C::Ok, C::Error>
+    where
+        C: Cipher,
+        A: IntoAad<'a>,
+    {
+        cipher
+            .encrypt_map(aad)
+            .encrypt_entry("id", Passthrough(self.id))?
+            .encrypt_entry("email", self.email)?
+            .end()
+    }
+}
+
+impl<'c> Decrypt<'c> for User {
+    fn decrypt_with_aad<'a, D, A>(decipher: D, aad: A) -> D::Ok<Self>
+    where
+        D: Decipher<'c>,
+        A: IntoAad<'a>,
+    {
+        struct UserVisitor;
+        impl<'c> DecipherVisitor<'c> for UserVisitor {
+            type Value = User;
+
+            fn visit_map<A: MapAccess<'c>>(self, mut map: A) -> Result<Self::Value, Unspecified> {
+                // Entries come back in encryption order; pull each with its type.
+                let (_, Passthrough(id)) = map
+                    .next_entry::<Passthrough<u32>>()
+                    .map_err(|_| Unspecified)?
+                    .ok_or(Unspecified)?;
+                let (_, email) = map
+                    .next_entry::<String>()
+                    .map_err(|_| Unspecified)?
+                    .ok_or(Unspecified)?;
+                Ok(User { id, email })
+            }
+        }
+        decipher.decrypt_map(UserVisitor, aad)
+    }
+}
+```
+
+A passthrough value — and, for map entries, its key — can be altered in the stored ciphertext without detection. Never route secret-bearing data through it; wrap it in `Protected` and encrypt it instead.
+
 ### Nonce Generation
 
 The crate provides nonce generation utilities for AEAD operations:

--- a/packages/aead/README.md
+++ b/packages/aead/README.md
@@ -335,7 +335,11 @@ The visitor pattern keeps the cipher and the type independent: the cipher decide
 
 ### Passing fields through in the clear
 
-Not every field of a record is sensitive. Wrap a field in [`Passthrough`] to carry it through the ciphertext container **unencrypted and unauthenticated** — routing or display data such as identifiers and schema versions. Because a custom type's impl is generic over every cipher, it cannot name a particular cipher's passthrough payload type; `Passthrough<T>` drives the type-erased channel for it, through the same `encrypt_entry` / `next_entry` calls as any encrypted field:
+Not every column of a table needs encrypting. A record usually has a few fields that other queries select, filter, or update without holding the key — a display name, a schema version, a plain `id` column — beside the ones that must be sealed. Wrap such a field in [`Passthrough`] and it is stored as a cleartext entry of the same ciphertext container, so the record still round-trips as one unit while that field stays an ordinary column.
+
+**Passthrough provides no security guarantees whatsoever.** The value is not encrypted and not authenticated — it, and for map entries its key, can be read, edited, added, or removed in storage and every encrypted field beside it still decrypts. Treat what comes back as untrusted input: non-sensitive, non-security-deciding data only, never a field the program then trusts for authorization, tenancy, access control, or for choosing which encrypted record to trust. The full contract is documented once, under [`#[aead(passthrough)]`](Encrypt#aeadpassthrough); `Passthrough<T>` is the hand-written equivalent of that attribute.
+
+Because a custom type's impl is generic over every cipher, it cannot name a particular cipher's passthrough payload type; `Passthrough<T>` drives the type-erased channel for it, through the same `encrypt_entry` / `next_value` calls as any encrypted field:
 
 ```rust
 use vitaminc_aead::{
@@ -373,16 +377,28 @@ impl<'c> Decrypt<'c> for User {
             type Value = User;
 
             fn visit_map<A: MapAccess<'c>>(self, mut map: A) -> Result<Self::Value, Unspecified> {
-                // Entries come back in encryption order; pull each with its type.
-                let (_, Passthrough(id)) = map
-                    .next_entry::<Passthrough<u32>>()
-                    .map_err(|_| Unspecified)?
-                    .ok_or(Unspecified)?;
-                let (_, email) = map
-                    .next_entry::<String>()
-                    .map_err(|_| Unspecified)?
-                    .ok_or(Unspecified)?;
-                Ok(User { id, email })
+                // Entry order in a stored ciphertext is not authenticated, so
+                // read key-first and let the key choose the type — never the
+                // position. A duplicate, unknown, or missing key is an error:
+                // a skipped value is one whose binding was never verified.
+                let (mut id, mut email) = (None, None);
+                while let Some(key) = map.next_key().map_err(|_| Unspecified)? {
+                    match key.as_str() {
+                        "id" if id.is_none() => {
+                            let Passthrough(value) =
+                                map.next_value::<Passthrough<u32>>().map_err(|_| Unspecified)?;
+                            id = Some(value);
+                        }
+                        "email" if email.is_none() => {
+                            email = Some(map.next_value::<String>().map_err(|_| Unspecified)?);
+                        }
+                        _ => return Err(Unspecified),
+                    }
+                }
+                Ok(User {
+                    id: id.ok_or(Unspecified)?,
+                    email: email.ok_or(Unspecified)?,
+                })
             }
         }
         decipher.decrypt_map(UserVisitor, aad)
@@ -390,7 +406,7 @@ impl<'c> Decrypt<'c> for User {
 }
 ```
 
-A passthrough value — and, for map entries, its key — can be altered in the stored ciphertext without detection. Never route secret-bearing data through it; wrap it in `Protected` and encrypt it instead.
+Anything secret-bearing belongs in `Protected` and gets encrypted; anything that must be tamper-evident but readable belongs in the AAD, not in a passthrough.
 
 ### Nonce Generation
 

--- a/packages/aead/src/lib.rs
+++ b/packages/aead/src/lib.rs
@@ -12,6 +12,7 @@ mod encrypt;
 #[cfg(feature = "hlist")]
 pub mod hlist;
 mod nonce;
+mod passthrough;
 #[cfg(test)]
 mod test_util;
 
@@ -40,3 +41,6 @@ pub use nonce::{Nonce, NonceGenerator, RandomNonceGenerator};
 // reader to another crate. There is still only one copy of that text.
 #[doc(inline)]
 pub use vitaminc_aead_derive::{Decrypt, Encrypt};
+
+#[doc(inline)]
+pub use passthrough::Passthrough;

--- a/packages/aead/src/passthrough.rs
+++ b/packages/aead/src/passthrough.rs
@@ -5,19 +5,21 @@
 //!
 //! # Why carry a field in the clear
 //!
-//! An encrypted record still has to work as a record. The identifier a row is
-//! fetched by, the tenant it is scoped to, the schema version that says how to
-//! read the rest — the storage layer needs those without holding a decryption
-//! key. Encrypt them and the system responsible for the record can no longer
-//! route, index, or interpret it.
+//! Not every column of a table needs encrypting. A record usually has a few
+//! fields that other queries select, filter, or update without holding the
+//! key — a display name, a schema version, a plain `id` column — beside the
+//! ones that must be sealed. Encrypt those too and the storage layer can no
+//! longer index, filter, or interpret the row without a decryption key.
 //!
-//! Passthrough keeps such a field inside the *same* ciphertext container as
-//! the encrypted ones, so the record still seals, moves, and round-trips as a
-//! single unit, while the clear fields stay readable along the way. The
-//! alternative — storing them beside the ciphertext — splits one record into
-//! two things that can drift apart.
+//! Passthrough stores such a field as a cleartext entry of the *same*
+//! ciphertext container as the encrypted ones, so the record still seals,
+//! moves, and round-trips as a single unit while that field stays an ordinary
+//! column. The alternative — storing it beside the ciphertext — splits one
+//! record into two things that can drift apart.
 //!
-//! Only non-sensitive data qualifies; see the warning below.
+//! This is exactly what [`#[aead(passthrough)]`](crate::Encrypt#aeadpassthrough)
+//! does for a derived impl; `Passthrough<T>` is its hand-written equivalent,
+//! and carries the same contract — see the warning below.
 //!
 //! # Why this type rather than the cipher's own hooks
 //!
@@ -49,14 +51,22 @@
 //! On decrypt, the visitor downcasts the erased payload back to `T`; a
 //! foreign payload type is an [`Unspecified`] error, never a panic.
 //!
-//! # ⚠️ Non-sensitive data only
+//! # ⚠️ No security guarantees whatsoever
 //!
-//! Identical contract to [`Cipher::passthrough`](crate::Cipher::passthrough):
-//! the value travels **in the clear** and is **not authenticated** — a stored
-//! passthrough value (and, for map entries, its key) can be altered
-//! undetectably. Use it for non-sensitive routing/display data (identifiers,
-//! schema versions, display names); never route secret-bearing data through
-//! it. Wrap in [`Protected`](vitaminc_protected::Protected) instead.
+//! Identical contract to [`Cipher::passthrough`](crate::Cipher::passthrough)
+//! and to [`#[aead(passthrough)]`](crate::Encrypt#aeadpassthrough), which
+//! documents it in full. In short: the value travels **in the clear** and is
+//! **not authenticated** — a stored passthrough value (and, for map entries,
+//! its key) can be read, edited, added, or removed undetectably, and every
+//! encrypted field beside it still decrypts. Treat what comes back as
+//! untrusted input.
+//!
+//! So: non-sensitive, non-security-deciding data only. Never a field the
+//! program then trusts to make an authorization choice — a tenant, a role, a
+//! scope — nor one used to select which encrypted record to trust. Anything
+//! secret-bearing belongs in [`Protected`](vitaminc_protected::Protected) and
+//! gets encrypted; anything that must be tamper-evident but readable belongs
+//! in the AAD, not in a passthrough.
 //!
 //! This is the dynamic-path counterpart of `hlist::Passthrough` (behind the
 //! `hlist` feature), which serves the opt-in statically-shaped encoding.

--- a/packages/aead/src/passthrough.rs
+++ b/packages/aead/src/passthrough.rs
@@ -3,16 +3,37 @@
 //! [`Cipher::passthrough_boxed`] / [`DecipherVisitor::visit_passthrough`]
 //! channel.
 //!
-//! # Why
+//! # Why carry a field in the clear
+//!
+//! An encrypted record still has to work as a record. The identifier a row is
+//! fetched by, the tenant it is scoped to, the schema version that says how to
+//! read the rest — the storage layer needs those without holding a decryption
+//! key. Encrypt them and the system responsible for the record can no longer
+//! route, index, or interpret it.
+//!
+//! Passthrough keeps such a field inside the *same* ciphertext container as
+//! the encrypted ones, so the record still seals, moves, and round-trips as a
+//! single unit, while the clear fields stay readable along the way. The
+//! alternative — storing them beside the ciphertext — splits one record into
+//! two things that can drift apart.
+//!
+//! Only non-sensitive data qualifies; see the warning below.
+//!
+//! # Why this type rather than the cipher's own hooks
+//!
+//! [`Cipher::passthrough`](crate::Cipher::passthrough) and its map/sequence
+//! siblings already provide the channel, but reaching them means naming the
+//! cipher's own [`Cipher::Passthrough`](crate::Cipher::Passthrough) payload
+//! type — which only code written against one concrete cipher can do.
 //!
 //! A struct's [`Encrypt`] / [`Decrypt`] impl is generic over *every* cipher,
-//! so it cannot name a specific cipher's
-//! [`Cipher::Passthrough`](crate::Cipher::Passthrough) payload type and has
-//! no way to call [`MapCipher::passthrough_entry`](crate::MapCipher::passthrough_entry)
+//! so it cannot name that type and has no way to call
+//! [`MapCipher::passthrough_entry`](crate::MapCipher::passthrough_entry)
 //! or [`SeqCipher::passthrough_next`](crate::SeqCipher::passthrough_next)
-//! with a value it owns. The type-erased hooks close that gap at the trait
-//! level; this wrapper packages them so a field can be declared "stored in
-//! the clear" with one type annotation and driven through the ordinary
+//! with a value it owns (an impl cannot add bounds the trait lacks). The
+//! type-erased hooks close that gap at the trait level; this wrapper packages
+//! them so a field can be declared "stored in the clear" with one type
+//! annotation and driven through the ordinary
 //! [`encrypt_entry`](crate::MapCipher::encrypt_entry) /
 //! [`encrypt_next`](crate::SeqCipher::encrypt_next) /
 //! [`next_entry`](crate::MapAccess::next_entry) calls like any other field:

--- a/packages/aead/src/passthrough.rs
+++ b/packages/aead/src/passthrough.rs
@@ -1,0 +1,349 @@
+//! [`Passthrough`], a wrapper that carries a value through the ciphertext
+//! container **without encrypting it** — the typed front door to the
+//! [`Cipher::passthrough_boxed`] / [`DecipherVisitor::visit_passthrough`]
+//! channel.
+//!
+//! # Why
+//!
+//! A struct's [`Encrypt`] / [`Decrypt`] impl is generic over *every* cipher,
+//! so it cannot name a specific cipher's
+//! [`Cipher::Passthrough`](crate::Cipher::Passthrough) payload type and has
+//! no way to call [`MapCipher::passthrough_entry`](crate::MapCipher::passthrough_entry)
+//! or [`SeqCipher::passthrough_next`](crate::SeqCipher::passthrough_next)
+//! with a value it owns. The type-erased hooks close that gap at the trait
+//! level; this wrapper packages them so a field can be declared "stored in
+//! the clear" with one type annotation and driven through the ordinary
+//! [`encrypt_entry`](crate::MapCipher::encrypt_entry) /
+//! [`encrypt_next`](crate::SeqCipher::encrypt_next) /
+//! [`next_entry`](crate::MapAccess::next_entry) calls like any other field:
+//!
+//! ```ignore
+//! cipher
+//!     .encrypt_map(aad)
+//!     .encrypt_entry("id", Passthrough(self.id))?        // in the clear
+//!     .encrypt_entry("email", self.email)?               // encrypted
+//!     .end()
+//! ```
+//!
+//! On decrypt, the visitor downcasts the erased payload back to `T`; a
+//! foreign payload type is an [`Unspecified`] error, never a panic.
+//!
+//! # ⚠️ Non-sensitive data only
+//!
+//! Identical contract to [`Cipher::passthrough`](crate::Cipher::passthrough):
+//! the value travels **in the clear** and is **not authenticated** — a stored
+//! passthrough value (and, for map entries, its key) can be altered
+//! undetectably. Use it for non-sensitive routing/display data (identifiers,
+//! schema versions, display names); never route secret-bearing data through
+//! it. Wrap in [`Protected`](vitaminc_protected::Protected) instead.
+//!
+//! This is the dynamic-path counterpart of `hlist::Passthrough` (behind the
+//! `hlist` feature), which serves the opt-in statically-shaped encoding.
+
+use std::any::Any;
+use std::marker::PhantomData;
+
+use crate::{
+    cipher::Cipher,
+    decipher::{Decipher, DecipherVisitor},
+    decrypt::Decrypt,
+    encrypt::Encrypt,
+    IntoAad, Unspecified,
+};
+
+/// A value carried through the ciphertext container **in the clear**: neither
+/// encrypted nor authenticated. For non-sensitive routing/display data only —
+/// identifiers, schema versions, display names. A struct field typed
+/// `Passthrough<T>` drives the type-erased passthrough channel through the
+/// ordinary `encrypt_entry` / `next_entry` calls, so a cipher-generic
+/// [`Encrypt`] / [`Decrypt`] impl can mix clear and encrypted fields without
+/// naming any cipher's payload type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct Passthrough<T>(pub T);
+
+impl<T> Passthrough<T> {
+    /// Consume the wrapper, returning the inner value.
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
+impl<T> From<T> for Passthrough<T> {
+    fn from(value: T) -> Self {
+        Self(value)
+    }
+}
+
+impl<T> Encrypt for Passthrough<T>
+where
+    T: Send + 'static,
+{
+    /// Hands the value to [`Cipher::passthrough_boxed`]. The AAD is ignored:
+    /// a passthrough value is neither encrypted nor authenticated.
+    fn encrypt_with_aad<'a, C, A>(self, cipher: C, _aad: A) -> Result<C::Ok, C::Error>
+    where
+        C: Cipher,
+        A: IntoAad<'a>,
+    {
+        cipher.passthrough_boxed(Box::new(self.0))
+    }
+}
+
+impl<'c, T> Decrypt<'c> for Passthrough<T>
+where
+    T: Send + 'static,
+{
+    /// Expects a passthrough node and downcasts its payload to `T`. Any other
+    /// node shape, or a payload of a different type, is [`Unspecified`].
+    fn decrypt_with_aad<'a, D, A>(decipher: D, aad: A) -> D::Ok<Self>
+    where
+        D: Decipher<'c>,
+        A: IntoAad<'a>,
+    {
+        struct PassthroughVisitor<T>(PhantomData<fn() -> T>);
+
+        impl<'c, T> DecipherVisitor<'c> for PassthroughVisitor<T>
+        where
+            T: Send + 'static,
+        {
+            type Value = Passthrough<T>;
+
+            fn visit_passthrough(
+                self,
+                value: Box<dyn Any + Send + 'static>,
+            ) -> Result<Self::Value, Unspecified> {
+                value
+                    .downcast::<T>()
+                    .map(|v| Passthrough(*v))
+                    .map_err(|_| Unspecified)
+            }
+        }
+
+        decipher.decrypt_any(PassthroughVisitor(PhantomData), aad)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cipher::{MapCipher, SeqCipher};
+    use std::cell::RefCell;
+
+    // A cipher that records what reaches the passthrough channel.
+    struct SpyCipher {
+        boxed: RefCell<Option<Box<dyn Any + Send + 'static>>>,
+    }
+
+    struct Unused;
+
+    impl Cipher for &SpyCipher {
+        type Ok = ();
+        type Error = Unspecified;
+        type Passthrough = ();
+        type SeqCipher = Unused;
+        type MapCipher = Unused;
+
+        fn encrypt_bytes_vec<'a, A>(
+            self,
+            _data: vitaminc_protected::Protected<Vec<u8>>,
+            _aad: A,
+        ) -> Result<Self::Ok, Self::Error>
+        where
+            A: IntoAad<'a>,
+        {
+            // A passthrough must never take the encrypted path.
+            Err(Unspecified)
+        }
+
+        fn encrypt_seq<'a, A>(self, _size_hint: Option<usize>, _aad: A) -> Self::SeqCipher
+        where
+            A: IntoAad<'a>,
+        {
+            Unused
+        }
+
+        fn encrypt_map<'a, A>(self, _aad: A) -> Self::MapCipher
+        where
+            A: IntoAad<'a>,
+        {
+            Unused
+        }
+
+        fn encrypt_none<'a, A>(self, _aad: A) -> Result<Self::Ok, Self::Error>
+        where
+            A: IntoAad<'a>,
+        {
+            Err(Unspecified)
+        }
+
+        fn passthrough(self, _value: Self::Passthrough) -> Result<Self::Ok, Self::Error> {
+            Err(Unspecified)
+        }
+
+        fn passthrough_boxed(
+            self,
+            value: Box<dyn Any + Send + 'static>,
+        ) -> Result<Self::Ok, Self::Error> {
+            *self.boxed.borrow_mut() = Some(value);
+            Ok(())
+        }
+    }
+
+    impl SeqCipher for Unused {
+        type Ok = ();
+        type Error = Unspecified;
+        type Passthrough = ();
+        fn encrypt_next<T: Encrypt>(self, _data: T) -> Result<Self, Self::Error> {
+            Err(Unspecified)
+        }
+        fn passthrough_next(self, _value: Self::Passthrough) -> Result<Self, Self::Error> {
+            Err(Unspecified)
+        }
+        fn end(self) -> Result<Self::Ok, Self::Error> {
+            Err(Unspecified)
+        }
+    }
+
+    impl MapCipher for Unused {
+        type Ok = ();
+        type Error = Unspecified;
+        type Passthrough = ();
+        fn encrypt_key<K>(self, _key: K) -> Result<Self, Self::Error>
+        where
+            K: Into<std::borrow::Cow<'static, str>>,
+        {
+            Err(Unspecified)
+        }
+        fn encrypt_value<T: Encrypt>(self, _value: T) -> Result<Self, Self::Error> {
+            Err(Unspecified)
+        }
+        fn passthrough_entry<K>(
+            self,
+            _key: K,
+            _value: Self::Passthrough,
+        ) -> Result<Self, Self::Error>
+        where
+            K: Into<std::borrow::Cow<'static, str>>,
+        {
+            Err(Unspecified)
+        }
+        fn passthrough_entry_boxed<K>(
+            self,
+            _key: K,
+            _value: Box<dyn Any + Send + 'static>,
+        ) -> Result<Self, Self::Error>
+        where
+            K: Into<std::borrow::Cow<'static, str>>,
+        {
+            Err(Unspecified)
+        }
+        fn end(self) -> Result<Self::Ok, Self::Error> {
+            Err(Unspecified)
+        }
+    }
+
+    // A decipher holding one passthrough node.
+    struct PassthroughDecipher(RefCell<Option<Box<dyn Any + Send + 'static>>>);
+
+    impl<'c> Decipher<'c> for &PassthroughDecipher {
+        type Ok<T>
+            = Result<T, Unspecified>
+        where
+            T: Send + 'c;
+        type Passthrough = ();
+
+        fn map_ok<T, U, F>(ok: Self::Ok<T>, f: F) -> Self::Ok<U>
+        where
+            T: Send + 'c,
+            U: Send + 'c,
+            F: FnOnce(T) -> U,
+        {
+            ok.map(f)
+        }
+
+        fn decrypt_bytes<'a, V, A>(self, _visitor: V, _aad: A) -> Self::Ok<V::Value>
+        where
+            V: DecipherVisitor<'c> + Send + 'c,
+            A: IntoAad<'a>,
+        {
+            Err(Unspecified)
+        }
+
+        fn decrypt_seq<'a, V, A>(self, _visitor: V, _aad: A) -> Self::Ok<V::Value>
+        where
+            V: DecipherVisitor<'c> + Send + 'c,
+            A: IntoAad<'a>,
+        {
+            Err(Unspecified)
+        }
+
+        fn decrypt_map<'a, V, A>(self, _visitor: V, _aad: A) -> Self::Ok<V::Value>
+        where
+            V: DecipherVisitor<'c> + Send + 'c,
+            A: IntoAad<'a>,
+        {
+            Err(Unspecified)
+        }
+
+        fn decrypt_any<'a, V, A>(self, visitor: V, _aad: A) -> Self::Ok<V::Value>
+        where
+            V: DecipherVisitor<'c> + Send + 'c,
+            A: IntoAad<'a>,
+        {
+            let value = self.0.borrow_mut().take().ok_or(Unspecified)?;
+            visitor.visit_passthrough(value)
+        }
+
+        fn decrypt_passthrough(self) -> Self::Ok<Self::Passthrough> {
+            Err(Unspecified)
+        }
+
+        fn decrypt_option<'a, T, A>(self, _aad: A) -> Self::Ok<Option<T>>
+        where
+            T: Decrypt<'c> + 'c,
+            A: IntoAad<'a>,
+        {
+            Err(Unspecified)
+        }
+    }
+
+    #[test]
+    fn encrypt_routes_through_the_boxed_passthrough_channel() {
+        let cipher = SpyCipher {
+            boxed: RefCell::new(None),
+        };
+        Passthrough(7u32)
+            .encrypt_with_aad(&cipher, "ignored")
+            .expect("passthrough must not fail");
+
+        let boxed = cipher
+            .boxed
+            .borrow_mut()
+            .take()
+            .expect("value reached passthrough_boxed");
+        assert_eq!(
+            *boxed
+                .downcast::<u32>()
+                .expect("payload is the original type"),
+            7
+        );
+    }
+
+    #[test]
+    fn decrypt_downcasts_the_payload_to_t() {
+        let decipher = PassthroughDecipher(RefCell::new(Some(Box::new(String::from("alice")))));
+        let got: Passthrough<String> =
+            Passthrough::decrypt(&decipher).expect("matching payload type decrypts");
+        assert_eq!(got, Passthrough("alice".to_string()));
+    }
+
+    #[test]
+    fn decrypt_rejects_a_foreign_payload_type() {
+        let decipher = PassthroughDecipher(RefCell::new(Some(Box::new(7u32))));
+        let got: Result<Passthrough<String>, _> = Passthrough::decrypt(&decipher);
+        assert!(
+            got.is_err(),
+            "a payload of another type must be an error, not a panic"
+        );
+    }
+}

--- a/packages/encrypt/tests/passthrough.rs
+++ b/packages/encrypt/tests/passthrough.rs
@@ -1,0 +1,178 @@
+//! End-to-end tests for `Passthrough` against the real AES-256-GCM cipher: a
+//! struct mixing encrypted and passthrough fields round-trips, the passthrough
+//! fields are readable in the stored ciphertext without a key, and a
+//! passthrough payload of the wrong type fails to decrypt cleanly.
+
+use vitaminc_aead::{
+    Cipher, Decipher, DecipherVisitor, Decrypt, Encrypt, IntoAad, MapAccess, MapCipher,
+    Passthrough, Unspecified,
+};
+use vitaminc_encrypt::{Aes256Cipher, AesCipherText, Key};
+
+fn cipher() -> Aes256Cipher {
+    Aes256Cipher::new(&Key::from([42u8; 32])).expect("failed to create cipher")
+}
+
+#[derive(Debug, PartialEq)]
+struct User {
+    id: u32,       // passthrough
+    email: String, // encrypted
+}
+
+impl Encrypt for User {
+    fn encrypt_with_aad<'a, C, A>(self, cipher: C, aad: A) -> Result<C::Ok, C::Error>
+    where
+        C: Cipher,
+        A: IntoAad<'a>,
+    {
+        cipher
+            .encrypt_map(aad)
+            .encrypt_entry("id", Passthrough(self.id))?
+            .encrypt_entry("email", self.email)?
+            .end()
+    }
+}
+
+impl<'c> Decrypt<'c> for User {
+    fn decrypt_with_aad<'a, D, A>(decipher: D, aad: A) -> D::Ok<Self>
+    where
+        D: Decipher<'c>,
+        A: IntoAad<'a>,
+    {
+        struct UserVisitor;
+        impl<'c> DecipherVisitor<'c> for UserVisitor {
+            type Value = User;
+
+            fn visit_map<M: MapAccess<'c>>(self, mut map: M) -> Result<User, Unspecified> {
+                let (k, Passthrough(id)) = map
+                    .next_entry::<Passthrough<u32>>()
+                    .map_err(|_| Unspecified)?
+                    .ok_or(Unspecified)?;
+                if k != "id" {
+                    return Err(Unspecified);
+                }
+                let (k, email) = map
+                    .next_entry::<String>()
+                    .map_err(|_| Unspecified)?
+                    .ok_or(Unspecified)?;
+                if k != "email" {
+                    return Err(Unspecified);
+                }
+                Ok(User { id, email })
+            }
+        }
+        decipher.decrypt_map(UserVisitor, aad)
+    }
+}
+
+#[test]
+fn mixed_struct_round_trips() {
+    let cipher = cipher();
+    let user = User {
+        id: 7,
+        email: "alice@example.com".into(),
+    };
+
+    let ciphertext = user
+        .encrypt_with_aad(&cipher, "users")
+        .expect("encryption failed");
+    let got: User = cipher
+        .decrypt_with_aad(ciphertext, "users")
+        .expect("decryption failed");
+
+    assert_eq!(
+        got,
+        User {
+            id: 7,
+            email: "alice@example.com".into()
+        }
+    );
+}
+
+#[test]
+fn passthrough_field_is_readable_in_the_stored_ciphertext() {
+    let cipher = cipher();
+    let user = User {
+        id: 7,
+        email: "alice@example.com".into(),
+    };
+
+    let ciphertext = user.encrypt(&cipher).expect("encryption failed");
+    let AesCipherText::Map(entries) = ciphertext else {
+        panic!("a struct encrypts to a map");
+    };
+    let (key, value) = &entries[0];
+    assert_eq!(key, "id");
+    let AesCipherText::Passthrough(boxed) = value else {
+        panic!("the passthrough field must be a passthrough node");
+    };
+    assert_eq!(boxed.downcast_ref::<u32>(), Some(&7));
+}
+
+#[test]
+fn vec_of_mixed_structs_round_trips() {
+    let cipher = cipher();
+    let users = vec![
+        User {
+            id: 1,
+            email: "a@example.com".into(),
+        },
+        User {
+            id: 2,
+            email: "b@example.com".into(),
+        },
+    ];
+
+    let ciphertext = users
+        .encrypt_with_aad(&cipher, "users")
+        .expect("encryption failed");
+    let got: Vec<User> = cipher
+        .decrypt_with_aad(ciphertext, "users")
+        .expect("decryption failed");
+
+    assert_eq!(got.len(), 2);
+    assert_eq!(got[0].id, 1);
+    assert_eq!(got[1].email, "b@example.com");
+}
+
+#[test]
+fn top_level_passthrough_round_trips() {
+    let cipher = cipher();
+    let ciphertext = Passthrough(String::from("display"))
+        .encrypt(&cipher)
+        .expect("encryption failed");
+    let got: Passthrough<String> = cipher.decrypt(ciphertext).expect("decryption failed");
+    assert_eq!(got.into_inner(), "display");
+}
+
+#[test]
+fn wrong_payload_type_fails_to_decrypt() {
+    let cipher = cipher();
+    let ciphertext = Passthrough(7u32)
+        .encrypt(&cipher)
+        .expect("encryption failed");
+    let got: Result<Passthrough<String>, _> = cipher.decrypt(ciphertext);
+    assert!(got.is_err());
+}
+
+#[test]
+fn passthrough_is_not_authenticated() {
+    // Documented caveat, pinned: altering a passthrough node in the stored
+    // ciphertext is not detected.
+    let cipher = cipher();
+    let user = User {
+        id: 7,
+        email: "alice@example.com".into(),
+    };
+    let ciphertext = user.encrypt(&cipher).expect("encryption failed");
+    let AesCipherText::Map(mut entries) = ciphertext else {
+        panic!("a struct encrypts to a map");
+    };
+    entries[0].1 = AesCipherText::Passthrough(Box::new(99u32));
+    let tampered = AesCipherText::Map(entries);
+
+    let got: User = cipher
+        .decrypt(tampered)
+        .expect("tampered passthrough still decrypts");
+    assert_eq!(got.id, 99);
+}


### PR DESCRIPTION
## What

Adds `vitaminc_aead::Passthrough<T>`: a wrapper carrying a value through the ciphertext container **without encrypting it**, as the typed front door to the existing `Cipher::passthrough_boxed` / `DecipherVisitor::visit_passthrough` channel.

```rust
cipher
    .encrypt_map(aad)
    .encrypt_entry("id", Passthrough(self.id))?   // in the clear
    .encrypt_entry("email", self.email)?          // encrypted
    .end()
```

```rust
let (_, Passthrough(id)) = map.next_entry::<Passthrough<u32>>()?.ok_or(Unspecified)?;
```

## Why

A custom type's `Encrypt` / `Decrypt` impl is generic over *every* cipher, so it cannot name a specific cipher's `Cipher::Passthrough` payload type and has no way to call `MapCipher::passthrough_entry` / `SeqCipher::passthrough_next` with a value it owns (an impl cannot add bounds the trait lacks). The type-erased hooks close the gap at the trait level, but every struct that wants a clear field today has to hand-roll the same `Encrypt` + visitor-downcast pair. This wrapper is that pair, once — and the thing a future `#[derive(Encrypt)]` would emit for a `#[encrypt(passthrough)]` field.

Dynamic-path counterpart of `hlist::Passthrough` (which serves the static HList encoding only).

## Behaviour

- `Encrypt`: hands the value to `passthrough_boxed`; AAD ignored (nothing to authenticate).
- `Decrypt`: expects a passthrough node and downcasts to `T`. Any other node shape, or a payload of a different type, is `Unspecified` — never a panic.
- Contract documented prominently: **non-sensitive data only, unauthenticated** (value and, for map entries, key can be altered undetectably). Pinned by a tamper test.

## Tests

- `aead` unit tests (spy cipher / decipher): encrypt routes through the boxed channel; decrypt downcasts; foreign payload type errors.
- `encrypt` integration tests against real AES-256-GCM: mixed struct round-trip, `Vec` of mixed structs, top-level passthrough, passthrough readable in stored ciphertext, wrong type fails, tamper-undetected caveat.
- README gains a "Passing fields through in the clear" section (compiled as a doctest).

Closes #298

Found while building the `stack-encrypt` target-directed layer in cipherstash-suite (cipherstash/cipherstash-suite#2147), whose `mixed_user` example currently carries a local copy of this wrapper.

https://claude.ai/code/session_01T5iYiJc6xwzMcHDtMwCadG
