### PR TITLE
ci(mutants): fail the gate on any exit that means the sweep did not complete

### DIFF
--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -203,10 +203,19 @@ jobs:
             [ -s "$out/timeout.txt" ] && cat "$out/timeout.txt"
             exit 1
           fi
-          # cargo-mutants failed before producing results (e.g. baseline tests
-          # failed) — surface that as a gate failure rather than a false pass.
-          if [ "${{ steps.mutants.outputs.exit_code }}" != "0" ] && [ ! -f "$out/outcomes.json" ]; then
-            echo "::error::cargo-mutants did not complete (exit ${{ steps.mutants.outputs.exit_code }}) — check the run logs."
-            exit 1
-          fi
+          # Only three exits mean the sweep actually completed: 0 (all mutants
+          # caught), 2 (missed mutants) and 3 (timeouts) — and 2/3 are already
+          # enforced via missed.txt/timeout.txt above. Everything else means it
+          # did not complete: 4 (the unmutated baseline failed to build or
+          # test), 70 (internal tool error), an OOM kill, … . The presence of
+          # outcomes.json cannot stand in for this check — it is written
+          # incrementally after the baseline, so a mid-run death leaves it on
+          # disk with most mutants untested.
+          case "${{ steps.mutants.outputs.exit_code }}" in
+            0|2|3) ;;
+            *)
+              echo "::error::cargo-mutants did not complete (exit ${{ steps.mutants.outputs.exit_code }}) — check the run logs."
+              exit 1
+              ;;
+          esac
           echo "No surviving mutants in the PR diff."


### PR DESCRIPTION
Closes #303.

Split out of #297 per review — unrelated to the `NonEmpty` context work.

The mutants gate treated the presence of `outcomes.json` as proof the sweep ran, but cargo-mutants writes that file incrementally after the baseline, so a mid-run death (internal error 70, filter-diff failures 5/6, an OOM kill) left it on disk and the gate went green with most mutants untested — the same silent-skip class the original check set out to close.

Only three exits mean the sweep completed: 0 (all caught), 2 (missed) and 3 (timeouts), and 2/3 are already enforced via `missed.txt`/`timeout.txt`. The gate now fails on every other exit instead of probing for the file.

https://claude.ai/code/session_01XerA7ky6KzQ4hfBLmsdvkr
