### PR TITLE
feat(aead): bind cleartext fields into the AAD with #[aead(aad)]

### DIFF
--- a/packages/aead-derive/docs/attributes.md
+++ b/packages/aead-derive/docs/attributes.md
@@ -9,6 +9,7 @@ option is one the author believes is in effect.
 | `crate = "path"` | container | Name the path to `vitaminc_aead` in the generated code |
 | `rename = "name"` | field | Store the field under `name` instead of its own name |
 | `passthrough` | field | Store the field **in the clear**, unencrypted and unauthenticated |
+| `aad` | field | Store the field **in the clear**, bound into every encrypted field's AAD |
 
 ## `#[aead(crate = "...")]`
 
@@ -80,10 +81,9 @@ That independence is bought by giving up everything, and the trade is total:
 So: non-sensitive, non-security-deciding data only. Never a field the program
 then trusts to make an authorization choice.
 
-A cleartext field that must be tamper-evident needs to be bound into the AAD
-instead of passed through — and note that binding couples the two, so any
-independent write to that column would break decryption of every encrypted
-field beside it. That coupling is precisely what `passthrough` exists to avoid.
+A cleartext field that must be tamper-evident wants [`aad`](#aeadaad) instead —
+but read the coupling it introduces first. `passthrough` exists precisely to
+avoid that coupling.
 
 ### Requirements
 
@@ -100,3 +100,68 @@ Two shapes are rejected at compile time:
 - **`passthrough` on a newtype.** A newtype is transparent and opens no map, so
   there is no entry to store in the clear; honouring the attribute would mean
   the whole value travelled unencrypted.
+
+## `#[aead(aad)]`
+
+Stores a field in the clear like `passthrough`, and additionally binds its bytes
+into the associated data every encrypted field is sealed against. Editing the
+cleartext therefore stops those fields opening.
+
+The case it is for is searchable encrypted metadata: an index term derived from
+a value and stored beside it, so a query can use the term without the key.
+
+```ignore
+#[derive(Encrypt, Decrypt)]
+struct Row {
+    #[aead(aad)]
+    ore_term: Vec<u8>,   // clear, so a query can read it
+    ssn: String,         // encrypted, and bound to the term above
+}
+```
+
+Substituting `ore_term` in storage, deleting it, or transposing it with another
+`aad` field all make `ssn` fail to decrypt. The context is a labelled
+`PAE(domain, key, bytes, …)` over the `aad` fields in **declaration** order, so
+permuting the stored map cannot change it, and each value is bound to its own
+key.
+
+### ⚠️ The field is still cleartext, and now everything depends on it
+
+`aad` makes the field *tamper-evident*, not confidential or trustworthy on its
+own:
+
+- It is **not encrypted** — anyone who can read the ciphertext can read it.
+- Nothing detects a change to it *in isolation*; what happens is that the
+  encrypted fields stop decrypting. That is a loud failure, not a silent one,
+  but it is the only signal.
+
+And the coupling runs both ways. **Anything that rewrites the field
+independently breaks decryption of every encrypted field beside it.** A column
+some other process updates on its own is a `passthrough` field, never an `aad`
+one. `aad` fits a value *derived from* the encrypted data and rewritten only
+when that data is — which is exactly what an index term is.
+
+### Consequences
+
+- **Adding or removing an `aad` field is wire-breaking.** The derivation carries
+  its own domain label, so a ciphertext written with context cannot be read
+  without it, or the reverse. Existing data does not decode after the change.
+- **The decode becomes order-dependent.** An encrypted entry cannot be opened
+  until every `aad` field has been read, and `MapAccess` cannot skip ahead to
+  fetch one. The derive writes cleartext entries first, so its own ciphertexts
+  are fine; a map reordered in storage fails to decrypt. That is a denial of
+  service, not a forgery — entry order was never authenticated.
+
+### Requirements
+
+An `aad` field's type must be `AsRef<[u8]>`, which supplies the bytes that go
+into the context, as well as the `Any + Send + 'static` that storing it in the
+clear requires. `Vec<u8>`, `String`, and byte-array newtypes qualify; an integer
+does not — give it a byte encoding you are willing to commit to.
+
+`aad` and `passthrough` on one field is a compile error: `aad` already stores
+the value in the clear. `aad` on a newtype is rejected for the same reason
+`passthrough` is, with the addition that a newtype has no sibling field for the
+value to be bound to. A struct whose fields are *all* cleartext is rejected
+whichever attribute is used — an `aad` field needs at least one encrypted field
+to bind.

--- a/packages/aead-derive/src/attrs.rs
+++ b/packages/aead-derive/src/attrs.rs
@@ -39,12 +39,16 @@ pub(crate) struct FieldAttrs {
     /// `#[aead(passthrough)]`. The value is neither encrypted nor
     /// authenticated — see the crate docs.
     pub(crate) passthrough: bool,
+    /// Store this field in the clear *and* bind it into the associated data
+    /// every encrypted field is sealed against, from `#[aead(aad)]`.
+    pub(crate) aad: bool,
 }
 
 impl FieldAttrs {
     pub(crate) fn parse(attrs: &[Attribute]) -> Result<Self> {
         let mut rename: Option<String> = None;
         let mut passthrough = false;
+        let mut aad = false;
 
         for attr in attrs.iter().filter(|a| a.path().is_ident("aead")) {
             attr.parse_nested_meta(|meta| {
@@ -57,8 +61,13 @@ impl FieldAttrs {
                     passthrough = true;
                     return Ok(());
                 }
+                if meta.path.is_ident("aad") {
+                    aad = true;
+                    return Ok(());
+                }
                 Err(meta.error(
-                    "unsupported field attribute; expected `rename = \"...\"` or `passthrough`",
+                    "unsupported field attribute; expected `rename = \"...\"`, `passthrough` \
+                     or `aad`",
                 ))
             })?;
         }
@@ -66,6 +75,7 @@ impl FieldAttrs {
         Ok(Self {
             rename,
             passthrough,
+            aad,
         })
     }
 }

--- a/packages/aead-derive/src/decrypt.rs
+++ b/packages/aead-derive/src/decrypt.rs
@@ -110,6 +110,8 @@ pub(crate) fn derive(input: DeriveInput) -> Result<TokenStream> {
 /// would be wrong; matching on the key is also what makes heterogeneous field
 /// types possible at all.
 fn visit_map_body(krate: &syn::Path, name: &syn::Ident, fields: &[FieldInfo]) -> TokenStream {
+    let aad_fields: Vec<&FieldInfo> = fields.iter().filter(|field| field.aad).collect();
+
     let slots = fields.iter().map(|field| {
         let local = &field.local;
         let ty = &field.ty;
@@ -130,7 +132,7 @@ fn visit_map_body(krate: &syn::Path, name: &syn::Ident, fields: &[FieldInfo]) ->
                 return ::core::result::Result::Err(#krate::Unspecified);
             }
         };
-        let read = if field.passthrough {
+        let read = if field.is_cleartext() {
             // Nothing here is verified — no tag covers a passthrough entry and
             // nothing binds its key — so this value is untrusted input, exactly
             // as the column it came from is. The downcast is the only check:
@@ -141,10 +143,43 @@ fn visit_map_body(krate: &syn::Path, name: &syn::Ident, fields: &[FieldInfo]) ->
                     .downcast::<#ty>()
                     .map_err(|_| #krate::Unspecified)?
             }
-        } else {
+        } else if aad_fields.is_empty() {
             quote! {
                 <__M as #krate::MapAccess<'__c>>::next_value::<#ty>(&mut __map)
                     .map_err(|_| #krate::Unspecified)?
+            }
+        } else {
+            let pieces = aad_fields.iter().map(|field| {
+                let key = &field.key;
+                let local = &field.local;
+                quote! {
+                    (
+                        #key,
+                        ::core::convert::AsRef::<[u8]>::as_ref(
+                            // Every `aad` field has to be in hand already: its
+                            // bytes are part of what this value verifies
+                            // against, and `MapAccess` cannot skip ahead to
+                            // fetch one. The encrypt side writes them first, so
+                            // a conforming ciphertext arrives in that order and
+                            // a reordered one fails here.
+                            #local.as_ref().ok_or(#krate::Unspecified)?,
+                        ),
+                    )
+                }
+            });
+            // Rebuilt per encrypted field rather than cached: the borrow would
+            // have to outlive the match arm that produced it, and a handful of
+            // PAE encodings over a struct's cleartext is not worth the
+            // contortion.
+            quote! {
+                {
+                    let __context = #krate::Aad::field_context(&[#(#pieces),*]);
+                    <__M as #krate::MapAccess<'__c>>::next_value_with_context::<#ty>(
+                        &mut __map,
+                        #krate::Aad::as_bytes(&__context),
+                    )
+                    .map_err(|_| #krate::Unspecified)?
+                }
             }
         };
         quote! {
@@ -317,6 +352,48 @@ mod tests {
                 return ::core::result::Result::Err(::vitaminc_aead::Unspecified);
             }),
         );
+    }
+
+    /// The context is rebuilt from the `aad` slots, which must already be
+    /// filled — that `ok_or` is what refuses a ciphertext whose encrypted
+    /// entries arrive before the field they are bound to.
+    #[test]
+    fn an_encrypted_field_is_read_against_the_aad_context() {
+        let out = expand(parse_quote! {
+            struct Indexed {
+                #[aead(aad)]
+                ore_term: Vec<u8>,
+                ssn: String,
+            }
+        });
+
+        assert_contains(
+            &out,
+            quote!(let __context = ::vitaminc_aead::Aad::field_context(&[(
+                "ore_term",
+                ::core::convert::AsRef::<[u8]>::as_ref(
+                    __field_0.as_ref().ok_or(::vitaminc_aead::Unspecified)?,
+                ),
+            )]);),
+        );
+        assert_contains(&out, quote!(::next_value_with_context::<String>));
+        // The term is read through the unauthenticated path — nothing covers it.
+        assert_contains(&out, quote!(::next_passthrough(&mut __map)));
+    }
+
+    /// With no `aad` field the read must be the plain one, so ciphertexts
+    /// written before the attribute existed still decode.
+    #[test]
+    fn without_an_aad_field_the_plain_read_is_used() {
+        let out = expand(parse_quote! {
+            struct User {
+                name: String,
+            }
+        });
+
+        assert_contains(&out, quote!(::next_value::<String>(&mut __map)));
+        assert_lacks(&out, quote!(next_value_with_context));
+        assert_lacks(&out, quote!(::vitaminc_aead::Aad::field_context));
     }
 
     /// Mirrors the `Encrypt` side: a newtype decrypts as its inner type and is

--- a/packages/aead-derive/src/encrypt.rs
+++ b/packages/aead-derive/src/encrypt.rs
@@ -57,14 +57,16 @@ fn newtype_body(krate: &syn::Path, field: &FieldInfo) -> TokenStream {
 }
 
 fn map_body(krate: &syn::Path, fields: &[FieldInfo]) -> TokenStream {
-    let entries = fields.iter().map(|field| {
+    let aad_fields: Vec<&FieldInfo> = fields.iter().filter(|field| field.aad).collect();
+    let context = context_binding(krate, &aad_fields);
+
+    let entry = |field: &FieldInfo| {
         let key = &field.key;
         let member = &field.member;
-        if field.passthrough {
-            // Stored in the clear and bound to nothing — not the value, not
-            // even its key. That is what lets the entry be an ordinary
-            // database column other queries read and write independently of
-            // the encrypted ones.
+        if field.is_cleartext() {
+            // Stored in the clear. For an `aad` field the bytes are also in
+            // `__context` by now, which is what makes editing this entry break
+            // every encrypted one.
             quote! {
                 let __map = #krate::MapCipher::passthrough_entry_boxed(
                     __map,
@@ -72,20 +74,58 @@ fn map_body(krate: &syn::Path, fields: &[FieldInfo]) -> TokenStream {
                     ::std::boxed::Box::new(self.#member),
                 )?;
             }
-        } else {
+        } else if aad_fields.is_empty() {
             quote! {
                 let __map = #krate::MapCipher::encrypt_entry(__map, #key, self.#member)?;
             }
+        } else {
+            quote! {
+                let __map = #krate::MapCipher::encrypt_entry_with_context(
+                    __map,
+                    #key,
+                    self.#member,
+                    __context,
+                )?;
+            }
         }
-    });
+    };
+
+    // Cleartext entries are written first so a decoder meets every `aad` field
+    // before the values bound to it: `MapAccess` cannot skip ahead to fetch one
+    // later. Entry order is not authenticated, so grouping them costs nothing.
+    let cleartext = fields.iter().filter(|f| f.is_cleartext()).map(entry);
+    let encrypted = fields.iter().filter(|f| !f.is_cleartext()).map(entry);
 
     quote! {
+        #context
         // The AAD is captured once by `encrypt_map`; `encrypt_entry` binds
         // each field's key into the AAD its value is sealed against, so a
         // stored field cannot be renamed or moved to another key undetected.
         let __map = #krate::Cipher::encrypt_map(__cipher, __aad);
-        #(#entries)*
+        #(#cleartext)*
+        #(#encrypted)*
         #krate::MapCipher::end(__map)
+    }
+}
+
+/// Builds the context every encrypted field is bound to, from the `#[aead(aad)]`
+/// fields' bytes. Empty when there are none, leaving the expansion byte-identical
+/// to what it was before the attribute existed.
+///
+/// Evaluated before any field is moved into the map, and ordered by the struct's
+/// declaration — never by the stored map, whose order an attacker controls.
+fn context_binding(krate: &syn::Path, aad_fields: &[&FieldInfo]) -> TokenStream {
+    if aad_fields.is_empty() {
+        return quote!();
+    }
+    let pieces = aad_fields.iter().map(|field| {
+        let key = &field.key;
+        let member = &field.member;
+        quote!((#key, ::core::convert::AsRef::<[u8]>::as_ref(&self.#member)))
+    });
+    quote! {
+        let __context = #krate::Aad::field_context(&[#(#pieces),*]);
+        let __context = #krate::Aad::as_bytes(&__context);
     }
 }
 
@@ -212,6 +252,93 @@ mod tests {
                 __map,
                 "tenant",
                 self.tenant
+            )),
+        );
+    }
+
+    /// An `aad` field is stored in the clear like a passthrough, and its bytes
+    /// additionally become the context every encrypted entry is sealed
+    /// against. The context is built before any field is moved into the map.
+    #[test]
+    fn an_aad_field_becomes_the_context_for_every_encrypted_field() {
+        let out = expand(parse_quote! {
+            struct Indexed {
+                #[aead(aad)]
+                ore_term: Vec<u8>,
+                ssn: String,
+                dob: String,
+            }
+        });
+
+        assert_contains(
+            &out,
+            quote!(let __context = ::vitaminc_aead::Aad::field_context(&[(
+                "ore_term",
+                ::core::convert::AsRef::<[u8]>::as_ref(&self.ore_term)
+            )]);),
+        );
+        assert_contains(
+            &out,
+            quote!(::vitaminc_aead::MapCipher::encrypt_entry_with_context(
+                __map, "ssn", self.ssn, __context,
+            )),
+        );
+        assert_contains(
+            &out,
+            quote!(::vitaminc_aead::MapCipher::encrypt_entry_with_context(
+                __map, "dob", self.dob, __context,
+            )),
+        );
+        // The term itself is written in the clear, not encrypted.
+        assert_contains(
+            &out,
+            quote!(::vitaminc_aead::MapCipher::passthrough_entry_boxed(
+                __map,
+                "ore_term",
+                ::std::boxed::Box::new(self.ore_term),
+            )),
+        );
+    }
+
+    /// A decoder cannot skip ahead to fetch an `aad` field, so the entries it
+    /// needs must already have gone by. Cleartext entries are written first
+    /// regardless of where they were declared.
+    #[test]
+    fn cleartext_entries_are_written_before_encrypted_ones() {
+        let out = expand(parse_quote! {
+            struct Indexed {
+                ssn: String,
+                #[aead(aad)]
+                ore_term: Vec<u8>,
+            }
+        });
+
+        let term = out
+            .find("\"ore_term\" , :: std :: boxed")
+            .expect("term entry");
+        let ssn = out.find("\"ssn\"").expect("ssn entry");
+        assert!(
+            term < ssn,
+            "cleartext entry should be written first:\n{out}"
+        );
+    }
+
+    /// With no `aad` field the expansion must be exactly what it was before the
+    /// attribute existed — no context, and the plain `encrypt_entry` call.
+    #[test]
+    fn without_an_aad_field_no_context_is_built() {
+        let out = expand(parse_quote! {
+            struct User {
+                name: String,
+            }
+        });
+
+        assert_lacks(&out, quote!(::vitaminc_aead::Aad::field_context));
+        assert_lacks(&out, quote!(encrypt_entry_with_context));
+        assert_contains(
+            &out,
+            quote!(::vitaminc_aead::MapCipher::encrypt_entry(
+                __map, "name", self.name
             )),
         );
     }

--- a/packages/aead-derive/src/shape.rs
+++ b/packages/aead-derive/src/shape.rs
@@ -22,6 +22,10 @@ pub(crate) struct FieldInfo {
     /// `#[aead(passthrough)]`: stored in the clear, never encrypted and never
     /// authenticated.
     pub(crate) passthrough: bool,
+    /// `#[aead(aad)]`: stored in the clear like a passthrough, but also bound
+    /// into the associated data every encrypted field is sealed against, so
+    /// editing it stops those fields opening.
+    pub(crate) aad: bool,
     /// Whether [`key`](FieldInfo::key) came from `#[aead(rename = "...")]`
     /// rather than the field's own name. Only the newtype guard needs this —
     /// everywhere else the rename has already been folded into `key`.
@@ -78,8 +82,18 @@ impl Shape {
         }
 
         reject_duplicate_keys(&fields, input)?;
-        reject_all_passthrough(&fields, input)?;
+        reject_conflicting_cleartext_attrs(&fields, input)?;
+        reject_all_cleartext(&fields, input)?;
         Ok(Shape::Map(fields))
+    }
+}
+
+impl FieldInfo {
+    /// Whether the field is stored in the clear rather than encrypted. Both
+    /// `passthrough` and `aad` fields are; they differ only in whether the
+    /// stored bytes are bound into the encrypted fields' associated data.
+    pub(crate) fn is_cleartext(&self) -> bool {
+        self.passthrough || self.aad
     }
 }
 
@@ -100,6 +114,7 @@ fn collect(fields: &Fields) -> Result<Vec<FieldInfo>> {
                 local: Ident::new(&format!("__field_{index}"), Span::call_site()),
                 ty: field.ty.clone(),
                 passthrough: attrs.passthrough,
+                aad: attrs.aad,
                 renamed,
             })
         })
@@ -153,6 +168,14 @@ fn reject_newtype_field_attrs(field: &FieldInfo, input: &DeriveInput) -> Result<
              would be encrypted at all. Give the struct a named field instead.",
         ));
     }
