### PR TITLE
test(protected): pin down zeroize-on-drop for Copy payloads (#263)

### DIFF
--- a/packages/permutation/src/key.rs
+++ b/packages/permutation/src/key.rs
@@ -11,9 +11,9 @@ use crate::{
 
 pub(crate) type KeyInner<const N: usize> = Exportable<Protected<[u8; N]>>;
 
-// NOTE: no `Copy` — `PermutationKey` wraps a `Protected` secret that zeroizes
-// on drop, and `Copy`/`Drop` are mutually exclusive. A bitwise copy would also
-// leave un-zeroized duplicates of the key. Use `Clone` where a copy is needed.
+// NOTE: no `Copy` — `KeyInner` is a `Protected` secret, and the reasons it can
+// never be `Copy` (see the `vitaminc_protected::Protected` docs) apply to any
+// wrapper around it. Use `Clone` where a copy is needed.
 //
 // The key IS wiped on drop: `KeyInner` is `Exportable<Protected<[u8; N]>>`, both
 // of which are `ZeroizeOnDrop`, so the field's drop glue zeroizes the bytes. We

--- a/packages/protected/README.md
+++ b/packages/protected/README.md
@@ -34,6 +34,10 @@ let x = Protected::new([0u8; 32]);
 ```
 
 `Protected` will call `zeroize` on the inner value when it goes out of scope.
+Because that wipe is a real `Drop`, `Protected` is never `Copy`, even when the
+inner type is: a bitwise copy would leave an un-wiped duplicate of the secret
+behind. Duplicating a protected value is always an explicit `clone()`, and each
+clone is wiped when it drops.
 It also provides an "opaque" implementation of the `Debug` trait so you can debug protected values
 without accidentally leaking their innards.
 

--- a/packages/protected/README.md
+++ b/packages/protected/README.md
@@ -37,9 +37,10 @@ let x = Protected::new([0u8; 32]);
 Because that wipe is a real `Drop`, `Protected` is never `Copy`, even when the
 inner type is: unlike a move, a `Copy` value has no single owner whose drop can
 wipe it. Duplicating the wrapper is an explicit `clone()`, and each clone is
-wiped when it drops. See the [Protected] docs for the full rationale, and note
-that escape hatches such as `risky_unwrap` and `map` hand back the plain inner
-value along with the obligation to wipe it.
+wiped when it drops. See the `Protected` type docs for the full rationale.
+`risky_unwrap` is the escape hatch: it hands back the plain inner value along
+with the obligation to wipe it. Combinators such as `map` show the plain value
+only to their closure and return the result re-wrapped.
 It also provides an "opaque" implementation of the `Debug` trait so you can debug protected values
 without accidentally leaking their innards.
 

--- a/packages/protected/README.md
+++ b/packages/protected/README.md
@@ -35,9 +35,11 @@ let x = Protected::new([0u8; 32]);
 
 `Protected` will call `zeroize` on the inner value when it goes out of scope.
 Because that wipe is a real `Drop`, `Protected` is never `Copy`, even when the
-inner type is: a bitwise copy would leave an un-wiped duplicate of the secret
-behind. Duplicating a protected value is always an explicit `clone()`, and each
-clone is wiped when it drops.
+inner type is: unlike a move, a `Copy` value has no single owner whose drop can
+wipe it. Duplicating the wrapper is an explicit `clone()`, and each clone is
+wiped when it drops. See the [Protected] docs for the full rationale, and note
+that escape hatches such as `risky_unwrap` and `map` hand back the plain inner
+value along with the obligation to wipe it.
 It also provides an "opaque" implementation of the `Debug` trait so you can debug protected values
 without accidentally leaking their innards.
 

--- a/packages/protected/src/digest.rs
+++ b/packages/protected/src/digest.rs
@@ -264,7 +264,6 @@ mod tests {
 
     #[test]
     fn protected_digest_state_is_zeroize_on_drop() {
-        fn assert_zeroize_on_drop<T: ZeroizeOnDrop>() {}
-        assert_zeroize_on_drop::<ProtectedDigest<Sha256>>();
+        crate::test_util::assert_zeroize_on_drop::<ProtectedDigest<Sha256>>();
     }
 }

--- a/packages/protected/src/equatable/mod.rs
+++ b/packages/protected/src/equatable/mod.rs
@@ -349,6 +349,31 @@ mod tests {
     use super::ConstantTimeEq;
     use crate::{Equatable, Protected};
     use core::num::NonZeroU16;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use zeroize::Zeroize;
+
+    /// `Equatable`'s `ZeroizeOnDrop` comes from the derive; this pins the
+    /// generated drop glue so removing the derive fails a test, not just a
+    /// promise. The `!Copy` half lives in `tests/ui/negative_space`.
+    #[test]
+    fn drop_zeroizes_inner() {
+        struct Tracked<'a>(&'a AtomicBool);
+        impl Zeroize for Tracked<'_> {
+            fn zeroize(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let zeroized = AtomicBool::new(false);
+        {
+            let _e = Equatable(Tracked(&zeroized));
+            assert!(!zeroized.load(Ordering::SeqCst));
+        }
+        assert!(
+            zeroized.load(Ordering::SeqCst),
+            "Equatable::drop must zeroize the inner value"
+        );
+    }
 
     #[test]
     fn test_opaque_debug() {

--- a/packages/protected/src/equatable/mod.rs
+++ b/packages/protected/src/equatable/mod.rs
@@ -347,31 +347,41 @@ mod private {
 #[cfg(test)]
 mod tests {
     use super::ConstantTimeEq;
-    use crate::{Equatable, Protected};
+    use crate::test_util::Tracked;
+    use crate::{Controlled, Equatable, Protected};
     use core::num::NonZeroU16;
-    use std::sync::atomic::{AtomicBool, Ordering};
-    use zeroize::Zeroize;
+    use std::sync::atomic::AtomicBool;
 
     /// `Equatable`'s `ZeroizeOnDrop` comes from the derive; this pins the
     /// generated drop glue so removing the derive fails a test, not just a
     /// promise. The `!Copy` half lives in `tests/ui/negative_space`.
     #[test]
     fn drop_zeroizes_inner() {
-        struct Tracked<'a>(&'a AtomicBool);
-        impl Zeroize for Tracked<'_> {
-            fn zeroize(&mut self) {
-                self.0.store(true, Ordering::SeqCst);
-            }
-        }
-
         let zeroized = AtomicBool::new(false);
+        let tracked = Tracked(&zeroized);
         {
-            let _e = Equatable(Tracked(&zeroized));
-            assert!(!zeroized.load(Ordering::SeqCst));
+            let _e = Equatable(tracked);
+            assert!(!tracked.was_zeroized());
         }
         assert!(
-            zeroized.load(Ordering::SeqCst),
+            tracked.was_zeroized(),
             "Equatable::drop must zeroize the inner value"
+        );
+    }
+
+    /// `risky_unwrap` routes through `into_inner_unchecked` and then the inner
+    /// wrapper's `risky_unwrap`: neither layer may wipe the value it hands on,
+    /// since the caller now owns the live secret.
+    #[test]
+    fn risky_unwrap_does_not_zeroize() {
+        let zeroized = AtomicBool::new(false);
+        let tracked = Tracked(&zeroized);
+        // `Tracked` has no `Drop`, so the recovered value falling out of
+        // scope is a no-op and the flag can only be raised by a wrapper.
+        let _recovered = Equatable(Protected::new(tracked)).risky_unwrap();
+        assert!(
+            !tracked.was_zeroized(),
+            "Equatable::risky_unwrap must not zeroize the value it hands back"
         );
     }
 

--- a/packages/protected/src/exportable/mod.rs
+++ b/packages/protected/src/exportable/mod.rs
@@ -171,9 +171,33 @@ where
 #[cfg(test)]
 mod tests {
     use std::fmt::Debug;
+    use std::sync::atomic::{AtomicBool, Ordering};
 
     use super::*;
     use crate::{Equatable, Protected};
+
+    /// `Exportable`'s `ZeroizeOnDrop` comes from the derive; this pins the
+    /// generated drop glue so removing the derive fails a test, not just a
+    /// promise. The `!Copy` half lives in `tests/ui/negative_space`.
+    #[test]
+    fn drop_zeroizes_inner() {
+        struct Tracked<'a>(&'a AtomicBool);
+        impl Zeroize for Tracked<'_> {
+            fn zeroize(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let zeroized = AtomicBool::new(false);
+        {
+            let _e = Exportable(Tracked(&zeroized));
+            assert!(!zeroized.load(Ordering::SeqCst));
+        }
+        assert!(
+            zeroized.load(Ordering::SeqCst),
+            "Exportable::drop must zeroize the inner value"
+        );
+    }
 
     #[test]
     fn test_opaque_debug() {

--- a/packages/protected/src/exportable/mod.rs
+++ b/packages/protected/src/exportable/mod.rs
@@ -171,9 +171,10 @@ where
 #[cfg(test)]
 mod tests {
     use std::fmt::Debug;
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::atomic::AtomicBool;
 
     use super::*;
+    use crate::test_util::Tracked;
     use crate::{Equatable, Protected};
 
     /// `Exportable`'s `ZeroizeOnDrop` comes from the derive; this pins the
@@ -181,21 +182,31 @@ mod tests {
     /// promise. The `!Copy` half lives in `tests/ui/negative_space`.
     #[test]
     fn drop_zeroizes_inner() {
-        struct Tracked<'a>(&'a AtomicBool);
-        impl Zeroize for Tracked<'_> {
-            fn zeroize(&mut self) {
-                self.0.store(true, Ordering::SeqCst);
-            }
-        }
-
         let zeroized = AtomicBool::new(false);
+        let tracked = Tracked(&zeroized);
         {
-            let _e = Exportable(Tracked(&zeroized));
-            assert!(!zeroized.load(Ordering::SeqCst));
+            let _e = Exportable(tracked);
+            assert!(!tracked.was_zeroized());
         }
         assert!(
-            zeroized.load(Ordering::SeqCst),
+            tracked.was_zeroized(),
             "Exportable::drop must zeroize the inner value"
+        );
+    }
+
+    /// `risky_unwrap` routes through `into_inner_unchecked` and then the inner
+    /// wrapper's `risky_unwrap`: neither layer may wipe the value it hands on,
+    /// since the caller now owns the live secret.
+    #[test]
+    fn risky_unwrap_does_not_zeroize() {
+        let zeroized = AtomicBool::new(false);
+        let tracked = Tracked(&zeroized);
+        // `Tracked` has no `Drop`, so the recovered value falling out of
+        // scope is a no-op and the flag can only be raised by a wrapper.
+        let _recovered = Exportable(Protected::new(tracked)).risky_unwrap();
+        assert!(
+            !tracked.was_zeroized(),
+            "Exportable::risky_unwrap must not zeroize the value it hands back"
         );
     }
 

--- a/packages/protected/src/lib.rs
+++ b/packages/protected/src/lib.rs
@@ -11,6 +11,8 @@ mod exportable;
 mod non_empty;
 mod ops;
 mod protected;
+#[cfg(test)]
+mod test_util;
 mod timing_safe;
 mod usage;
 mod zeroed;

--- a/packages/protected/src/protected/mod.rs
+++ b/packages/protected/src/protected/mod.rs
@@ -8,6 +8,19 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 ///
 /// The inner value is wiped when the `Protected` is dropped (`ZeroizeOnDrop`),
 /// so the `T: Zeroize` bound is required on the type itself.
+///
+/// # Never `Copy`, always an explicit `clone()`
+///
+/// `Protected<T>` is not `Copy`, even when `T` is. The wipe is a real `Drop`,
+/// and `Copy` and `Drop` are mutually exclusive in Rust: unlike a move, a
+/// `Copy` value has no single owner whose drop can wipe it, so a bitwise copy
+/// would leave an un-wiped duplicate of the secret behind. Where a duplicate of
+/// the wrapper is genuinely needed, call `clone()`: each clone is its own owner
+/// and is wiped when it drops.
+///
+/// Escape hatches such as [`Controlled::risky_unwrap`] and
+/// [`Controlled::map`] hand back the plain inner value, and with it the wiping
+/// obligation.
 #[derive(Zeroize, ZeroizeOnDrop, OpaqueDebug)]
 pub struct Protected<T: Zeroize>(pub(crate) T);
 
@@ -99,10 +112,7 @@ where
     }
 }
 
-// NOTE: `Protected<T>` deliberately does NOT implement `Copy`. `Copy` and
-// `Drop` are mutually exclusive in Rust, and the zeroizing `Drop` is the whole
-// point — a bitwise copy would leave un-zeroized duplicates of the secret.
-// Use `Clone` (explicit) where a duplicate is genuinely needed.
+// No `Copy`: see the "Never `Copy`" section of the `Protected` item docs.
 
 impl<T> Clone for Protected<T>
 where
@@ -163,8 +173,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::cell::Cell;
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use crate::test_util::{assert_zeroize_on_drop, Counted, Tracked};
+    use std::sync::atomic::{AtomicBool, AtomicUsize};
 
     #[test]
     fn test_new_array() {
@@ -172,54 +182,34 @@ mod tests {
         assert_eq!(x.0, [0u8; 32]);
     }
 
-    /// Regression test for #181: dropping a `Protected<T>` must zeroize its
-    /// inner value. Uses an inner type whose `Zeroize` sets a flag, so we can
-    /// observe that `Drop` ran the wipe (the bytes themselves are freed and
-    /// can't be inspected after drop).
+    /// Regression test for #181 and #263: dropping a `Protected<T>` must
+    /// zeroize its inner value. `Tracked` is `Copy`, so this is also the
+    /// #263 case: `Protected<T>` used to be `Copy` whenever `T` was, which
+    /// made a zeroizing `Drop` structurally impossible for exactly the
+    /// payloads that carry key material.
     #[test]
     fn drop_zeroizes_inner() {
-        struct Tracked<'a>(&'a AtomicBool);
-        impl Zeroize for Tracked<'_> {
-            fn zeroize(&mut self) {
-                self.0.store(true, Ordering::SeqCst);
-            }
-        }
-
         let zeroized = AtomicBool::new(false);
+        let tracked = Tracked(&zeroized);
         {
-            let _p = Protected::new(Tracked(&zeroized));
-            assert!(!zeroized.load(Ordering::SeqCst));
+            let _p = Protected::new(tracked);
+            assert!(!tracked.was_zeroized());
         }
         assert!(
-            zeroized.load(Ordering::SeqCst),
+            tracked.was_zeroized(),
             "Protected::drop should zeroize the inner value"
         );
     }
 
-    /// Regression test for #263: a `Copy` payload must still be wiped when
-    /// the wrapper drops. `Protected<T>` used to be `Copy` whenever `T` was,
-    /// which made a zeroizing `Drop` structurally impossible for exactly the
-    /// payloads that carry key material (`[u8; 32]` and friends). The payload
-    /// here is `Copy`, and the wipe must run anyway.
+    /// The derived `Zeroize` (which the derived `Drop` calls) must actually
+    /// write zeros over a real byte-array payload. This is the only test that
+    /// inspects wiped bytes on a `Protected<[u8; N]>`; it does so while the
+    /// value is live, since the bytes cannot be inspected after drop.
     #[test]
-    fn drop_zeroizes_copy_payload() {
-        #[derive(Clone, Copy)]
-        struct CopyTracked<'a>(&'a AtomicBool);
-        impl Zeroize for CopyTracked<'_> {
-            fn zeroize(&mut self) {
-                self.0.store(true, Ordering::SeqCst);
-            }
-        }
-
-        let zeroized = AtomicBool::new(false);
-        {
-            let _p = Protected::new(CopyTracked(&zeroized));
-            assert!(!zeroized.load(Ordering::SeqCst));
-        }
-        assert!(
-            zeroized.load(Ordering::SeqCst),
-            "Protected::drop must zeroize a Copy payload"
-        );
+    fn zeroize_wipes_array_payload() {
+        let mut p = Protected::new([0xAB_u8; 32]);
+        p.zeroize();
+        assert_eq!(p.0, [0_u8; 32], "Protected::zeroize must wipe the array");
     }
 
     /// Regression test for #263: `ZeroizeOnDrop` on `Protected<T>` must be
@@ -227,7 +217,6 @@ mod tests {
     /// vectors are the payloads downstream key material actually uses.
     #[test]
     fn zeroize_on_drop_is_backed_by_drop_glue() {
-        fn assert_zeroize_on_drop<T: ZeroizeOnDrop>() {}
         assert_zeroize_on_drop::<Protected<[u8; 32]>>();
         assert_zeroize_on_drop::<Protected<Vec<u8>>>();
 
@@ -243,16 +232,25 @@ mod tests {
         assert!(std::mem::needs_drop::<Protected<u64>>());
     }
 
-    /// The canonical downstream nesting from the `Exportable` docs: the drop
-    /// glue must propagate through all three wrapper layers, and the payload
-    /// alone contributes none of it.
+    /// The canonical downstream nesting from the `Exportable` docs. Each
+    /// wrapper layer is checked on its own around a payload with no drop glue
+    /// of its own, so a layer losing its zeroizing `Drop` fails here even
+    /// though the other layers would still make the nested type `needs_drop`.
+    /// The nested shapes are then checked as a whole.
     #[test]
     fn nested_wrappers_keep_zeroizing_drop_glue() {
         use crate::{Equatable, Exportable};
-        fn assert_zeroize_on_drop<T: ZeroizeOnDrop>() {}
+
+        assert!(!std::mem::needs_drop::<[u8; 32]>());
+        assert_zeroize_on_drop::<Protected<[u8; 32]>>();
+        assert!(std::mem::needs_drop::<Protected<[u8; 32]>>());
+        assert_zeroize_on_drop::<Equatable<[u8; 32]>>();
+        assert!(std::mem::needs_drop::<Equatable<[u8; 32]>>());
+        assert_zeroize_on_drop::<Exportable<[u8; 32]>>();
+        assert!(std::mem::needs_drop::<Exportable<[u8; 32]>>());
+
         assert_zeroize_on_drop::<Exportable<Equatable<Protected<[u8; 32]>>>>();
         assert_zeroize_on_drop::<Equatable<Exportable<Protected<[u8; 32]>>>>();
-        assert!(!std::mem::needs_drop::<[u8; 32]>());
         assert!(std::mem::needs_drop::<
             Exportable<Equatable<Protected<[u8; 32]>>>,
         >());
@@ -261,86 +259,33 @@ mod tests {
         >());
     }
 
-    /// The README's clone contract: a clone is a distinct value with its own
-    /// zeroizing `Drop`, so each duplicate is wiped exactly once, when it
-    /// itself drops. Fails if `Clone` ever starts aliasing the payload or the
-    /// clone loses its drop glue.
+    /// The clone contract from the `Protected` item docs: a clone is a
+    /// distinct value with its own zeroizing `Drop`, so each duplicate is
+    /// wiped exactly once, when it itself drops. Fails if `Clone` ever starts
+    /// aliasing the payload or the clone loses its drop glue.
     #[test]
     fn each_clone_is_wiped_independently() {
-        use std::sync::atomic::AtomicUsize;
-
-        #[derive(Clone)]
-        struct Counted<'a>(&'a AtomicUsize);
-        impl Zeroize for Counted<'_> {
-            fn zeroize(&mut self) {
-                self.0.fetch_add(1, Ordering::SeqCst);
-            }
-        }
-
         let wipes = AtomicUsize::new(0);
-        let original = Protected::new(Counted(&wipes));
+        let counted = Counted(&wipes);
+        let original = Protected::new(counted.clone());
         let dup = original.clone();
         drop(original);
-        assert_eq!(
-            wipes.load(Ordering::SeqCst),
-            1,
-            "original wiped on its own drop"
-        );
+        assert_eq!(counted.wipes(), 1, "original wiped on its own drop");
         drop(dup);
-        assert_eq!(wipes.load(Ordering::SeqCst), 2, "clone wiped independently");
-    }
-
-    /// Regression test for #263: `Protected`'s drop glue runs the payload's
-    /// `Zeroize` to completion — the payload observes its own wiped bytes
-    /// from inside `zeroize`, while the value is still live, so the
-    /// observation never touches a dropped value. (That the array wipe
-    /// itself writes zeros is the `zeroize` crate's property; what this
-    /// pins for `Protected` is that the wipe runs and finishes.)
-    #[test]
-    fn drop_runs_payload_zeroize_to_completion() {
-        struct Recorded<'a> {
-            bytes: [u8; 32],
-            wiped: &'a Cell<Option<[u8; 32]>>,
-        }
-        impl Zeroize for Recorded<'_> {
-            fn zeroize(&mut self) {
-                self.bytes.zeroize();
-                self.wiped.set(Some(self.bytes));
-            }
-        }
-
-        let wiped = Cell::new(None);
-        {
-            let _p = Protected::new(Recorded {
-                bytes: [0xAB_u8; 32],
-                wiped: &wiped,
-            });
-            assert!(wiped.get().is_none());
-        }
-        assert_eq!(
-            wiped.get(),
-            Some([0_u8; 32]),
-            "Protected::drop must wipe the array bytes"
-        );
+        assert_eq!(counted.wipes(), 2, "clone wiped independently");
     }
 
     /// `risky_unwrap` must move the secret out *without* the wrapper's `Drop`
     /// zeroizing it on the way (the caller now owns the live value).
     #[test]
     fn risky_unwrap_does_not_zeroize() {
-        struct Tracked<'a>(&'a AtomicBool);
-        impl Zeroize for Tracked<'_> {
-            fn zeroize(&mut self) {
-                self.0.store(true, Ordering::SeqCst);
-            }
-        }
-
         let zeroized = AtomicBool::new(false);
+        let tracked = Tracked(&zeroized);
         // The recovered value is live and owned here; `Tracked` has no `Drop`,
         // so letting it fall out of scope is a no-op and the flag stays false.
-        let _recovered = Protected::new(Tracked(&zeroized)).risky_unwrap();
+        let _recovered = Protected::new(tracked).risky_unwrap();
         assert!(
-            !zeroized.load(Ordering::SeqCst),
+            !tracked.was_zeroized(),
             "risky_unwrap must not zeroize the value it hands back"
         );
     }
@@ -351,34 +296,29 @@ mod tests {
     /// the result, and it must still happen there.
     #[test]
     fn flatten_and_transpose_move_without_zeroizing() {
-        struct Tracked<'a>(&'a AtomicBool);
-        impl Zeroize for Tracked<'_> {
-            fn zeroize(&mut self) {
-                self.0.store(true, Ordering::SeqCst);
-            }
-        }
-
         let zeroized = AtomicBool::new(false);
-        let flattened = Protected::new(Protected::new(Tracked(&zeroized))).flatten();
+        let tracked = Tracked(&zeroized);
+        let flattened = Protected::new(Protected::new(tracked)).flatten();
         assert!(
-            !zeroized.load(Ordering::SeqCst),
+            !tracked.was_zeroized(),
             "flatten must not zeroize the value it hands on"
         );
         drop(flattened);
         assert!(
-            zeroized.load(Ordering::SeqCst),
+            tracked.was_zeroized(),
             "the flattened wrapper still wipes on drop"
         );
 
         let zeroized = AtomicBool::new(false);
-        let transposed = Protected::new(Some(Tracked(&zeroized))).transpose();
+        let tracked = Tracked(&zeroized);
+        let transposed = Protected::new(Some(tracked)).transpose();
         assert!(
-            !zeroized.load(Ordering::SeqCst),
+            !tracked.was_zeroized(),
             "transpose must not zeroize the value it hands on"
         );
         drop(transposed);
         assert!(
-            zeroized.load(Ordering::SeqCst),
+            tracked.was_zeroized(),
             "the transposed wrapper still wipes on drop"
         );
     }

--- a/packages/protected/src/protected/mod.rs
+++ b/packages/protected/src/protected/mod.rs
@@ -163,6 +163,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::Cell;
     use std::sync::atomic::{AtomicBool, Ordering};
 
     #[test]
@@ -237,24 +238,33 @@ mod tests {
     }
 
     /// Regression test for #263: the bytes of a `Protected<[u8; 32]>` are
-    /// zero after its destructor runs. The wrapper lives in a `ManuallyDrop`
-    /// so its storage stays addressable once the destructor has been run by
-    /// hand.
+    /// zero once its destructor has wiped them. The payload records its own
+    /// bytes from inside `Zeroize`, while the value is still live, so the
+    /// observation never touches a dropped value.
     #[test]
-    fn drop_zeroizes_array_bytes_in_place() {
-        use std::mem::ManuallyDrop;
+    fn drop_zeroizes_array_bytes() {
+        struct Recorded<'a> {
+            bytes: [u8; 32],
+            wiped: &'a Cell<Option<[u8; 32]>>,
+        }
+        impl Zeroize for Recorded<'_> {
+            fn zeroize(&mut self) {
+                self.bytes.zeroize();
+                self.wiped.set(Some(self.bytes));
+            }
+        }
 
-        let mut slot = ManuallyDrop::new(Protected::new([0xAB_u8; 32]));
-        assert_eq!(slot.0, [0xAB_u8; 32]);
-
-        // SAFETY: `slot` is dropped exactly once, here. The storage is a
-        // plain byte array on this stack frame, so reading it back after the
-        // destructor is a read of initialised `u8`s, and `slot` is never
-        // used as a live `Protected` again.
-        unsafe { ManuallyDrop::drop(&mut slot) };
-        let after: [u8; 32] = slot.0;
+        let wiped = Cell::new(None);
+        {
+            let _p = Protected::new(Recorded {
+                bytes: [0xAB_u8; 32],
+                wiped: &wiped,
+            });
+            assert!(wiped.get().is_none());
+        }
         assert_eq!(
-            after, [0_u8; 32],
+            wiped.get(),
+            Some([0_u8; 32]),
             "Protected::drop must wipe the array bytes"
         );
     }

--- a/packages/protected/src/protected/mod.rs
+++ b/packages/protected/src/protected/mod.rs
@@ -233,16 +233,71 @@ mod tests {
 
         // A marker-only `ZeroizeOnDrop` leaves `[u8; 32]` with no destructor
         // at all; `needs_drop` is the compiler's word on whether one exists.
+        // Each pair shows the payload alone contributes no glue, so the
+        // wrapper's `true` can only come from `Protected`'s zeroizing `Drop`.
+        // (`Protected<Vec<u8>>` proves nothing here: `Vec` brings its own
+        // destructor, so `needs_drop` stays true even with no wipe at all.)
+        assert!(!std::mem::needs_drop::<[u8; 32]>());
         assert!(std::mem::needs_drop::<Protected<[u8; 32]>>());
-        assert!(std::mem::needs_drop::<Protected<Vec<u8>>>());
+        assert!(!std::mem::needs_drop::<u64>());
+        assert!(std::mem::needs_drop::<Protected<u64>>());
     }
 
-    /// Regression test for #263: the bytes of a `Protected<[u8; 32]>` are
-    /// zero once its destructor has wiped them. The payload records its own
-    /// bytes from inside `Zeroize`, while the value is still live, so the
-    /// observation never touches a dropped value.
+    /// The canonical downstream nesting from the `Exportable` docs: the drop
+    /// glue must propagate through all three wrapper layers, and the payload
+    /// alone contributes none of it.
     #[test]
-    fn drop_zeroizes_array_bytes() {
+    fn nested_wrappers_keep_zeroizing_drop_glue() {
+        use crate::{Equatable, Exportable};
+        fn assert_zeroize_on_drop<T: ZeroizeOnDrop>() {}
+        assert_zeroize_on_drop::<Exportable<Equatable<Protected<[u8; 32]>>>>();
+        assert_zeroize_on_drop::<Equatable<Exportable<Protected<[u8; 32]>>>>();
+        assert!(!std::mem::needs_drop::<[u8; 32]>());
+        assert!(std::mem::needs_drop::<
+            Exportable<Equatable<Protected<[u8; 32]>>>,
+        >());
+        assert!(std::mem::needs_drop::<
+            Equatable<Exportable<Protected<[u8; 32]>>>,
+        >());
+    }
+
+    /// The README's clone contract: a clone is a distinct value with its own
+    /// zeroizing `Drop`, so each duplicate is wiped exactly once, when it
+    /// itself drops. Fails if `Clone` ever starts aliasing the payload or the
+    /// clone loses its drop glue.
+    #[test]
+    fn each_clone_is_wiped_independently() {
+        use std::sync::atomic::AtomicUsize;
+
+        #[derive(Clone)]
+        struct Counted<'a>(&'a AtomicUsize);
+        impl Zeroize for Counted<'_> {
+            fn zeroize(&mut self) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        let wipes = AtomicUsize::new(0);
+        let original = Protected::new(Counted(&wipes));
+        let dup = original.clone();
+        drop(original);
+        assert_eq!(
+            wipes.load(Ordering::SeqCst),
+            1,
+            "original wiped on its own drop"
+        );
+        drop(dup);
+        assert_eq!(wipes.load(Ordering::SeqCst), 2, "clone wiped independently");
+    }
+
+    /// Regression test for #263: `Protected`'s drop glue runs the payload's
+    /// `Zeroize` to completion — the payload observes its own wiped bytes
+    /// from inside `zeroize`, while the value is still live, so the
+    /// observation never touches a dropped value. (That the array wipe
+    /// itself writes zeros is the `zeroize` crate's property; what this
+    /// pins for `Protected` is that the wipe runs and finishes.)
+    #[test]
+    fn drop_runs_payload_zeroize_to_completion() {
         struct Recorded<'a> {
             bytes: [u8; 32],
             wiped: &'a Cell<Option<[u8; 32]>>,
@@ -287,6 +342,44 @@ mod tests {
         assert!(
             !zeroized.load(Ordering::SeqCst),
             "risky_unwrap must not zeroize the value it hands back"
+        );
+    }
+
+    /// `flatten` and `transpose` route through `into_inner_unchecked`, so the
+    /// consumed outer wrapper must NOT wipe the value it hands on — the
+    /// result still owns the live secret. The wipe belongs to whoever drops
+    /// the result, and it must still happen there.
+    #[test]
+    fn flatten_and_transpose_move_without_zeroizing() {
+        struct Tracked<'a>(&'a AtomicBool);
+        impl Zeroize for Tracked<'_> {
+            fn zeroize(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let zeroized = AtomicBool::new(false);
+        let flattened = Protected::new(Protected::new(Tracked(&zeroized))).flatten();
+        assert!(
+            !zeroized.load(Ordering::SeqCst),
+            "flatten must not zeroize the value it hands on"
+        );
+        drop(flattened);
+        assert!(
+            zeroized.load(Ordering::SeqCst),
+            "the flattened wrapper still wipes on drop"
+        );
+
+        let zeroized = AtomicBool::new(false);
+        let transposed = Protected::new(Some(Tracked(&zeroized))).transpose();
+        assert!(
+            !zeroized.load(Ordering::SeqCst),
+            "transpose must not zeroize the value it hands on"
+        );
+        drop(transposed);
+        assert!(
+            zeroized.load(Ordering::SeqCst),
+            "the transposed wrapper still wipes on drop"
         );
     }
 

--- a/packages/protected/src/protected/mod.rs
+++ b/packages/protected/src/protected/mod.rs
@@ -195,6 +195,70 @@ mod tests {
         );
     }
 
+    /// Regression test for #263: a `Copy` payload must still be wiped when
+    /// the wrapper drops. `Protected<T>` used to be `Copy` whenever `T` was,
+    /// which made a zeroizing `Drop` structurally impossible for exactly the
+    /// payloads that carry key material (`[u8; 32]` and friends). The payload
+    /// here is `Copy`, and the wipe must run anyway.
+    #[test]
+    fn drop_zeroizes_copy_payload() {
+        #[derive(Clone, Copy)]
+        struct CopyTracked<'a>(&'a AtomicBool);
+        impl Zeroize for CopyTracked<'_> {
+            fn zeroize(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let zeroized = AtomicBool::new(false);
+        {
+            let _p = Protected::new(CopyTracked(&zeroized));
+            assert!(!zeroized.load(Ordering::SeqCst));
+        }
+        assert!(
+            zeroized.load(Ordering::SeqCst),
+            "Protected::drop must zeroize a Copy payload"
+        );
+    }
+
+    /// Regression test for #263: `ZeroizeOnDrop` on `Protected<T>` must be
+    /// backed by real drop glue, not a bare marker impl. Byte arrays and byte
+    /// vectors are the payloads downstream key material actually uses.
+    #[test]
+    fn zeroize_on_drop_is_backed_by_drop_glue() {
+        fn assert_zeroize_on_drop<T: ZeroizeOnDrop>() {}
+        assert_zeroize_on_drop::<Protected<[u8; 32]>>();
+        assert_zeroize_on_drop::<Protected<Vec<u8>>>();
+
+        // A marker-only `ZeroizeOnDrop` leaves `[u8; 32]` with no destructor
+        // at all; `needs_drop` is the compiler's word on whether one exists.
+        assert!(std::mem::needs_drop::<Protected<[u8; 32]>>());
+        assert!(std::mem::needs_drop::<Protected<Vec<u8>>>());
+    }
+
+    /// Regression test for #263: the bytes of a `Protected<[u8; 32]>` are
+    /// zero after its destructor runs. The wrapper lives in a `ManuallyDrop`
+    /// so its storage stays addressable once the destructor has been run by
+    /// hand.
+    #[test]
+    fn drop_zeroizes_array_bytes_in_place() {
+        use std::mem::ManuallyDrop;
+
+        let mut slot = ManuallyDrop::new(Protected::new([0xAB_u8; 32]));
+        assert_eq!(slot.0, [0xAB_u8; 32]);
+
+        // SAFETY: `slot` is dropped exactly once, here. The storage is a
+        // plain byte array on this stack frame, so reading it back after the
+        // destructor is a read of initialised `u8`s, and `slot` is never
+        // used as a live `Protected` again.
+        unsafe { ManuallyDrop::drop(&mut slot) };
+        let after: [u8; 32] = slot.0;
+        assert_eq!(
+            after, [0_u8; 32],
+            "Protected::drop must wipe the array bytes"
+        );
+    }
+
     /// `risky_unwrap` must move the secret out *without* the wrapper's `Drop`
     /// zeroizing it on the way (the caller now owns the live value).
     #[test]

--- a/packages/protected/src/protected/mod.rs
+++ b/packages/protected/src/protected/mod.rs
@@ -18,9 +18,11 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 /// the wrapper is genuinely needed, call `clone()`: each clone is its own owner
 /// and is wiped when it drops.
 ///
-/// Escape hatches such as [`Controlled::risky_unwrap`] and
-/// [`Controlled::map`] hand back the plain inner value, and with it the wiping
-/// obligation.
+/// [`Controlled::risky_unwrap`] is the escape hatch: it hands back the plain
+/// inner value, and with it the wiping obligation. Combinators such as
+/// [`Controlled::map`] expose the plain value only to their closure and
+/// return the result re-wrapped in a controlled type; the closure owns the
+/// plain value for its own duration and anything it copies out of it.
 #[derive(Zeroize, ZeroizeOnDrop, OpaqueDebug)]
 pub struct Protected<T: Zeroize>(pub(crate) T);
 

--- a/packages/protected/src/test_util.rs
+++ b/packages/protected/src/test_util.rs
@@ -1,0 +1,50 @@
+//! Test-only observers shared by the wrapper-type unit tests. Each one makes
+//! a `Zeroize` call visible from outside the value so a test can prove that a
+//! wrapper's `Drop` ran (or deliberately did not run) the payload's wipe.
+
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+/// A payload whose `zeroize` sets a flag. It has no `Drop` of its own, so the
+/// flag can only be raised by a wrapper's drop glue (or an explicit call).
+///
+/// `Copy` is deliberate (#263): `Protected<T>` used to be `Copy` whenever `T`
+/// was, which made a zeroizing `Drop` structurally impossible for exactly the
+/// payloads that carry key material. Every test that observes a wipe through
+/// `Tracked` therefore does so with a `Copy` payload.
+#[derive(Clone, Copy)]
+pub(crate) struct Tracked<'a>(pub(crate) &'a AtomicBool);
+
+impl Tracked<'_> {
+    pub(crate) fn was_zeroized(&self) -> bool {
+        self.0.load(Ordering::SeqCst)
+    }
+}
+
+impl Zeroize for Tracked<'_> {
+    fn zeroize(&mut self) {
+        self.0.store(true, Ordering::SeqCst);
+    }
+}
+
+/// A `Clone` payload whose `zeroize` bumps a counter, so a test can prove each
+/// duplicate is wiped exactly once.
+#[derive(Clone)]
+pub(crate) struct Counted<'a>(pub(crate) &'a AtomicUsize);
+
+impl Counted<'_> {
+    pub(crate) fn wipes(&self) -> usize {
+        self.0.load(Ordering::SeqCst)
+    }
+}
+
+impl Zeroize for Counted<'_> {
+    fn zeroize(&mut self) {
+        self.0.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+/// Compile-time check that `T` claims `ZeroizeOnDrop`. Pair it with a
+/// runtime `Tracked` observation: the marker alone says nothing about whether
+/// a wipe actually runs.
+pub(crate) fn assert_zeroize_on_drop<T: ZeroizeOnDrop>() {}

--- a/packages/protected/src/usage/mod.rs
+++ b/packages/protected/src/usage/mod.rs
@@ -99,6 +99,19 @@ mod tests {
     struct MyScope;
     impl Scope for MyScope {}
 
+    /// `Usage` deliberately has no `ZeroizeOnDrop` of its own (see the note
+    /// on the `Zeroize` impl above): the wipe is the inner wrapper's drop
+    /// glue, reached through `Usage`'s field. This pins that the delegation
+    /// actually holds — a bare `[u8; 32]` has no glue, so the `true` can
+    /// only come from `Protected`'s zeroizing `Drop` propagating through.
+    #[test]
+    fn drop_glue_comes_from_inner_wrapper() {
+        assert!(!std::mem::needs_drop::<[u8; 32]>());
+        assert!(std::mem::needs_drop::<
+            Usage<Protected<[u8; 32]>, DefaultScope>,
+        >());
+    }
+
     // TODO: Create some compilation tests
     fn example1<T: Acceptable<DefaultScope>>(_: T) -> bool {
         true

--- a/packages/protected/src/usage/mod.rs
+++ b/packages/protected/src/usage/mod.rs
@@ -22,12 +22,16 @@ impl<T, S> Usage<T, S> {
 // (`PhantomData` is a ZST with nothing to wipe).
 //
 // `Usage` intentionally has no `Drop` (and so no `ZeroizeOnDrop` *derive*) of
-// its own. Its secret is still wiped on drop: `Usage::new` requires
-// `Self: Controlled`, so the inner `T` is always a controlled type
-// (`Protected`/`Equatable`/`Exportable`), each of which is `ZeroizeOnDrop` —
-// dropping `Usage` runs the field's drop glue and wipes the bytes. Giving
-// `Usage` its own `Drop` would require a viral `T: Zeroize` bound on the struct
-// (E0367: a conditional `Drop` must match the struct bounds), which would
+// its own: the wipe is whatever drop glue the field `T` brings. Every path that
+// can put a secret into a `Usage` goes through `Controlled` (`Usage::new`,
+// `init_from_inner`, `inner_mut`), and `Controlled for Usage` requires
+// `T: Controlled`, so a `Usage` holding a secret always has a
+// `Protected`/`Equatable`/`Exportable` field whose `ZeroizeOnDrop` wipes the
+// bytes when `Usage` drops. The one constructor without that bound,
+// `Zeroed for Usage`, can build e.g. `Usage<[u8; 32], S>`, but such a value is
+// inert: it holds only zeros and exposes no way to write a secret into it.
+// Giving `Usage` its own `Drop` would require a viral `T: Zeroize` bound on the
+// struct (E0367: a conditional `Drop` must match the struct bounds), which would
 // cascade through every `Usage<T, S>` use for no behavioural gain.
 impl<T: Zeroize, Scope> Zeroize for Usage<T, Scope> {
     fn zeroize(&mut self) {

--- a/packages/protected/src/usage/mod.rs
+++ b/packages/protected/src/usage/mod.rs
@@ -2,7 +2,7 @@ use serde::{Serialize, Serializer};
 
 use crate::{exportable::SafeSerialize, private::ControlledPrivate, Controlled, Protected};
 use std::marker::PhantomData;
-use zeroize::Zeroize;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 // TODO: Docs, explain compile time
 pub struct Usage<T, Scope = DefaultScope>(pub(crate) T, pub(crate) PhantomData<Scope>);
@@ -21,18 +21,27 @@ impl<T, S> Usage<T, S> {
 // satisfy the `Controlled: Zeroize` supertrait and delegates to the inner type
 // (`PhantomData` is a ZST with nothing to wipe).
 //
-// `Usage` intentionally does NOT derive `ZeroizeOnDrop`. Its secret is still
-// wiped on drop: `Usage::new` requires `Self: Controlled`, so the inner `T` is
-// always a controlled type (`Protected`/`Equatable`/`Exportable`), each of which
-// is `ZeroizeOnDrop` — dropping `Usage` runs the field's drop glue and wipes the
-// bytes. Giving `Usage` its own `Drop` would require a viral `T: Zeroize` bound
-// on the struct (E0367: a conditional `Drop` must match the struct bounds),
-// which would cascade through every `Usage<T, S>` use for no behavioural gain.
+// `Usage` intentionally has no `Drop` (and so no `ZeroizeOnDrop` *derive*) of
+// its own. Its secret is still wiped on drop: `Usage::new` requires
+// `Self: Controlled`, so the inner `T` is always a controlled type
+// (`Protected`/`Equatable`/`Exportable`), each of which is `ZeroizeOnDrop` —
+// dropping `Usage` runs the field's drop glue and wipes the bytes. Giving
+// `Usage` its own `Drop` would require a viral `T: Zeroize` bound on the struct
+// (E0367: a conditional `Drop` must match the struct bounds), which would
+// cascade through every `Usage<T, S>` use for no behavioural gain.
 impl<T: Zeroize, Scope> Zeroize for Usage<T, Scope> {
     fn zeroize(&mut self) {
         self.0.zeroize();
     }
 }
+
+// `ZeroizeOnDrop` is a method-less marker, so unlike a `Drop` impl it needs no
+// struct-level bound (the same pattern as `ProtectedDigest`). It is correct
+// exactly when the field is `ZeroizeOnDrop`: `PhantomData` holds nothing, so
+// the field's drop glue is the whole of `Usage`'s drop. Without this impl every
+// `T: ZeroizeOnDrop` bound downstream would reject `Usage<..>` and force
+// callers to strip the scope wrapper first.
+impl<T: ZeroizeOnDrop, Scope> ZeroizeOnDrop for Usage<T, Scope> {}
 
 impl<T: ControlledPrivate, Scope> ControlledPrivate for Usage<T, Scope> {}
 
@@ -95,21 +104,38 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_util::{assert_zeroize_on_drop, Tracked};
+    use std::sync::atomic::AtomicBool;
 
     struct MyScope;
     impl Scope for MyScope {}
 
-    /// `Usage` deliberately has no `ZeroizeOnDrop` of its own (see the note
-    /// on the `Zeroize` impl above): the wipe is the inner wrapper's drop
-    /// glue, reached through `Usage`'s field. This pins that the delegation
-    /// actually holds — a bare `[u8; 32]` has no glue, so the `true` can
-    /// only come from `Protected`'s zeroizing `Drop` propagating through.
+    /// `Usage` has no `Drop` of its own (see the note on the `Zeroize` impl
+    /// above): the wipe is the inner wrapper's drop glue, reached through
+    /// `Usage`'s field. This observes the wipe directly, so it fails if
+    /// `Usage` ever stops letting the field's `Drop` run (e.g. by wrapping it
+    /// in `ManuallyDrop`), regardless of what other destructors exist.
     #[test]
-    fn drop_glue_comes_from_inner_wrapper() {
-        assert!(!std::mem::needs_drop::<[u8; 32]>());
-        assert!(std::mem::needs_drop::<
-            Usage<Protected<[u8; 32]>, DefaultScope>,
-        >());
+    fn drop_wipes_through_inner_wrapper() {
+        let zeroized = AtomicBool::new(false);
+        let tracked = Tracked(&zeroized);
+        {
+            let _u = Usage::<Protected<Tracked<'_>>, DefaultScope>::new(tracked);
+            assert!(!tracked.was_zeroized());
+        }
+        assert!(
+            tracked.was_zeroized(),
+            "dropping Usage must run the inner wrapper's zeroizing Drop"
+        );
+    }
+
+    /// The `ZeroizeOnDrop` marker on `Usage` follows the inner wrapper, so
+    /// `Usage<..>` satisfies the same `T: ZeroizeOnDrop` bounds its payload
+    /// does. Nested inside `Option` too, as callers commonly hold it.
+    #[test]
+    fn usage_is_zeroize_on_drop_when_inner_is() {
+        assert_zeroize_on_drop::<Usage<Protected<[u8; 32]>, DefaultScope>>();
+        assert_zeroize_on_drop::<Option<Usage<Protected<[u8; 32]>, MyScope>>>();
     }
 
     // TODO: Create some compilation tests

--- a/packages/protected/tests/ui/negative_space/equatable_is_not_copy.rs
+++ b/packages/protected/tests/ui/negative_space/equatable_is_not_copy.rs
@@ -1,8 +1,15 @@
-use vitaminc_protected::{Equatable, Protected};
+// `Equatable` wraps a secret whose zeroizing `Drop` reaches the bytes via
+// `Equatable`'s field. A bitwise copy would leave an un-wiped duplicate
+// behind, so `Equatable` itself must never be `Copy`.
+//
+// The payload is a bare `[u8; 32]` on purpose: it *is* `Copy`, so the only
+// thing that can reject this is `Equatable`. (With a `Protected` payload the
+// error would already come from `Protected: !Copy`, and a conditional `Copy`
+// added to `Equatable` would go unnoticed.)
+use vitaminc_protected::Equatable;
 
-fn require_copy<T: Copy>(_: &T) {}
+fn require_copy<T: Copy>() {}
 
 fn main() {
-    let secret: Equatable<Protected<[u8; 32]>> = Equatable::new([0_u8; 32]);
-    require_copy(&secret);
+    require_copy::<Equatable<[u8; 32]>>();
 }

--- a/packages/protected/tests/ui/negative_space/equatable_is_not_copy.rs
+++ b/packages/protected/tests/ui/negative_space/equatable_is_not_copy.rs
@@ -1,0 +1,8 @@
+use vitaminc_protected::{Equatable, Protected};
+
+fn require_copy<T: Copy>(_: &T) {}
+
+fn main() {
+    let secret: Equatable<Protected<[u8; 32]>> = Equatable::new([0_u8; 32]);
+    require_copy(&secret);
+}

--- a/packages/protected/tests/ui/negative_space/equatable_is_not_copy.stderr
+++ b/packages/protected/tests/ui/negative_space/equatable_is_not_copy.stderr
@@ -1,13 +1,11 @@
-error[E0277]: the trait bound `Equatable<Protected<[u8; 32]>>: Copy` is not satisfied
- --> tests/ui/negative_space/equatable_is_not_copy.rs:7:18
-  |
-7 |     require_copy(&secret);
-  |     ------------ ^^^^^^^ the trait `Copy` is not implemented for `Equatable<Protected<[u8; 32]>>`
-  |     |
-  |     required by a bound introduced by this call
-  |
+error[E0277]: the trait bound `Equatable<[u8; 32]>: Copy` is not satisfied
+  --> tests/ui/negative_space/equatable_is_not_copy.rs:14:20
+   |
+14 |     require_copy::<Equatable<[u8; 32]>>();
+   |                    ^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `Equatable<[u8; 32]>`
+   |
 note: required by a bound in `require_copy`
- --> tests/ui/negative_space/equatable_is_not_copy.rs:3:20
-  |
-3 | fn require_copy<T: Copy>(_: &T) {}
-  |                    ^^^^ required by this bound in `require_copy`
+  --> tests/ui/negative_space/equatable_is_not_copy.rs:11:20
+   |
+11 | fn require_copy<T: Copy>() {}
+   |                    ^^^^ required by this bound in `require_copy`

--- a/packages/protected/tests/ui/negative_space/equatable_is_not_copy.stderr
+++ b/packages/protected/tests/ui/negative_space/equatable_is_not_copy.stderr
@@ -1,0 +1,13 @@
+error[E0277]: the trait bound `Equatable<Protected<[u8; 32]>>: Copy` is not satisfied
+ --> tests/ui/negative_space/equatable_is_not_copy.rs:7:18
+  |
+7 |     require_copy(&secret);
+  |     ------------ ^^^^^^^ the trait `Copy` is not implemented for `Equatable<Protected<[u8; 32]>>`
+  |     |
+  |     required by a bound introduced by this call
+  |
+note: required by a bound in `require_copy`
+ --> tests/ui/negative_space/equatable_is_not_copy.rs:3:20
+  |
+3 | fn require_copy<T: Copy>(_: &T) {}
+  |                    ^^^^ required by this bound in `require_copy`

--- a/packages/protected/tests/ui/negative_space/exportable_is_not_copy.rs
+++ b/packages/protected/tests/ui/negative_space/exportable_is_not_copy.rs
@@ -1,0 +1,8 @@
+use vitaminc_protected::{Exportable, Protected};
+
+fn require_copy<T: Copy>(_: &T) {}
+
+fn main() {
+    let secret: Exportable<Protected<[u8; 32]>> = Exportable::new([0_u8; 32]);
+    require_copy(&secret);
+}

--- a/packages/protected/tests/ui/negative_space/exportable_is_not_copy.rs
+++ b/packages/protected/tests/ui/negative_space/exportable_is_not_copy.rs
@@ -1,8 +1,15 @@
-use vitaminc_protected::{Exportable, Protected};
+// `Exportable` wraps a secret whose zeroizing `Drop` reaches the bytes via
+// `Exportable`'s field. A bitwise copy would leave an un-wiped duplicate
+// behind, so `Exportable` itself must never be `Copy`.
+//
+// The payload is a bare `[u8; 32]` on purpose: it *is* `Copy`, so the only
+// thing that can reject this is `Exportable`. (With a `Protected` payload the
+// error would already come from `Protected: !Copy`, and a conditional `Copy`
+// added to `Exportable` would go unnoticed.)
+use vitaminc_protected::Exportable;
 
-fn require_copy<T: Copy>(_: &T) {}
+fn require_copy<T: Copy>() {}
 
 fn main() {
-    let secret: Exportable<Protected<[u8; 32]>> = Exportable::new([0_u8; 32]);
-    require_copy(&secret);
+    require_copy::<Exportable<[u8; 32]>>();
 }

--- a/packages/protected/tests/ui/negative_space/exportable_is_not_copy.stderr
+++ b/packages/protected/tests/ui/negative_space/exportable_is_not_copy.stderr
@@ -1,0 +1,13 @@
+error[E0277]: the trait bound `Exportable<Protected<[u8; 32]>>: Copy` is not satisfied
+ --> tests/ui/negative_space/exportable_is_not_copy.rs:7:18
+  |
+7 |     require_copy(&secret);
+  |     ------------ ^^^^^^^ the trait `Copy` is not implemented for `Exportable<Protected<[u8; 32]>>`
+  |     |
+  |     required by a bound introduced by this call
+  |
+note: required by a bound in `require_copy`
+ --> tests/ui/negative_space/exportable_is_not_copy.rs:3:20
+  |
+3 | fn require_copy<T: Copy>(_: &T) {}
+  |                    ^^^^ required by this bound in `require_copy`

--- a/packages/protected/tests/ui/negative_space/exportable_is_not_copy.stderr
+++ b/packages/protected/tests/ui/negative_space/exportable_is_not_copy.stderr
@@ -1,13 +1,11 @@
-error[E0277]: the trait bound `Exportable<Protected<[u8; 32]>>: Copy` is not satisfied
- --> tests/ui/negative_space/exportable_is_not_copy.rs:7:18
-  |
-7 |     require_copy(&secret);
-  |     ------------ ^^^^^^^ the trait `Copy` is not implemented for `Exportable<Protected<[u8; 32]>>`
-  |     |
-  |     required by a bound introduced by this call
-  |
+error[E0277]: the trait bound `Exportable<[u8; 32]>: Copy` is not satisfied
+  --> tests/ui/negative_space/exportable_is_not_copy.rs:14:20
+   |
+14 |     require_copy::<Exportable<[u8; 32]>>();
+   |                    ^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `Exportable<[u8; 32]>`
+   |
 note: required by a bound in `require_copy`
- --> tests/ui/negative_space/exportable_is_not_copy.rs:3:20
-  |
-3 | fn require_copy<T: Copy>(_: &T) {}
-  |                    ^^^^ required by this bound in `require_copy`
+  --> tests/ui/negative_space/exportable_is_not_copy.rs:11:20
+   |
+11 | fn require_copy<T: Copy>() {}
+   |                    ^^^^ required by this bound in `require_copy`

--- a/packages/protected/tests/ui/negative_space/usage_is_not_copy.rs
+++ b/packages/protected/tests/ui/negative_space/usage_is_not_copy.rs
@@ -1,0 +1,11 @@
+// `Usage` carries a secret through its inner controlled wrapper, whose
+// zeroizing `Drop` reaches the bytes via `Usage`'s field. A bitwise copy
+// would leave an un-wiped duplicate behind, so `Usage` must never be `Copy`.
+use vitaminc_protected::{DefaultScope, Protected, Usage};
+
+fn require_copy<T: Copy>(_: &T) {}
+
+fn main() {
+    let secret: Usage<Protected<[u8; 32]>, DefaultScope> = Usage::new([0_u8; 32]);
+    require_copy(&secret);
+}

--- a/packages/protected/tests/ui/negative_space/usage_is_not_copy.rs
+++ b/packages/protected/tests/ui/negative_space/usage_is_not_copy.rs
@@ -1,11 +1,18 @@
 // `Usage` carries a secret through its inner controlled wrapper, whose
-// zeroizing `Drop` reaches the bytes via `Usage`'s field. A bitwise copy
-// would leave an un-wiped duplicate behind, so `Usage` must never be `Copy`.
-use vitaminc_protected::{DefaultScope, Protected, Usage};
+// zeroizing `Drop` reaches the bytes via `Usage`'s field. A bitwise copy of
+// the scope wrapper would leave an un-wiped duplicate behind, so `Usage`
+// itself must never be `Copy`.
+//
+// The payload here is a bare `[u8; 32]` on purpose: it *is* `Copy`, so the
+// only thing that can reject this call is `Usage` itself. (With a `Protected`
+// payload the error would already come from `Protected: !Copy`, and a `Copy`
+// impl added to `Usage` would go unnoticed.) `Zeroed` is the one constructor
+// that admits a non-controlled payload.
+use vitaminc_protected::{DefaultScope, Usage, Zeroed};
 
 fn require_copy<T: Copy>(_: &T) {}
 
 fn main() {
-    let secret: Usage<Protected<[u8; 32]>, DefaultScope> = Usage::new([0_u8; 32]);
+    let secret: Usage<[u8; 32], DefaultScope> = Usage::zeroed();
     require_copy(&secret);
 }

--- a/packages/protected/tests/ui/negative_space/usage_is_not_copy.rs
+++ b/packages/protected/tests/ui/negative_space/usage_is_not_copy.rs
@@ -3,16 +3,20 @@
 // the scope wrapper would leave an un-wiped duplicate behind, so `Usage`
 // itself must never be `Copy`.
 //
-// The payload here is a bare `[u8; 32]` on purpose: it *is* `Copy`, so the
-// only thing that can reject this call is `Usage` itself. (With a `Protected`
-// payload the error would already come from `Protected: !Copy`, and a `Copy`
-// impl added to `Usage` would go unnoticed.) `Zeroed` is the one constructor
-// that admits a non-controlled payload.
-use vitaminc_protected::{DefaultScope, Usage, Zeroed};
+// Both type arguments are `Copy` on purpose, so the only thing that can
+// reject this is `Usage`. The payload is a bare `[u8; 32]` rather than a
+// `Protected` (whose `!Copy` would mask a `Copy` added to `Usage`), and the
+// scope is a local `Copy` marker rather than `DefaultScope` (a derived
+// `Copy` on `Usage` would also require `Scope: Copy`, so with `DefaultScope`
+// the case would keep failing for the wrong reason).
+use vitaminc_protected::{Scope, Usage};
 
-fn require_copy<T: Copy>(_: &T) {}
+#[derive(Clone, Copy)]
+struct CopyScope;
+impl Scope for CopyScope {}
+
+fn require_copy<T: Copy>() {}
 
 fn main() {
-    let secret: Usage<[u8; 32], DefaultScope> = Usage::zeroed();
-    require_copy(&secret);
+    require_copy::<Usage<[u8; 32], CopyScope>>();
 }

--- a/packages/protected/tests/ui/negative_space/usage_is_not_copy.stderr
+++ b/packages/protected/tests/ui/negative_space/usage_is_not_copy.stderr
@@ -1,0 +1,13 @@
+error[E0277]: the trait bound `Usage<Protected<[u8; 32]>>: Copy` is not satisfied
+  --> tests/ui/negative_space/usage_is_not_copy.rs:10:18
+   |
+10 |     require_copy(&secret);
+   |     ------------ ^^^^^^^ the trait `Copy` is not implemented for `Usage<Protected<[u8; 32]>>`
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: required by a bound in `require_copy`
+  --> tests/ui/negative_space/usage_is_not_copy.rs:6:20
+   |
+ 6 | fn require_copy<T: Copy>(_: &T) {}
+   |                    ^^^^ required by this bound in `require_copy`

--- a/packages/protected/tests/ui/negative_space/usage_is_not_copy.stderr
+++ b/packages/protected/tests/ui/negative_space/usage_is_not_copy.stderr
@@ -1,13 +1,11 @@
-error[E0277]: the trait bound `Usage<[u8; 32]>: Copy` is not satisfied
-  --> tests/ui/negative_space/usage_is_not_copy.rs:17:18
+error[E0277]: the trait bound `Usage<[u8; 32], CopyScope>: Copy` is not satisfied
+  --> tests/ui/negative_space/usage_is_not_copy.rs:21:20
    |
-17 |     require_copy(&secret);
-   |     ------------ ^^^^^^^ the trait `Copy` is not implemented for `Usage<[u8; 32]>`
-   |     |
-   |     required by a bound introduced by this call
+21 |     require_copy::<Usage<[u8; 32], CopyScope>>();
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `Usage<[u8; 32], CopyScope>`
    |
 note: required by a bound in `require_copy`
-  --> tests/ui/negative_space/usage_is_not_copy.rs:13:20
+  --> tests/ui/negative_space/usage_is_not_copy.rs:18:20
    |
-13 | fn require_copy<T: Copy>(_: &T) {}
+18 | fn require_copy<T: Copy>() {}
    |                    ^^^^ required by this bound in `require_copy`

--- a/packages/protected/tests/ui/negative_space/usage_is_not_copy.stderr
+++ b/packages/protected/tests/ui/negative_space/usage_is_not_copy.stderr
@@ -1,13 +1,13 @@
-error[E0277]: the trait bound `Usage<Protected<[u8; 32]>>: Copy` is not satisfied
-  --> tests/ui/negative_space/usage_is_not_copy.rs:10:18
+error[E0277]: the trait bound `Usage<[u8; 32]>: Copy` is not satisfied
+  --> tests/ui/negative_space/usage_is_not_copy.rs:17:18
    |
-10 |     require_copy(&secret);
-   |     ------------ ^^^^^^^ the trait `Copy` is not implemented for `Usage<Protected<[u8; 32]>>`
+17 |     require_copy(&secret);
+   |     ------------ ^^^^^^^ the trait `Copy` is not implemented for `Usage<[u8; 32]>`
    |     |
    |     required by a bound introduced by this call
    |
 note: required by a bound in `require_copy`
-  --> tests/ui/negative_space/usage_is_not_copy.rs:6:20
+  --> tests/ui/negative_space/usage_is_not_copy.rs:13:20
    |
- 6 | fn require_copy<T: Copy>(_: &T) {}
+13 | fn require_copy<T: Copy>(_: &T) {}
    |                    ^^^^ required by this bound in `require_copy`


### PR DESCRIPTION
## Summary

Closes #263.

#263 was filed against the published `vitaminc-protected` 0.2.0-pre.1, where `Protected<T>` asserted the `ZeroizeOnDrop` marker with no `Drop` impl and was `Copy` whenever `T` was. The substance of that fix already landed on `main` in #185 (real derived `ZeroizeOnDrop`, `Copy` removed, `Clone` kept explicit) but has not been released, so the crates.io source the issue quotes is still the broken one.

This PR locks the guarantee in so it cannot regress silently, and documents it. It contains one small additive API change, called out below.

### Tests

Shared observers live in a new `cfg(test)` module `src/test_util.rs`: `Tracked` (a `Copy` payload whose `zeroize` raises a flag, so every drop-wipe observation is the #263 `Copy`-payload case), `Counted`, and `assert_zeroize_on_drop`.

- `drop_zeroizes_inner` on `Protected`, `Equatable` and `Exportable`: dropping the wrapper runs the payload's `zeroize`. Covers #181 and #263.
- `zeroize_wipes_array_payload`: a real `Protected<[u8; 32]>` reads back as zeros after `zeroize()`. The bytes are inspected while the value is live. There is no post-drop byte read; the earlier `ManuallyDrop` version was unsound and was removed.
- `zeroize_on_drop_is_backed_by_drop_glue`: `needs_drop` is false for `[u8; 32]` and `u64` but true for `Protected` of each, so the glue can only be the wrapper's `Drop`.
- `nested_wrappers_keep_zeroizing_drop_glue`: each wrapper checked alone around a glue-free payload, then the two canonical nested shapes.
- `each_clone_is_wiped_independently`: one wipe per drop for an original and its clone.
- `risky_unwrap_does_not_zeroize` on all three wrappers, and `flatten_and_transpose_move_without_zeroizing` on `Protected`: the move-out paths hand on a live value and the receiving owner still wipes.
- `drop_wipes_through_inner_wrapper` and `usage_is_zeroize_on_drop_when_inner_is` on `Usage`.
- trybuild cases `equatable_is_not_copy`, `exportable_is_not_copy`, `usage_is_not_copy`, alongside the existing `protected_is_not_copy`. Each checks the wrapper around a bare `[u8; 32]` (and a `Copy` scope for `Usage`), so the only thing that can reject it is the wrapper itself. Verified by adding `Copy` to each wrapper in turn.

### API change

`impl<T: ZeroizeOnDrop, Scope> ZeroizeOnDrop for Usage<T, Scope> {}` is new. `ZeroizeOnDrop` is a method-less marker, so this needs no `Drop` and no struct bound (same pattern as `ProtectedDigest`). It is correct exactly when the field is `ZeroizeOnDrop`, which is every `Usage` that can hold a secret. Effect for callers: `T: ZeroizeOnDrop` bounds now accept `Usage<..>` instead of forcing the scope wrapper to be stripped first. Additive, non-breaking.

### Docs

- The never-`Copy`, explicit-`clone()` rationale is on the `Protected` item docs. The README, the impl-site note and `PermutationKey` point at it instead of restating it.
- The README's clone claim is scoped to duplicating the wrapper. `risky_unwrap`, `map` and friends hand back plain values with the wiping obligation attached.
- The `Usage` comment says why it has no `Drop` of its own and that the `Zeroed` constructor, which lacks the `Controlled` bound, can only build values that hold zeros.

## Verification

- `cargo test -p vitaminc-protected`: 71 unit, 14 trybuild cases, 48 doctests pass.
- `cargo test --workspace --no-fail-fast` passes apart from `vitaminc-kms::test_finalize`, which needs a local KMS endpoint and fails identically on `main`.
- `cargo clippy --workspace --all-targets`, `cargo doc --no-deps` and `cargo fmt --check` are clean.

Note for release: the fix reaches crates.io users only with the next release of `vitaminc-protected`.

https://claude.ai/code/session_01YJnTLJyFEJL47ZCP33MokQ