+    if field.aad {
+        return Err(syn::Error::new_spanned(
+            &input.ident,
+            "`#[aead(aad)]` is meaningless on a newtype struct: a newtype is transparent, \
+             so there is no map entry to store the value in the clear and no other field \
+             for it to be bound to. Give the struct a named field instead.",
+        ));
+    }
     Ok(())
 }
 
@@ -160,15 +183,35 @@ fn reject_newtype_field_attrs(field: &FieldInfo, input: &DeriveInput) -> Result<
 /// authenticates the map's AAD, and nothing binds the entry keys — so
 /// `MapCipher::end` rejects one at seal time. Catch it here, where the error
 /// names the struct instead of surfacing as a runtime encrypt failure.
-fn reject_all_passthrough(fields: &[FieldInfo], input: &DeriveInput) -> Result<()> {
-    if fields.iter().all(|field| field.passthrough) {
+fn reject_all_cleartext(fields: &[FieldInfo], input: &DeriveInput) -> Result<()> {
+    if fields.iter().all(FieldInfo::is_cleartext) {
         return Err(syn::Error::new_spanned(
             &input.ident,
-            "every field is `#[aead(passthrough)]`, so nothing would be encrypted and the \
-             ciphertext would carry no tag — neither the associated data nor the entry keys \
-             would be authenticated. Encrypt at least one field, or do not derive Encrypt for \
-             this struct at all.",
+            "every field is stored in the clear (`#[aead(passthrough)]` or `#[aead(aad)]`), so \
+             nothing would be encrypted and the ciphertext would carry no tag — neither the \
+             associated data nor the entry keys would be authenticated. An `aad` field binds \
+             encrypted fields to itself, so it needs at least one to bind. Encrypt at least \
+             one field, or do not derive Encrypt for this struct at all.",
         ));
+    }
+    Ok(())
+}
+
+/// `aad` already stores the field in the clear — it is `passthrough` plus the
+/// binding. Accepting both would leave the author guessing which won.
+fn reject_conflicting_cleartext_attrs(fields: &[FieldInfo], input: &DeriveInput) -> Result<()> {
+    for field in fields {
+        if field.passthrough && field.aad {
+            return Err(syn::Error::new_spanned(
+                &input.ident,
+                format!(
+                    "field `{}` is both `#[aead(passthrough)]` and `#[aead(aad)]`: `aad` \
+                     already stores the value in the clear, and additionally binds it into \
+                     the associated data. Use one or the other.",
+                    field.key
+                ),
+            ));
+        }
     }
     Ok(())
 }
@@ -244,6 +287,50 @@ mod tests {
         );
         let err = Shape::parse(&input).expect_err("renamed newtype should be rejected");
         assert!(err.to_string().contains("no effect on a newtype"));
+    }
+
+    /// `aad` is `passthrough` plus a binding, so asking for both leaves the
+    /// author guessing which won.
+    #[test]
+    fn aad_and_passthrough_on_one_field_is_rejected() {
+        let input: DeriveInput = parse_quote! {
+            struct Row {
+                #[aead(aad, passthrough)]
+                term: Vec<u8>,
+                ssn: String,
+            }
+        };
+        let err = Shape::parse(&input).expect_err("conflicting attributes should be rejected");
+        assert!(err
+            .to_string()
+            .contains("already stores the value in the clear"));
+    }
+
+    /// An `aad` field binds encrypted fields to itself, so a struct of nothing
+    /// but cleartext has neither anything to bind nor any tag at all.
+    #[test]
+    fn a_struct_of_only_cleartext_fields_is_rejected() {
+        let input: DeriveInput = parse_quote! {
+            struct Row {
+                #[aead(aad)]
+                term: Vec<u8>,
+                #[aead(passthrough)]
+                id: i64,
+            }
+        };
+        let err = Shape::parse(&input).expect_err("all-cleartext struct should be rejected");
+        assert!(err.to_string().contains("nothing would be encrypted"));
+    }
+
+    /// A newtype is transparent: nothing is stored under a key, and there is no
+    /// sibling field for the value to be bound to.
+    #[test]
+    fn aad_on_a_newtype_is_rejected() {
+        let input: DeriveInput = parse_quote!(
+            struct Term(#[aead(aad)] Vec<u8>);
+        );
+        let err = Shape::parse(&input).expect_err("aad newtype should be rejected");
+        assert!(err.to_string().contains("meaningless on a newtype"));
     }
 
     /// A newtype is transparent, so there is no map entry for a passthrough to

--- a/packages/aead-value/src/value.rs
+++ b/packages/aead-value/src/value.rs
@@ -582,6 +582,17 @@ mod tests {
                 Err(Unspecified)
             }
 
+            fn encrypt_value_with_context<T>(
+                self,
+                _value: T,
+                _context: &[u8],
+            ) -> Result<Self, Self::Error>
+            where
+                T: Encrypt,
+            {
+                Ok(self)
+            }
+
             fn passthrough_entry_boxed<K>(
                 self,
                 _key: K,

--- a/packages/aead/README.md
+++ b/packages/aead/README.md
@@ -134,6 +134,14 @@ impl<'c> MapCipher for MyMapCipher<'c> {
         T: vitaminc_aead::Encrypt,
     { unimplemented!() }
 
+    // Same binding as `encrypt_value`, plus cleartext context the whole map's
+    // encrypted entries are bound to — derive it through
+    // `Aad::for_map_entry_with_context`, which carries its own domain label.
+    fn encrypt_value_with_context<T>(self, _value: T, _context: &[u8]) -> Result<Self, Self::Error>
+    where
+        T: vitaminc_aead::Encrypt,
+    { unimplemented!() }
+
     fn passthrough_entry<K>(self, _key: K, _value: Self::Passthrough) -> Result<Self, Self::Error>
     where
         K: Into<std::borrow::Cow<'static, str>>,

--- a/packages/aead/src/aad/mod.rs
+++ b/packages/aead/src/aad/mod.rs
@@ -81,6 +81,59 @@ impl<'a> Aad<'a> {
         pae::encode(&[MAP_ENTRY_DOMAIN, self.as_bytes(), key.as_bytes()])
     }
 
+    /// Derives the AAD a map entry's value must be sealed against when the map
+    /// also carries **cleartext context** that every encrypted entry is bound
+    /// to — a searchable index term stored beside the value it was derived
+    /// from, say.
+    ///
+    /// Where [`for_map_entry`](Aad::for_map_entry) binds only the entry's own
+    /// key, this additionally binds `context`, so editing the cleartext the
+    /// context was built from makes every value sealed against it fail to
+    /// open. The caller is responsible for `context` being an unambiguous
+    /// encoding of that cleartext — [`pae`](Aad::pae) over the contributing
+    /// (key, value) pairs in a fixed order is the intended construction, since
+    /// a positional or concatenated encoding would let two fields trade
+    /// content undetected.
+    ///
+    /// The encoding is `PAE(domain, aad, key, context)` under a **different**
+    /// domain label from `for_map_entry`. That separation is the point: a
+    /// ciphertext sealed with context can never verify as one sealed without
+    /// it, so the context-bearing entries cannot be stripped out and read as
+    /// an ordinary map.
+    pub fn for_map_entry_with_context(&self, key: &str, context: &[u8]) -> Aad<'static> {
+        const MAP_ENTRY_CONTEXT_DOMAIN: &[u8] = b"vitaminc/aead/map-entry-context/v1";
+        pae::encode(&[
+            MAP_ENTRY_CONTEXT_DOMAIN,
+            self.as_bytes(),
+            key.as_bytes(),
+            context,
+        ])
+    }
+
+    /// Builds the `context` argument for
+    /// [`for_map_entry_with_context`](Aad::for_map_entry_with_context) from the
+    /// cleartext fields that contribute to it, given as `(key, bytes)` pairs.
+    ///
+    /// The encoding is a labelled `PAE(domain, key, bytes, key, bytes, …)`.
+    /// PAE length-prefixes every piece, so no two different field sets encode
+    /// alike: two fields cannot trade contents, and no run of bytes can be
+    /// re-split across the key/value boundary.
+    ///
+    /// **Order is part of the encoding.** Callers must pass the fields in an
+    /// order fixed by something other than the stored ciphertext — a struct's
+    /// declaration order, say — or a stored map could be permuted to change
+    /// the context, and with it what every value verifies against.
+    pub fn field_context(fields: &[(&str, &[u8])]) -> Aad<'static> {
+        const FIELD_CONTEXT_DOMAIN: &[u8] = b"vitaminc/aead/field-context/v1";
+        let mut pieces: Vec<&[u8]> = Vec::with_capacity(fields.len() * 2 + 1);
+        pieces.push(FIELD_CONTEXT_DOMAIN);
+        for (key, bytes) in fields {
+            pieces.push(key.as_bytes());
+            pieces.push(bytes);
+        }
+        pae::encode(&pieces)
+    }
+
     /// Derives the AAD a structural marker must be sealed against.
     ///
     /// Markers are sealed empty plaintexts whose tag is the only thing
@@ -286,6 +339,92 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The whole reason `for_map_entry_with_context` carries its own domain
+    /// label: an entry sealed with context must not verify as one sealed
+    /// without it, or the context-bearing entries could be stripped from a
+    /// stored ciphertext and read as an ordinary map.
+    #[test]
+    fn context_entries_are_disjoint_from_plain_entries() {
+        let aad = Aad::from_slice(b"tenant:1");
+        assert_ne!(
+            aad.for_map_entry("ssn").as_bytes(),
+            aad.for_map_entry_with_context("ssn", b"").as_bytes(),
+        );
+    }
+
+    /// Changing the context changes the AAD, which is what makes editing the
+    /// cleartext it was built from break every value sealed against it.
+    #[test]
+    fn a_different_context_derives_a_different_aad() {
+        let aad = Aad::from_slice(b"tenant:1");
+        assert_ne!(
+            aad.for_map_entry_with_context("ssn", b"term-a").as_bytes(),
+            aad.for_map_entry_with_context("ssn", b"term-b").as_bytes(),
+        );
+    }
+
+    /// The key stays bound too, so an entry cannot be moved to another key
+    /// just because both share a context.
+    #[test]
+    fn the_entry_key_is_still_bound_alongside_the_context() {
+        let aad = Aad::from_slice(b"tenant:1");
+        assert_ne!(
+            aad.for_map_entry_with_context("ssn", b"term").as_bytes(),
+            aad.for_map_entry_with_context("dob", b"term").as_bytes(),
+        );
+    }
+
+    /// PAE is length-prefixed per piece, so a key/context split cannot be
+    /// shifted to produce the same encoding from different inputs.
+    #[test]
+    fn the_key_and_context_boundary_is_unambiguous() {
+        let aad = Aad::empty();
+        assert_ne!(
+            aad.for_map_entry_with_context("ab", b"c").as_bytes(),
+            aad.for_map_entry_with_context("a", b"bc").as_bytes(),
+        );
+    }
+
+    /// Two fields trading contents must not encode alike, or a stored map
+    /// could have its cleartext shuffled without any value noticing.
+    #[test]
+    fn field_context_binds_each_value_to_its_own_key() {
+        assert_ne!(
+            Aad::field_context(&[("a", b"1"), ("b", b"2")]).as_bytes(),
+            Aad::field_context(&[("a", b"2"), ("b", b"1")]).as_bytes(),
+        );
+    }
+
+    /// Order is part of the encoding — callers fix it from something the
+    /// stored ciphertext cannot influence.
+    #[test]
+    fn field_context_is_order_sensitive() {
+        assert_ne!(
+            Aad::field_context(&[("a", b"1"), ("b", b"2")]).as_bytes(),
+            Aad::field_context(&[("b", b"2"), ("a", b"1")]).as_bytes(),
+        );
+    }
+
+    /// PAE length-prefixes every piece, so a boundary cannot be shifted to
+    /// produce one encoding from two different field sets.
+    #[test]
+    fn field_context_boundaries_are_unambiguous() {
+        assert_ne!(
+            Aad::field_context(&[("ab", b"c")]).as_bytes(),
+            Aad::field_context(&[("a", b"bc")]).as_bytes(),
+        );
+        assert_ne!(
+            Aad::field_context(&[("a", b""), ("b", b"")]).as_bytes(),
+            Aad::field_context(&[("ab", b"")]).as_bytes(),
+        );
+    }
+
+    /// No fields is still a domain-labelled encoding, not the empty string.
+    #[test]
+    fn an_empty_field_context_is_not_empty_bytes() {
+        assert!(!Aad::field_context(&[]).is_empty());
+    }
 
     #[test]
     fn test_aad() {

--- a/packages/aead/src/cipher.rs
+++ b/packages/aead/src/cipher.rs
@@ -289,6 +289,43 @@ pub trait MapCipher: Sized {
         self.encrypt_key(key).and_then(|mc| mc.encrypt_value(value))
     }
 
+    /// Encrypt the value for the most recently supplied key, additionally
+    /// binding `context` — cleartext carried elsewhere in the same map that
+    /// every encrypted entry must be inseparable from.
+    ///
+    /// Implementations must derive the effective AAD through
+    /// [`Aad::for_map_entry_with_context`](crate::Aad::for_map_entry_with_context)
+    /// rather than [`for_map_entry`](crate::Aad::for_map_entry). The two use
+    /// different domain labels, so entries sealed with context and entries
+    /// sealed without it are mutually unreadable — a map cannot have its
+    /// context-bearing values quietly reinterpreted as plain ones.
+    ///
+    /// The motivating case is searchable encrypted metadata: an index term
+    /// derived from a value and stored in the clear beside it, so a query can
+    /// use it without the key. Binding the term into the value's AAD means a
+    /// term substituted in storage does not go unnoticed — the value it
+    /// indexes stops opening.
+    fn encrypt_value_with_context<T>(self, value: T, context: &[u8]) -> Result<Self, Self::Error>
+    where
+        T: Encrypt;
+
+    /// Convenience for [`encrypt_key`](MapCipher::encrypt_key) followed by
+    /// [`encrypt_value_with_context`](MapCipher::encrypt_value_with_context).
+    fn encrypt_entry_with_context<K, T>(
+        self,
+        key: K,
+        value: T,
+        context: &[u8],
+    ) -> Result<Self, Self::Error>
+    where
+        K: Into<Cow<'static, str>>,
+        T: Encrypt,
+        Self: Sized,
+    {
+        self.encrypt_key(key)
+            .and_then(|mc| mc.encrypt_value_with_context(value, context))
+    }
+
     /// Insert a passthrough (unencrypted) entry under `key`. Equivalent to
     /// [`encrypt_key`](MapCipher::encrypt_key) followed by storing the value
     /// without AEAD treatment.

--- a/packages/aead/src/decipher/mod.rs
+++ b/packages/aead/src/decipher/mod.rs
@@ -289,6 +289,26 @@ pub trait MapAccess<'c> {
     /// implementations must return an error.
     fn next_value<T: Decrypt<'c> + 'c>(&mut self) -> Result<T, Self::Error>;
 
+    /// Decrypt the value for the most recently returned key, additionally
+    /// binding `context` — the decrypt-side counterpart of
+    /// [`MapCipher::encrypt_value_with_context`](crate::MapCipher::encrypt_value_with_context).
+    ///
+    /// Implementations must derive the effective AAD through
+    /// [`Aad::for_map_entry_with_context`](crate::Aad::for_map_entry_with_context),
+    /// mirroring the encrypt side exactly. Because that derivation carries its
+    /// own domain label, passing the wrong `context` — or reading a
+    /// context-bearing entry through
+    /// [`next_value`](MapAccess::next_value), or the reverse — fails
+    /// authentication rather than returning a value built from the wrong
+    /// assumptions.
+    ///
+    /// Calling this without a pending key is a contract violation;
+    /// implementations must return an error.
+    fn next_value_with_context<T: Decrypt<'c> + 'c>(
+        &mut self,
+        context: &[u8],
+    ) -> Result<T, Self::Error>;
+
     /// Take the value belonging to the key most recently returned by
     /// [`next_key`](MapAccess::next_key) as a **passthrough** payload,
     /// consuming the pending entry.

--- a/packages/aead/src/test_util.rs
+++ b/packages/aead/src/test_util.rs
@@ -137,6 +137,13 @@ impl MapCipher for UnusedMap {
         Ok(self)
     }
 
+    fn encrypt_value_with_context<T>(self, _value: T, _context: &[u8]) -> Result<Self, Self::Error>
+    where
+        T: Encrypt,
+    {
+        Ok(self)
+    }
+
     fn passthrough_entry_boxed<K>(
         self,
         _key: K,
@@ -293,6 +300,16 @@ impl<'c> MapAccess<'c> for MockMapAccess {
         let payload = self.pending.take().ok_or(Unspecified)?;
         let decipher = MockDecipher::new(payload);
         T::decrypt_with_aad(&decipher, crate::Aad::empty())
+    }
+
+    /// The mock authenticates nothing, so context is accepted and ignored —
+    /// what it exists to exercise is the `MapAccess` call sequence, not the
+    /// AAD derivation, which `AesMapAccess` covers.
+    fn next_value_with_context<T: crate::Decrypt<'c> + 'c>(
+        &mut self,
+        _context: &[u8],
+    ) -> Result<T, Self::Error> {
+        self.next_value::<T>()
     }
 
     /// The mock stores every entry as an encrypted payload, so there is no

--- a/packages/aead/tests/ui/derive/aad_and_passthrough_conflict.rs
+++ b/packages/aead/tests/ui/derive/aad_and_passthrough_conflict.rs
@@ -1,0 +1,12 @@
+// `aad` is `passthrough` plus a binding, so asking for both leaves it ambiguous
+// which was meant.
+use vitaminc_aead::{Decrypt, Encrypt};
+
+#[derive(Encrypt, Decrypt)]
+struct Row {
+    #[aead(aad, passthrough)]
+    term: Vec<u8>,
+    ssn: String,
+}
+
+fn main() {}

--- a/packages/aead/tests/ui/derive/aad_and_passthrough_conflict.stderr
+++ b/packages/aead/tests/ui/derive/aad_and_passthrough_conflict.stderr
@@ -1,0 +1,5 @@
+error: field `term` is both `#[aead(passthrough)]` and `#[aead(aad)]`: `aad` already stores the value in the clear, and additionally binds it into the associated data. Use one or the other.
+ --> tests/ui/derive/aad_and_passthrough_conflict.rs:6:8
+  |
+6 | struct Row {
+  |        ^^^

--- a/packages/aead/tests/ui/derive/aad_on_newtype.rs
+++ b/packages/aead/tests/ui/derive/aad_on_newtype.rs
@@ -1,0 +1,8 @@
+// A newtype is transparent: nothing is stored under a key, and there is no
+// sibling field for the value to be bound to.
+use vitaminc_aead::{Decrypt, Encrypt};
+
+#[derive(Encrypt, Decrypt)]
+struct Term(#[aead(aad)] Vec<u8>);
+
+fn main() {}

--- a/packages/aead/tests/ui/derive/aad_on_newtype.stderr
+++ b/packages/aead/tests/ui/derive/aad_on_newtype.stderr
@@ -1,0 +1,5 @@
+error: `#[aead(aad)]` is meaningless on a newtype struct: a newtype is transparent, so there is no map entry to store the value in the clear and no other field for it to be bound to. Give the struct a named field instead.
+ --> tests/ui/derive/aad_on_newtype.rs:6:8
+  |
+6 | struct Term(#[aead(aad)] Vec<u8>);
+  |        ^^^^

--- a/packages/aead/tests/ui/derive/all_fields_cleartext.rs
+++ b/packages/aead/tests/ui/derive/all_fields_cleartext.rs
@@ -1,0 +1,13 @@
+// An `aad` field binds the encrypted fields to itself, so a struct with none
+// has nothing to bind — and, like an all-passthrough struct, no tag at all.
+use vitaminc_aead::{Decrypt, Encrypt};
+
+#[derive(Encrypt, Decrypt)]
+struct Row {
+    #[aead(aad)]
+    term: Vec<u8>,
+    #[aead(passthrough)]
+    id: i64,
+}
+
+fn main() {}

--- a/packages/aead/tests/ui/derive/all_fields_cleartext.stderr
+++ b/packages/aead/tests/ui/derive/all_fields_cleartext.stderr
@@ -1,5 +1,5 @@
 error: every field is stored in the clear (`#[aead(passthrough)]` or `#[aead(aad)]`), so nothing would be encrypted and the ciphertext would carry no tag — neither the associated data nor the entry keys would be authenticated. An `aad` field binds encrypted fields to itself, so it needs at least one to bind. Encrypt at least one field, or do not derive Encrypt for this struct at all.
- --> tests/ui/derive/all_fields_passthrough.rs:7:8
+ --> tests/ui/derive/all_fields_cleartext.rs:6:8
   |
-7 | struct Row {
+6 | struct Row {
   |        ^^^

--- a/packages/aead/tests/ui/derive/unknown_field_attribute.stderr
+++ b/packages/aead/tests/ui/derive/unknown_field_attribute.stderr
@@ -1,4 +1,4 @@
-error: unsupported field attribute; expected `rename = "..."` or `passthrough`
+error: unsupported field attribute; expected `rename = "..."`, `passthrough` or `aad`
  --> tests/ui/derive/unknown_field_attribute.rs:7:12
   |
 7 |     #[aead(passthru)]

--- a/packages/encrypt/src/cipher.rs
+++ b/packages/encrypt/src/cipher.rs
@@ -365,6 +365,26 @@ impl<'c> MapCipher for AesMapCipher<'c> {
         Ok(self)
     }
 
+    fn encrypt_value_with_context<U>(
+        mut self,
+        value: U,
+        context: &[u8],
+    ) -> Result<Self, Self::Error>
+    where
+        U: Encrypt,
+    {
+        let key = self.current_key.take().ok_or(Unspecified)?;
+        // Same binding as `encrypt_value`, plus the map's cleartext context —
+        // and under a distinct domain label, so these entries cannot be read
+        // back as context-free ones. `AesMapAccess::next_value_with_context`
+        // derives the identical AAD.
+        let entry_aad = self.aad.for_map_entry_with_context(&key, context);
+        let encrypted = value.encrypt_with_aad(self.cipher, entry_aad)?;
+        self.encrypted |= !matches!(encrypted, AesCipherText::Passthrough(_));
+        self.entries.push((key.into_owned(), encrypted));
+        Ok(self)
+    }
+
     fn passthrough_entry<K>(mut self, key: K, value: Self::Passthrough) -> Result<Self, Self::Error>
     where
         K: Into<Cow<'static, str>>,
@@ -772,6 +792,17 @@ impl<'c> MapAccess<'c> for AesMapAccess<'c, '_> {
         // Mirror `AesMapCipher::encrypt_value`: the value was sealed against
         // PAE(domain, aad, key), so a swapped or renamed key fails here.
         let entry_aad = self.aad.for_map_entry(&key);
+        T::decrypt_with_aad(decipher, entry_aad)
+    }
+
+    fn next_value_with_context<T: Decrypt<'c> + 'c>(
+        &mut self,
+        context: &[u8],
+    ) -> Result<T, Self::Error> {
+        let (key, ct) = self.pending.take().ok_or(Unspecified)?;
+        let decipher = self.cipher.decipher(ct);
+        // Mirror `AesMapCipher::encrypt_value_with_context`.
+        let entry_aad = self.aad.for_map_entry_with_context(&key, context);
         T::decrypt_with_aad(decipher, entry_aad)
     }
 

--- a/packages/encrypt/tests/derive.rs
+++ b/packages/encrypt/tests/derive.rs
@@ -539,3 +539,211 @@ fn roundtrip_non_usize_const_generic() {
 
     assert_eq!(decrypted.value, "x");
 }
+
+/// A row carrying searchable encrypted metadata: an index term derived from
+/// the value, stored in the clear so a query can use it without the key, and
+/// bound into the associated data so it cannot be substituted.
+#[derive(Encrypt, Decrypt, Debug, PartialEq)]
+struct Indexed {
+    #[aead(aad)]
+    ore_term: Vec<u8>,
+    #[aead(passthrough)]
+    id: i64,
+    ssn: String,
+}
+
+/// Same fields and same keys, but the term is a plain passthrough — used to
+/// show the two ciphertexts are not interchangeable.
+#[derive(Encrypt, Decrypt, Debug, PartialEq)]
+struct Unindexed {
+    #[aead(passthrough)]
+    ore_term: Vec<u8>,
+    #[aead(passthrough)]
+    id: i64,
+    ssn: String,
+}
+
+fn indexed() -> Indexed {
+    Indexed {
+        ore_term: vec![1, 2, 3, 4],
+        id: 7,
+        ssn: "123-45-6789".to_string(),
+    }
+}
+
+#[test]
+fn roundtrip_with_an_aad_field() {
+    let cipher = cipher();
+
+    let ciphertext = indexed().encrypt(&cipher).expect("encryption failed");
+    let decrypted: Indexed = cipher.decrypt(ciphertext).expect("decryption failed");
+
+    assert_eq!(decrypted, indexed());
+}
+
+/// An `aad` field is still stored in the clear — a query has to be able to read
+/// the term without the key, which is the entire reason it is not encrypted.
+#[test]
+fn an_aad_field_is_readable_without_the_key() {
+    let cipher = cipher();
+    let ciphertext = indexed().encrypt(&cipher).expect("encryption failed");
+
+    let entries = match &ciphertext {
+        vitaminc_aead::CipherText::Map(entries) => entries,
+        other => panic!("expected a Map ciphertext, got {other:?}"),
+    };
+    let term = entries
+        .iter()
+        .find(|(k, _)| k == "ore_term")
+        .map(|(_, v)| v)
+        .expect("ore_term entry missing");
+
+    match term {
+        vitaminc_aead::CipherText::Passthrough(value) => {
+            let value = value.downcast_ref::<Vec<u8>>().expect("wrong payload type");
+            assert_eq!(value, &vec![1, 2, 3, 4]);
+        }
+        other => panic!("expected a Passthrough node, got {other:?}"),
+    }
+}
+
+/// The property `#[aead(aad)]` exists for: substituting the index term in
+/// storage makes the value it indexes fail to open.
+#[test]
+fn substituting_an_aad_field_breaks_decryption() {
+    let cipher = cipher();
+    let ciphertext = indexed().encrypt(&cipher).expect("encryption failed");
+
+    let tampered = rewrite_entry(
+        ciphertext,
+        "ore_term",
+        vitaminc_aead::CipherText::Passthrough(Box::new(vec![9u8, 9, 9, 9])),
+    );
+
+    assert!(cipher.decrypt::<Indexed>(tampered).is_err());
+}
+
+/// The contrast that shows the binding is doing the work: the same edit to a
+/// plain `passthrough` field in the same struct is accepted, because nothing
+/// binds it.
+#[test]
+fn substituting_a_plain_passthrough_field_does_not() {
+    let cipher = cipher();
+    let ciphertext = indexed().encrypt(&cipher).expect("encryption failed");
+
+    let rewritten = rewrite_entry(
+        ciphertext,
+        "id",
+        vitaminc_aead::CipherText::Passthrough(Box::new(99i64)),
+    );
+
+    let decrypted: Indexed = cipher.decrypt(rewritten).expect("decryption failed");
+    assert_eq!(decrypted.id, 99);
+    assert_eq!(decrypted.ssn, "123-45-6789");
+}
+
+/// Deleting the term is not a way around the binding: the value that depends
+/// on it has nothing to verify against.
+#[test]
+fn deleting_an_aad_field_breaks_decryption() {
+    let cipher = cipher();
+    let ciphertext = indexed().encrypt(&cipher).expect("encryption failed");
+
+    let truncated = match ciphertext {
+        vitaminc_aead::CipherText::Map(entries) => vitaminc_aead::CipherText::Map(
+            entries
+                .into_iter()
+                .filter(|(k, _)| k != "ore_term")
+                .collect(),
+        ),
+        other => panic!("expected a Map ciphertext, got {other:?}"),
+    };
+
+    assert!(cipher.decrypt::<Indexed>(truncated).is_err());
+}
+
+/// `for_map_entry_with_context` carries its own domain label, so a value
+/// sealed against a context cannot be read as one sealed without — the
+/// binding cannot be dropped by decoding into a type that ignores it.
+#[test]
+fn a_bound_ciphertext_cannot_be_read_as_an_unbound_one() {
+    let cipher = cipher();
+
+    let bound = indexed().encrypt(&cipher).expect("encryption failed");
+    assert!(cipher.decrypt::<Unindexed>(bound).is_err());
+
+    let unbound = Unindexed {
+        ore_term: vec![1, 2, 3, 4],
+        id: 7,
+        ssn: "123-45-6789".to_string(),
+    }
+    .encrypt(&cipher)
+    .expect("encryption failed");
+    assert!(cipher.decrypt::<Indexed>(unbound).is_err());
+}
+
+#[derive(Encrypt, Decrypt, Debug, PartialEq)]
+struct TwoTerms {
+    #[aead(aad)]
+    first: Vec<u8>,
+    #[aead(aad)]
+    second: Vec<u8>,
+    ssn: String,
+}
+
+/// The context binds each value to its own key, so two terms of equal length
+/// cannot be transposed in storage — the same property the map shape gives
+/// encrypted fields, extended to the cleartext ones.
+#[test]
+fn transposing_two_aad_fields_breaks_decryption() {
+    let cipher = cipher();
+
+    let ciphertext = TwoTerms {
+        first: vec![1, 1, 1, 1],
+        second: vec![2, 2, 2, 2],
+        ssn: "123-45-6789".to_string(),
+    }
+    .encrypt(&cipher)
+    .expect("encryption failed");
+
+    let swapped = match ciphertext {
+        vitaminc_aead::CipherText::Map(entries) => vitaminc_aead::CipherText::Map(
+            entries
+                .into_iter()
+                .map(|(k, v)| match k.as_str() {
+                    "first" => ("second".to_string(), v),
+                    "second" => ("first".to_string(), v),
+                    _ => (k, v),
+                })
+                .collect(),
+        ),
+        other => panic!("expected a Map ciphertext, got {other:?}"),
+    };
+
+    assert!(cipher.decrypt::<TwoTerms>(swapped).is_err());
+}
+
+/// `MapAccess` cannot skip ahead, so an `aad` field has to arrive before the
+/// values bound to it. The derive writes cleartext entries first; a ciphertext
+/// reordered in storage fails to decrypt rather than decoding against a
+/// context it cannot yet build. That is a denial of service, not a forgery —
+/// entry order was never authenticated.
+#[test]
+fn an_encrypted_entry_before_its_aad_field_is_refused() {
+    let cipher = cipher();
+    let ciphertext = indexed().encrypt(&cipher).expect("encryption failed");
+
+    let reordered = match ciphertext {
+        vitaminc_aead::CipherText::Map(entries) => {
+            let mut entries = entries;
+            // Longest key last, which puts the encrypted `ssn` first.
+            entries.sort_by_key(|(k, _)| std::cmp::Reverse(k.len()));
+            assert_eq!(entries[0].0, "ore_term", "expected the term to sort first");
+            entries.reverse();
+            vitaminc_aead::CipherText::Map(entries)
+        }
+        other => panic!("expected a Map ciphertext, got {other:?}"),
+    };
+
+    assert!(cipher.decrypt::<Indexed>(reordered).is_err());
+}


### PR DESCRIPTION
Stacked on #287 — please merge that first.

Adds `#[aead(aad)]`: a field stored in the clear, like `#[aead(passthrough)]`, whose bytes are additionally bound into the associated data every encrypted field is sealed against.

## Why

Searchable encrypted metadata — an ORE term, an index term — has to travel in the clear so a query can use it without the key. But unlike an ordinary plaintext column it is **derived from** the value beside it, and rewritten only when that value is. `passthrough` is the wrong shape: nothing would stop a term being swapped in storage, silently pointing an index at a value it was never computed from.

```rust
#[derive(Encrypt, Decrypt)]
struct Row {
    #[aead(aad)]
    ore_term: Vec<u8>,   // clear, so a query can read it
    ssn: String,         // encrypted, and bound to the term above
}
```

Substituting `ore_term` in storage, deleting it, or transposing it with another `aad` field all make `ssn` fail to decrypt.

## Why it needed new protocol surface

The binding cannot live in the map's AAD. `Cipher::encrypt_map` fixes that before any entry exists — encrypt could fold the term in, but decrypt has not read it yet. So the binding moves down to each entry:

```rust
Aad::field_context(&[(key, bytes), …])          // canonical context encoding
Aad::for_map_entry_with_context(key, context)
MapCipher::encrypt_value_with_context(value, context)
MapAccess::next_value_with_context::<T>(context)
```

- **`field_context`** is a labelled `PAE(domain, key, bytes, …)` over the `aad` fields in **declaration** order — so permuting a stored map cannot change it, and each value stays bound to its own key.
- **`for_map_entry_with_context`** carries a domain label distinct from `for_map_entry`. That is what stops a context-bearing ciphertext being read as a context-free one: the binding cannot be dropped by decoding into a type that ignores it.

## Consequences

- **Adding or removing an `aad` field is wire-breaking**, by that same domain separation. Existing data does not decode after the change.
- **The decode becomes order-dependent.** An encrypted entry cannot open until every `aad` field has been read, and `MapAccess` cannot skip ahead to fetch one, so the derive now writes cleartext entries first. A map reordered in storage fails to decrypt — a denial of service, not a forgery, since entry order was never authenticated.
- **The coupling runs both ways**, and the docs lead with it: anything that rewrites an `aad` field independently breaks decryption of every encrypted field beside it. A column another process updates on its own is a `passthrough` field, never an `aad` one.

With no `aad` field the expansion is unchanged — same calls, same wire format — and a test pins that.

## Guards

- `aad` + `passthrough` on one field — compile error; `aad` already stores the value in the clear.
- `aad` on a newtype — rejected like `passthrough`, with the addition that a newtype has no sibling field to bind to.
- All fields cleartext — rejected whichever attribute is used; an `aad` field needs at least one encrypted field to bind.

## Tests

- 4 `Aad` units on `field_context` (key binding, order sensitivity, unambiguous boundaries, non-empty empty case) and 4 on `for_map_entry_with_context` (domain separation, context sensitivity, key binding, boundary).
- 8 expansion units pinning which channel each field routes through, and that a struct with no `aad` field expands exactly as before.
- 8 end-to-end tests against real AES-256-GCM: round-trip, term readable without the key, substitution breaks decryption, the same edit to a plain `passthrough` field does not, deletion breaks it, transposing two terms breaks it, a bound ciphertext cannot be read as an unbound one (both directions), and an encrypted entry before its `aad` field is refused.
- 3 new `trybuild` cases for the guards.

Full workspace green (40 targets); clippy, `cargo fmt --check`, the rustdoc gate, and the wasm32 build all clean. `cargo mutants` on the derive crate: 23 caught, 0 missed. CRAP under threshold.

https://claude.ai/code/session_011kjxjgxWmT4yi23ZqufSEc