### PR TITLE
fix(prf, hmac)!: make the PRF own its key and derive by reference (#307)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,9 +30,15 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: setup rust stable
+      - name: setup rust
+        # Pinned, not `@stable`: the trybuild cases under
+        # packages/hmac/tests/ui compare rustc diagnostics verbatim, and a
+        # stable release that rewords a diagnostic would fail unrelated PRs.
+        # When bumping, regenerate the pinned output with
+        # `TRYBUILD=overwrite cargo test -p vitaminc-hmac`.
         uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: 1.96.0
           components: clippy, rustfmt
           targets: wasm32-unknown-unknown
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2527,6 +2527,7 @@ dependencies = [
  "quickcheck",
  "quickcheck_macros",
  "sha2",
+ "trybuild",
  "vitaminc-prf",
  "vitaminc-protected",
  "zeroize",

--- a/packages/hmac/Cargo.toml
+++ b/packages/hmac/Cargo.toml
@@ -22,3 +22,4 @@ zeroize = { workspace = true }
 futures = "0.3.31"
 quickcheck = "1.1.0"
 quickcheck_macros = "1.2.0"
+trybuild = "1.0.118"

--- a/packages/hmac/README.md
+++ b/packages/hmac/README.md
@@ -10,7 +10,7 @@ buffer in a wiped allocation, so no unwiped copy of the key material is left
 behind by construction. Each leaf derives
 `HMAC-SHA256(key, PAE(encoding, context, input))`.
 
-## Keying
+## Keying and ownership
 
 `HmacSha256Prf::new` takes a `Protected<[u8; 32]>`, so the key length is
 guaranteed by the type and construction cannot fail. Key material whose length
@@ -18,6 +18,15 @@ is only known at runtime — a KMS response, an environment variable — goes
 through `try_from_bytes`, which rejects anything shorter than `MIN_KEY_LEN`
 with a `WeakKeyError`. HMAC itself accepts a key of any length, including an
 empty one, which would silently produce derivations anybody can recompute.
+
+Both constructors take the key **by value**, and that is the whole ownership
+story: the key moves into the PRF, lives there in one `Protected` allocation,
+and is wiped when the PRF drops. `HmacSha256Prf` is deliberately not `Clone`,
+so there is never a second handle whose lifetime could postpone that wipe.
+Derivation borrows the PRF (`&prf`), so one instance serves as many
+derivations as you like. Code that is generic over "any PRF I can build from a
+key" bounds on `vitaminc_prf::PrfKeyInit`, which `HmacSha256Prf` implements
+with the same two constructors.
 
 ```rust
 use vitaminc_hmac::{HmacSha256Prf, WeakKeyError};
@@ -46,9 +55,15 @@ use vitaminc_protected::Protected;
 # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 let prf = HmacSha256Prf::new(Protected::new([7; 32]));
 let term = "alice@example.com"
-    .prf_with_context(prf, "users/email/exact/v1")
+    .prf_with_context(&prf, "users/email/exact/v1")
     .await?;
 assert_eq!(term.len(), 32);
+
+// The same instance keeps serving; nothing was consumed.
+let again = "bob@example.com"
+    .prf_with_context(&prf, "users/email/exact/v1")
+    .await?;
+assert_ne!(term, again);
 # Ok(())
 # }
 ```
@@ -86,7 +101,7 @@ impl<P> PrfVisitor<[u8; 32], P> for BloomPositions {
 let prf = HmacSha256Prf::new(Protected::new([7; 32]));
 let positions = "alice@example.com"
     .prf_visit(
-        prf,
+        &prf,
         BloomPositions {
             count: 4,
             modulus: 2048,
@@ -122,7 +137,7 @@ struct User {
 impl PrfValue for User {
     fn prf_visit_with_context<'a, P, V, C>(
         self,
-        prf: P,
+        prf: &P,
         context: C,
         visitor: V,
     ) -> P::Ok<V::Value>
@@ -185,7 +200,7 @@ let user = User {
 };
 let prf = HmacSha256Prf::new(Protected::new([7; 32]));
 let terms = user
-    .prf_visit_with_context(prf, "tenant/acme/users/v1", UserTermsVisitor)
+    .prf_visit_with_context(&prf, "tenant/acme/users/v1", UserTermsVisitor)
     .await?;
 
 assert_eq!(terms.aliases.len(), 2);

--- a/packages/hmac/README.md
+++ b/packages/hmac/README.md
@@ -12,24 +12,26 @@ behind by construction. Each leaf derives
 
 ## Keying and ownership
 
-`HmacSha256Prf::new` takes a `Protected<[u8; 32]>`, so the key length is
-guaranteed by the type and construction cannot fail. Key material whose length
-is only known at runtime — a KMS response, an environment variable — goes
-through `try_from_bytes`, which rejects anything shorter than `MIN_KEY_LEN`
-with a `WeakKeyError`. HMAC itself accepts a key of any length, including an
-empty one, which would silently produce derivations anybody can recompute.
+Construction goes through `vitaminc_prf::PrfKeyInit`. `new` takes a
+`Protected<[u8; 32]>`, so the key length is guaranteed by the type and
+construction cannot fail. Key material whose length is only known at runtime —
+a KMS response, an environment variable — goes through `try_from_bytes`, which
+rejects anything shorter than `MIN_KEY_LEN` with a `WeakKeyError`. HMAC itself
+accepts a key of any length, including an empty one, which would silently
+produce derivations anybody can recompute.
 
 Both constructors take the key **by value**, and that is the whole ownership
 story: the key moves into the PRF, lives there in one `Protected` allocation,
 and is wiped when the PRF drops. `HmacSha256Prf` is deliberately not `Clone`,
-so there is never a second handle whose lifetime could postpone that wipe.
-Derivation borrows the PRF (`&prf`), so one instance serves as many
-derivations as you like. Code that is generic over "any PRF I can build from a
-key" bounds on `vitaminc_prf::PrfKeyInit`, which `HmacSha256Prf` implements
-with the same two constructors.
+so there is never a hidden second handle whose lifetime could postpone that
+wipe. Derivation borrows the PRF (`&prf`), so one instance serves as many
+derivations as you like; where a PRF genuinely has to be shared, wrap it in
+an `Arc` so the sharing is visible at every call site (see the
+`HmacSha256Prf` docs).
 
 ```rust
 use vitaminc_hmac::{HmacSha256Prf, WeakKeyError};
+use vitaminc_prf::PrfKeyInit;
 use vitaminc_protected::Protected;
 
 # fn example() -> Result<(), Box<dyn std::error::Error>> {
@@ -48,7 +50,7 @@ Built-in values return the backend's raw block through `prf`. Use
 `prf_with_context` to separate the same value across indexes or applications.
 
 ```rust
-use vitaminc_prf::PrfValue;
+use vitaminc_prf::{PrfKeyInit, PrfValue};
 use vitaminc_hmac::HmacSha256Prf;
 use vitaminc_protected::Protected;
 
@@ -74,7 +76,7 @@ assert_ne!(term, again);
 or other policy in the PRF crates.
 
 ```rust
-use vitaminc_prf::{PrfValue, PrfVisitor, PrfVisitorError};
+use vitaminc_prf::{PrfKeyInit, PrfValue, PrfVisitor, PrfVisitorError};
 use vitaminc_hmac::HmacSha256Prf;
 use vitaminc_protected::Protected;
 
@@ -123,7 +125,7 @@ batch.
 
 ```rust
 use vitaminc_prf::{
-    BlockVisitor, IntoPrfContext, MapAccess, MapPrf, Prf,
+    BlockVisitor, IntoPrfContext, MapAccess, MapPrf, Prf, PrfKeyInit,
     PrfValue, PrfVisitor, PrfVisitorError, SeqAccess,
 };
 use vitaminc_hmac::HmacSha256Prf;

--- a/packages/hmac/src/lib.rs
+++ b/packages/hmac/src/lib.rs
@@ -1,7 +1,7 @@
 #![forbid(unsafe_code)]
 #![doc = include_str!("../README.md")]
 
-use std::{any::Any, borrow::Cow, convert::Infallible, sync::Arc};
+use std::{any::Any, borrow::Cow, convert::Infallible};
 
 use hmac::{
     digest::{
@@ -15,8 +15,8 @@ use vitaminc_protected::{Acceptable, Controlled, DefaultScope, Protected, Protec
 use zeroize::{ZeroizeOnDrop, Zeroizing};
 
 use vitaminc_prf::{
-    MapPrf, Prf, PrfBuildError, PrfContext, PrfEncoding, PrfError, PrfValue, PrfVisitor, ReadyPrf,
-    ResolvedPrf, ResolvedVisitor, SeqPrf,
+    MapPrf, Prf, PrfBuildError, PrfContext, PrfEncoding, PrfError, PrfKeyInit, PrfValue,
+    PrfVisitor, ReadyPrf, ResolvedPrf, ResolvedVisitor, SeqPrf,
 };
 
 type PassthroughValue = Box<dyn Any + Send + 'static>;
@@ -144,18 +144,32 @@ impl ZeroizeOnDrop for ZeroizingHmacSha256 {}
 
 /// Local HMAC-SHA256 structured PRF.
 ///
-/// The key remains in a [`Protected`] allocation shared by nested drivers.
+/// The PRF owns its key outright. Construction takes the key by value, the
+/// key lives in a single [`Protected`] allocation for the life of the PRF,
+/// and it is wiped when the PRF drops, unconditionally. There is no `Clone`:
+/// a shared handle would make that wipe depend on whichever clone happens to
+/// drop last, which no call site can see. Derivation borrows the PRF
+/// (`&self`), so one instance serves any number of derivations.
+///
 /// Each leaf derives `HMAC-SHA256(key, PAE(encoding, context, input))`.
-#[derive(Clone)]
 pub struct HmacSha256Prf {
-    key: Arc<Protected<Vec<u8>>>,
+    key: Protected<Vec<u8>>,
 }
+
+// The only field is `Protected`, which wipes on drop; there is no other copy
+// of the key to leave behind. `ZeroizingHmacSha256` covers the expanded
+// ipad/opad state each derivation builds from it.
+impl ZeroizeOnDrop for HmacSha256Prf {}
 
 impl HmacSha256Prf {
     /// Key the PRF with a full-strength key.
     ///
     /// The array type carries the length guarantee, so this cannot fail.
     pub fn new(key: Protected<[u8; KEY_LEN]>) -> Self {
+        // `risky_ref` + drop, not `map`: `map` moves the array out through
+        // `risky_unwrap`, and a bare `[u8; 32]` has no destructor to wipe it.
+        // Borrowing leaves the array inside its `Protected`, which wipes it
+        // when `key` drops at the end of this call.
         Self::from_vec(Protected::new(key.risky_ref().to_vec()))
     }
 
@@ -176,7 +190,7 @@ impl HmacSha256Prf {
     }
 
     fn from_vec(key: Protected<Vec<u8>>) -> Self {
-        Self { key: Arc::new(key) }
+        Self { key }
     }
 
     fn derive<T>(&self, data: &T, encoding: PrfEncoding, context: &PrfContext<'_>) -> [u8; 32]
@@ -185,7 +199,7 @@ impl HmacSha256Prf {
         T::Inner: AsRef<[u8]>,
     {
         let mut hmac: ProtectedDigest<ZeroizingHmacSha256> =
-            ProtectedDigest::new_with_key(self.key.as_ref())
+            ProtectedDigest::new_with_key(&self.key)
                 .expect("HMAC-SHA256 accepts keys of any length");
 
         // Stream PAE directly into the digest. Building a framed Vec here would
@@ -210,19 +224,32 @@ impl HmacSha256Prf {
     }
 }
 
+impl PrfKeyInit for HmacSha256Prf {
+    type Key = Protected<[u8; KEY_LEN]>;
+    type KeyError = WeakKeyError;
+
+    fn new(key: Self::Key) -> Self {
+        HmacSha256Prf::new(key)
+    }
+
+    fn try_from_bytes(key: Protected<Vec<u8>>) -> Result<Self, Self::KeyError> {
+        HmacSha256Prf::try_from_bytes(key)
+    }
+}
+
 impl Prf for HmacSha256Prf {
     type Block = [u8; 32];
     type BackendError = Infallible;
     type Passthrough = PassthroughValue;
-    type SeqPrf = HmacSeqPrf;
-    type MapPrf = HmacMapPrf;
+    type SeqPrf<'a> = HmacSeqPrf<'a>;
+    type MapPrf<'a> = HmacMapPrf<'a>;
     type Ok<T>
         = ReadyPrf<T, Infallible>
     where
         T: Send + 'static;
 
     fn prf_bytes_vec<V>(
-        self,
+        &self,
         data: Protected<Vec<u8>>,
         encoding: PrfEncoding,
         context: PrfContext<'static>,
@@ -238,7 +265,7 @@ impl Prf for HmacSha256Prf {
     // Overrides the Vec-copying default: fixed-size leaves stream into the
     // digest without an intermediate heap allocation.
     fn prf_bytes_array<const N: usize, V>(
-        self,
+        &self,
         data: Protected<[u8; N]>,
         encoding: PrfEncoding,
         context: PrfContext<'static>,
@@ -251,7 +278,7 @@ impl Prf for HmacSha256Prf {
         Self::resolved(visitor.visit_block(block).map_err(PrfError::Visitor))
     }
 
-    fn prf_seq(self, size_hint: Option<usize>) -> Self::SeqPrf {
+    fn prf_seq(&self, size_hint: Option<usize>) -> Self::SeqPrf<'_> {
         HmacSeqPrf {
             backend: self,
             values: Vec::with_capacity(size_hint.unwrap_or(0)),
@@ -259,7 +286,7 @@ impl Prf for HmacSha256Prf {
         }
     }
 
-    fn prf_map(self, size_hint: Option<usize>) -> Self::MapPrf {
+    fn prf_map(&self, size_hint: Option<usize>) -> Self::MapPrf<'_> {
         HmacMapPrf {
             backend: self,
             entries: Vec::with_capacity(size_hint.unwrap_or(0)),
@@ -268,14 +295,14 @@ impl Prf for HmacSha256Prf {
         }
     }
 
-    fn prf_none<V>(self, _context: PrfContext<'static>, visitor: V) -> Self::Ok<V::Value>
+    fn prf_none<V>(&self, _context: PrfContext<'static>, visitor: V) -> Self::Ok<V::Value>
     where
         V: PrfVisitor<Self::Block, Self::Passthrough>,
     {
         Self::resolved(visitor.visit_absent().map_err(PrfError::Visitor))
     }
 
-    fn passthrough<V>(self, value: Self::Passthrough, visitor: V) -> Self::Ok<V::Value>
+    fn passthrough<V>(&self, value: Self::Passthrough, visitor: V) -> Self::Ok<V::Value>
     where
         V: PrfVisitor<Self::Block, Self::Passthrough>,
     {
@@ -283,7 +310,7 @@ impl Prf for HmacSha256Prf {
     }
 
     fn passthrough_boxed<V>(
-        self,
+        &self,
         value: Box<dyn Any + Send + 'static>,
         visitor: V,
     ) -> Self::Ok<V::Value>
@@ -293,7 +320,7 @@ impl Prf for HmacSha256Prf {
         self.passthrough(value, visitor)
     }
 
-    fn failure<T>(self, error: PrfError<Self::BackendError>) -> Self::Ok<T>
+    fn failure<T>(&self, error: PrfError<Self::BackendError>) -> Self::Ok<T>
     where
         T: Send + 'static,
     {
@@ -301,13 +328,14 @@ impl Prf for HmacSha256Prf {
     }
 }
 
-pub struct HmacSeqPrf {
-    backend: HmacSha256Prf,
+/// Sequence driver borrowing its [`HmacSha256Prf`] for one derivation.
+pub struct HmacSeqPrf<'a> {
+    backend: &'a HmacSha256Prf,
     values: Vec<ResolvedPrf<[u8; 32], PassthroughValue>>,
     error: Option<PrfError<Infallible>>,
 }
 
-impl SeqPrf for HmacSeqPrf {
+impl SeqPrf for HmacSeqPrf<'_> {
     type Prf = HmacSha256Prf;
     type Block = [u8; 32];
     type BackendError = Infallible;
@@ -319,7 +347,7 @@ impl SeqPrf for HmacSeqPrf {
     {
         if self.error.is_none() {
             match value
-                .prf_visit_with_context(self.backend.clone(), context, ResolvedVisitor)
+                .prf_visit_with_context(self.backend, context, ResolvedVisitor)
                 .into_result()
             {
                 Ok(value) => self.values.push(value),
@@ -355,14 +383,15 @@ impl SeqPrf for HmacSeqPrf {
     }
 }
 
-pub struct HmacMapPrf {
-    backend: HmacSha256Prf,
+/// Map driver borrowing its [`HmacSha256Prf`] for one derivation.
+pub struct HmacMapPrf<'a> {
+    backend: &'a HmacSha256Prf,
     entries: Vec<(String, ResolvedPrf<[u8; 32], PassthroughValue>)>,
     pending_key: Option<String>,
     error: Option<PrfError<Infallible>>,
 }
 
-impl HmacMapPrf {
+impl HmacMapPrf<'_> {
     fn set_build_error(&mut self, error: PrfBuildError) {
         if self.error.is_none() {
             self.error = Some(PrfError::Build(error));
@@ -374,7 +403,7 @@ impl HmacMapPrf {
     }
 }
 
-impl MapPrf for HmacMapPrf {
+impl MapPrf for HmacMapPrf<'_> {
     type Prf = HmacSha256Prf;
     type Block = [u8; 32];
     type BackendError = Infallible;
@@ -409,7 +438,7 @@ impl MapPrf for HmacMapPrf {
         }
         let entry_context = context.for_map_entry(&key);
         match value
-            .prf_visit_with_context(self.backend.clone(), entry_context, ResolvedVisitor)
+            .prf_visit_with_context(self.backend, entry_context, ResolvedVisitor)
             .into_result()
         {
             Ok(value) => self.entries.push((key, value)),

--- a/packages/hmac/src/lib.rs
+++ b/packages/hmac/src/lib.rs
@@ -191,14 +191,15 @@ impl ZeroizeOnDrop for ZeroizingHmacSha256 {}
 /// # }
 /// # example().unwrap();
 /// ```
+// Derived, not hand-written: the derive only compiles while every field
+// wipes on drop, so caching key-derived state (say, expanded ipad/opad
+// bytes) in a new field without zeroizing it is a compile error, not a
+// silent leak. `ZeroizingHmacSha256` covers the expanded state each
+// derivation builds from the key.
+#[derive(ZeroizeOnDrop)]
 pub struct HmacSha256Prf {
     key: Protected<Vec<u8>>,
 }
-
-// The only field is `Protected`, which wipes on drop; there is no other copy
-// of the key to leave behind. `ZeroizingHmacSha256` covers the expanded
-// ipad/opad state each derivation builds from it.
-impl ZeroizeOnDrop for HmacSha256Prf {}
 
 impl PrfKeyInit for HmacSha256Prf {
     type Key = Protected<[u8; KEY_LEN]>;

--- a/packages/hmac/src/lib.rs
+++ b/packages/hmac/src/lib.rs
@@ -26,13 +26,13 @@ const SHA256_OUTPUT_SIZE: usize = 32;
 const IPAD: u8 = 0x36;
 const OPAD: u8 = 0x5C;
 
-/// Length of the key accepted by [`HmacSha256Prf::new`].
+/// Length of the key accepted by [`PrfKeyInit::new`] on [`HmacSha256Prf`].
 pub const KEY_LEN: usize = 32;
 
-/// Shortest key accepted by [`HmacSha256Prf::try_from_bytes`].
+/// Shortest key accepted by [`PrfKeyInit::try_from_bytes`] on [`HmacSha256Prf`].
 pub const MIN_KEY_LEN: usize = KEY_LEN;
 
-/// Key material offered to [`HmacSha256Prf::try_from_bytes`] was too short to
+/// Key material offered to [`PrfKeyInit::try_from_bytes`] was too short to
 /// key the PRF safely.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WeakKeyError {
@@ -144,14 +144,53 @@ impl ZeroizeOnDrop for ZeroizingHmacSha256 {}
 
 /// Local HMAC-SHA256 structured PRF.
 ///
-/// The PRF owns its key outright. Construction takes the key by value, the
-/// key lives in a single [`Protected`] allocation for the life of the PRF,
-/// and it is wiped when the PRF drops, unconditionally. There is no `Clone`:
-/// a shared handle would make that wipe depend on whichever clone happens to
-/// drop last, which no call site can see. Derivation borrows the PRF
-/// (`&self`), so one instance serves any number of derivations.
+/// The PRF owns its key outright. Construction goes through [`PrfKeyInit`]
+/// and takes the key by value; the key lives in a single [`Protected`]
+/// allocation for the life of the PRF and is wiped when the PRF drops,
+/// unconditionally. Derivation borrows the PRF (`&self`), so one instance
+/// serves any number of derivations.
 ///
 /// Each leaf derives `HMAC-SHA256(key, PAE(encoding, context, input))`.
+///
+/// # Sharing
+///
+/// `HmacSha256Prf` is deliberately not `Clone`. A clone would either copy the
+/// key or, worse, share it behind a hidden `Arc`, which turns "wiped when
+/// this PRF drops" into "wiped when the last clone drops" with nothing at
+/// the call site to say so. Sharing is still supported; it is just spelled
+/// out by the caller. Wrap the PRF in an [`Arc`](std::sync::Arc) where it
+/// needs to be shared, and the type at every call site then says exactly
+/// when the key is wiped: when the last `Arc` goes away.
+///
+/// ```
+/// use std::sync::Arc;
+/// use vitaminc_hmac::HmacSha256Prf;
+/// use vitaminc_prf::{PrfKeyInit, PrfValue};
+/// use vitaminc_protected::Protected;
+///
+/// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let prf = Arc::new(HmacSha256Prf::new(Protected::new([7; 32])));
+///
+/// // Hand a handle to each place that derives; `Arc<T>` clones without
+/// // `T: Clone`, and `&*handle` is the `&HmacSha256Prf` that derivation
+/// // borrows.
+/// let for_worker = Arc::clone(&prf);
+/// let handle = std::thread::spawn(move || {
+///     "alice@example.com".prf_with_context(&*for_worker, "users/email/v1")
+/// });
+///
+/// let here = "alice@example.com"
+///     .prf_with_context(&*prf, "users/email/v1")
+///     .into_result()?;
+/// let there = handle.join().expect("worker panicked").into_result()?;
+/// assert_eq!(here, there);
+///
+/// // Dropping the last handle wipes the key.
+/// drop(prf);
+/// # Ok(())
+/// # }
+/// # example().unwrap();
+/// ```
 pub struct HmacSha256Prf {
     key: Protected<Vec<u8>>,
 }
@@ -161,11 +200,14 @@ pub struct HmacSha256Prf {
 // ipad/opad state each derivation builds from it.
 impl ZeroizeOnDrop for HmacSha256Prf {}
 
-impl HmacSha256Prf {
+impl PrfKeyInit for HmacSha256Prf {
+    type Key = Protected<[u8; KEY_LEN]>;
+    type KeyError = WeakKeyError;
+
     /// Key the PRF with a full-strength key.
     ///
     /// The array type carries the length guarantee, so this cannot fail.
-    pub fn new(key: Protected<[u8; KEY_LEN]>) -> Self {
+    fn new(key: Self::Key) -> Self {
         // `risky_ref` + drop, not `map`: `map` moves the array out through
         // `risky_unwrap`, and a bare `[u8; 32]` has no destructor to wipe it.
         // Borrowing leaves the array inside its `Protected`, which wipes it
@@ -181,14 +223,16 @@ impl HmacSha256Prf {
     /// Returns [`WeakKeyError`] if the key is shorter than [`MIN_KEY_LEN`].
     /// HMAC itself accepts any key length, including an empty one, which
     /// would silently produce derivations that anybody can recompute.
-    pub fn try_from_bytes(key: Protected<Vec<u8>>) -> Result<Self, WeakKeyError> {
+    fn try_from_bytes(key: Protected<Vec<u8>>) -> Result<Self, Self::KeyError> {
         let len = key.risky_ref().len();
         if len < MIN_KEY_LEN {
             return Err(WeakKeyError { len });
         }
         Ok(Self::from_vec(key))
     }
+}
 
+impl HmacSha256Prf {
     fn from_vec(key: Protected<Vec<u8>>) -> Self {
         Self { key }
     }
@@ -221,19 +265,6 @@ impl HmacSha256Prf {
         result: Result<T, PrfError<Infallible>>,
     ) -> ReadyPrf<T, Infallible> {
         ReadyPrf::new(result)
-    }
-}
-
-impl PrfKeyInit for HmacSha256Prf {
-    type Key = Protected<[u8; KEY_LEN]>;
-    type KeyError = WeakKeyError;
-
-    fn new(key: Self::Key) -> Self {
-        HmacSha256Prf::new(key)
-    }
-
-    fn try_from_bytes(key: Protected<Vec<u8>>) -> Result<Self, Self::KeyError> {
-        HmacSha256Prf::try_from_bytes(key)
     }
 }
 

--- a/packages/hmac/tests/negative_space.rs
+++ b/packages/hmac/tests/negative_space.rs
@@ -1,0 +1,8 @@
+// `trybuild` launches rustc and inspects the filesystem, so these cases run
+// in the normal test job only.
+#[cfg(not(miri))]
+#[test]
+fn negative_space() {
+    let tests = trybuild::TestCases::new();
+    tests.compile_fail("tests/ui/negative_space/*.rs");
+}

--- a/packages/hmac/tests/structured.rs
+++ b/packages/hmac/tests/structured.rs
@@ -619,10 +619,10 @@ fn derivation_is_deterministic(key_suffix: Vec<u8>, context: Vec<u8>, input: Vec
     first == second
 }
 
-/// `HmacSha256Prf` declares `ZeroizeOnDrop`. The marker is hand-written,
-/// so this only checks the declaration exists; the single-owner property it
-/// rests on (no `Clone`) is pinned by the compile-fail case in
-/// `tests/ui/negative_space`.
+/// `HmacSha256Prf` declares `ZeroizeOnDrop`. The impl is derived, so it
+/// only compiles while every field wipes on drop; this test pins the
+/// declaration itself. The single-owner property it rests on (no `Clone`)
+/// is pinned by the compile-fail case in `tests/ui/negative_space`.
 #[test]
 fn prf_declares_zeroize_on_drop() {
     fn assert_zeroize_on_drop<T: ZeroizeOnDrop>() {}

--- a/packages/hmac/tests/structured.rs
+++ b/packages/hmac/tests/structured.rs
@@ -19,9 +19,10 @@ use vitaminc_protected::{Controlled, Protected};
 use vitaminc_hmac::HmacSha256Prf;
 use vitaminc_prf::{
     BlockVisitor, IntoPrfContext, MapAccess, MapPrf, Prf, PrfBuildError, PrfContext, PrfEncoding,
-    PrfError, PrfValue, PrfVisitor, PrfVisitorError, ReadyPrf, ResolvedPrf, ResolvedVisitor,
-    SeqAccess, SeqPrf,
+    PrfError, PrfKeyInit, PrfValue, PrfVisitor, PrfVisitorError, ReadyPrf, ResolvedPrf,
+    ResolvedVisitor, SeqAccess, SeqPrf,
 };
+use zeroize::ZeroizeOnDrop;
 
 type Boxed = Box<dyn Any + Send + 'static>;
 type Node = ResolvedPrf<[u8; 32], Boxed>;
@@ -60,12 +61,12 @@ fn hmac_sha256_known_answer_and_byte_container_equivalence() {
     let array = *b"Hi There";
 
     let from_array = array
-        .prf(HmacSha256Prf::new(Protected::new(key)))
+        .prf(&HmacSha256Prf::new(Protected::new(key)))
         .into_result()
         .unwrap();
     let from_vec = array
         .to_vec()
-        .prf(HmacSha256Prf::new(Protected::new(key)))
+        .prf(&HmacSha256Prf::new(Protected::new(key)))
         .into_result()
         .unwrap();
 
@@ -79,12 +80,12 @@ fn hmac_sha256_normalizes_keys_larger_than_one_hash_block() {
     let input = b"long HMAC key".to_vec();
     let local = input
         .clone()
-        .prf(HmacSha256Prf::try_from_bytes(Protected::new(key_bytes.clone())).unwrap())
+        .prf(&HmacSha256Prf::try_from_bytes(Protected::new(key_bytes.clone())).unwrap())
         .into_result()
         .unwrap();
     let reference = block_on(
         input
-            .prf(DeferredPrf::new(Protected::new(key_bytes)))
+            .prf(&DeferredPrf::new(Protected::new(key_bytes)))
             .into_future(),
     )
     .unwrap();
@@ -112,11 +113,11 @@ impl<P> PrfVisitor<[u8; 32], P> for BloomVisitor {
 
 #[test]
 fn visitors_can_produce_equality_and_bloom_terms() {
-    let equality: [u8; 32] = b"needle".as_slice().prf(local()).into_result().unwrap();
+    let equality: [u8; 32] = b"needle".as_slice().prf(&local()).into_result().unwrap();
     let positions: Vec<i16> = b"needle"
         .as_slice()
         .prf_visit(
-            local(),
+            &local(),
             BloomVisitor {
                 positions: 6,
                 modulus: 2048,
@@ -224,7 +225,7 @@ struct MixedRecord {
 }
 
 impl PrfValue for MixedRecord {
-    fn prf_visit_with_context<'a, P, V, C>(self, prf: P, context: C, visitor: V) -> P::Ok<V::Value>
+    fn prf_visit_with_context<'a, P, V, C>(self, prf: &P, context: C, visitor: V) -> P::Ok<V::Value>
     where
         P: Prf,
         V: PrfVisitor<P::Block, P::Passthrough>,
@@ -252,7 +253,7 @@ fn mixed_record() -> MixedRecord {
 #[test]
 fn handwritten_mixed_record_resolves_heterogeneous_children() {
     let output = mixed_record()
-        .prf_visit_with_context(local(), "tenant-42", RecordVisitor)
+        .prf_visit_with_context(&local(), "tenant-42", RecordVisitor)
         .into_result()
         .unwrap();
     assert_eq!(output.tags.len(), 2);
@@ -360,15 +361,15 @@ impl Prf for DeferredPrf {
     type Block = [u8; 32];
     type BackendError = Infallible;
     type Passthrough = Boxed;
-    type SeqPrf = DeferredSeq;
-    type MapPrf = DeferredMap;
+    type SeqPrf<'a> = DeferredSeq<'a>;
+    type MapPrf<'a> = DeferredMap<'a>;
     type Ok<T>
         = DeferredOutput<T>
     where
         T: Send + 'static;
 
     fn prf_bytes_vec<V>(
-        self,
+        &self,
         data: Protected<Vec<u8>>,
         encoding: PrfEncoding,
         context: PrfContext<'static>,
@@ -382,7 +383,7 @@ impl Prf for DeferredPrf {
         self.output(PendingNode::Leaf(data, encoding, context), visitor)
     }
 
-    fn prf_seq(self, size_hint: Option<usize>) -> Self::SeqPrf {
+    fn prf_seq(&self, size_hint: Option<usize>) -> Self::SeqPrf<'_> {
         DeferredSeq {
             backend: self,
             values: Vec::with_capacity(size_hint.unwrap_or(0)),
@@ -390,7 +391,7 @@ impl Prf for DeferredPrf {
         }
     }
 
-    fn prf_map(self, size_hint: Option<usize>) -> Self::MapPrf {
+    fn prf_map(&self, size_hint: Option<usize>) -> Self::MapPrf<'_> {
         DeferredMap {
             backend: self,
             entries: Vec::with_capacity(size_hint.unwrap_or(0)),
@@ -399,46 +400,46 @@ impl Prf for DeferredPrf {
         }
     }
 
-    fn prf_none<V>(self, _context: PrfContext<'static>, visitor: V) -> Self::Ok<V::Value>
+    fn prf_none<V>(&self, _context: PrfContext<'static>, visitor: V) -> Self::Ok<V::Value>
     where
         V: PrfVisitor<Self::Block, Self::Passthrough>,
     {
         self.output(PendingNode::Absent, visitor)
     }
 
-    fn passthrough<V>(self, value: Self::Passthrough, visitor: V) -> Self::Ok<V::Value>
+    fn passthrough<V>(&self, value: Self::Passthrough, visitor: V) -> Self::Ok<V::Value>
     where
         V: PrfVisitor<Self::Block, Self::Passthrough>,
     {
         self.output(PendingNode::Passthrough(value), visitor)
     }
 
-    fn passthrough_boxed<V>(self, value: Boxed, visitor: V) -> Self::Ok<V::Value>
+    fn passthrough_boxed<V>(&self, value: Boxed, visitor: V) -> Self::Ok<V::Value>
     where
         V: PrfVisitor<Self::Block, Self::Passthrough>,
     {
         self.passthrough(value, visitor)
     }
 
-    fn failure<T>(self, error: PrfError<Self::BackendError>) -> Self::Ok<T>
+    fn failure<T>(&self, error: PrfError<Self::BackendError>) -> Self::Ok<T>
     where
         T: Send + 'static,
     {
         DeferredOutput {
             node: Err(error),
             finish: None,
-            backend: self,
+            backend: self.clone(),
         }
     }
 }
 
-struct DeferredSeq {
-    backend: DeferredPrf,
+struct DeferredSeq<'a> {
+    backend: &'a DeferredPrf,
     values: Vec<PendingNode>,
     error: Option<PrfError<Infallible>>,
 }
 
-impl SeqPrf for DeferredSeq {
+impl SeqPrf for DeferredSeq<'_> {
     type Prf = DeferredPrf;
     type Block = [u8; 32];
     type BackendError = Infallible;
@@ -447,7 +448,7 @@ impl SeqPrf for DeferredSeq {
     fn prf_next<T: PrfValue>(mut self, value: T, context: PrfContext<'static>) -> Self {
         if self.error.is_none() {
             match value
-                .prf_visit_with_context(self.backend.clone(), context, ResolvedVisitor)
+                .prf_visit_with_context(self.backend, context, ResolvedVisitor)
                 .into_node()
             {
                 Ok(node) => self.values.push(node),
@@ -479,14 +480,14 @@ impl SeqPrf for DeferredSeq {
     }
 }
 
-struct DeferredMap {
-    backend: DeferredPrf,
+struct DeferredMap<'a> {
+    backend: &'a DeferredPrf,
     entries: Vec<(String, PendingNode)>,
     pending: Option<String>,
     error: Option<PrfError<Infallible>>,
 }
 
-impl DeferredMap {
+impl DeferredMap<'_> {
     fn build_error(&mut self, error: PrfBuildError) {
         if self.error.is_none() {
             self.error = Some(PrfError::Build(error));
@@ -494,7 +495,7 @@ impl DeferredMap {
     }
 }
 
-impl MapPrf for DeferredMap {
+impl MapPrf for DeferredMap<'_> {
     type Prf = DeferredPrf;
     type Block = [u8; 32];
     type BackendError = Infallible;
@@ -515,11 +516,7 @@ impl MapPrf for DeferredMap {
             return self;
         };
         match value
-            .prf_visit_with_context(
-                self.backend.clone(),
-                context.for_map_entry(&key),
-                ResolvedVisitor,
-            )
+            .prf_visit_with_context(self.backend, context.for_map_entry(&key), ResolvedVisitor)
             .into_node()
         {
             Ok(node) => self.entries.push((key, node)),
@@ -562,7 +559,7 @@ fn deferred_nested_record_executes_one_batch() {
     let calls = backend.batch_calls.clone();
     let output = block_on(
         mixed_record()
-            .prf_visit_with_context(backend, "tenant-42", RecordVisitor)
+            .prf_visit_with_context(&backend, "tenant-42", RecordVisitor)
             .into_future(),
     )
     .unwrap();
@@ -574,12 +571,12 @@ fn deferred_nested_record_executes_one_batch() {
 fn local_and_deferred_backends_match(values: Vec<Vec<u8>>, context: Vec<u8>) -> bool {
     let expected = values
         .clone()
-        .prf_visit_with_context(local(), context.clone(), BlocksVisitor)
+        .prf_visit_with_context(&local(), context.clone(), BlocksVisitor)
         .into_result()
         .unwrap();
     let actual = block_on(
         values
-            .prf_visit_with_context(DeferredPrf::new(key()), context, BlocksVisitor)
+            .prf_visit_with_context(&DeferredPrf::new(key()), context, BlocksVisitor)
             .into_future(),
     )
     .unwrap();
@@ -590,10 +587,10 @@ fn local_and_deferred_backends_match(values: Vec<Vec<u8>>, context: Vec<u8>) -> 
 fn sequence_order_and_shape_are_preserved(values: Vec<Vec<u8>>) -> bool {
     let expected: Vec<_> = values
         .iter()
-        .map(|value| value.clone().prf(local()).into_result().unwrap())
+        .map(|value| value.clone().prf(&local()).into_result().unwrap())
         .collect();
     let structured = values
-        .prf_visit(local(), BlocksVisitor)
+        .prf_visit(&local(), BlocksVisitor)
         .into_result()
         .unwrap();
     expected == structured
@@ -607,19 +604,78 @@ fn derivation_is_deterministic(key_suffix: Vec<u8>, context: Vec<u8>, input: Vec
     let first = input
         .clone()
         .prf_with_context(
-            HmacSha256Prf::try_from_bytes(Protected::new(key_bytes.clone())).unwrap(),
+            &HmacSha256Prf::try_from_bytes(Protected::new(key_bytes.clone())).unwrap(),
             context.clone(),
         )
         .into_result()
         .unwrap();
     let second = input
         .prf_with_context(
-            HmacSha256Prf::try_from_bytes(Protected::new(key_bytes)).unwrap(),
+            &HmacSha256Prf::try_from_bytes(Protected::new(key_bytes)).unwrap(),
             context,
         )
         .into_result()
         .unwrap();
     first == second
+}
+
+/// The key is wiped when the PRF drops, full stop. `HmacSha256Prf` used to
+/// hold its key behind an `Arc` with a derived `Clone`, so the wipe only ran
+/// when the last outstanding clone dropped, which no call site could see.
+#[test]
+fn prf_owns_its_key_and_wipes_it_on_drop() {
+    fn assert_zeroize_on_drop<T: ZeroizeOnDrop>() {}
+    assert_zeroize_on_drop::<HmacSha256Prf>();
+}
+
+/// Derivation borrows the PRF, so one instance serves repeated derivations
+/// without a `Clone` handle and without consuming the key.
+#[test]
+fn one_prf_instance_serves_repeated_derivations_by_reference() {
+    let prf = local();
+    let first: [u8; 32] = b"needle".as_slice().prf(&prf).into_result().unwrap();
+    let second: [u8; 32] = b"needle".as_slice().prf(&prf).into_result().unwrap();
+    let other: [u8; 32] = b"haystack".as_slice().prf(&prf).into_result().unwrap();
+    assert_eq!(first, second);
+    assert_ne!(first, other);
+
+    // Structural drivers borrow the same instance, then hand it back.
+    let terms = vec![vec![1_u8], vec![2_u8]]
+        .prf_visit(&prf, BlocksVisitor)
+        .into_result()
+        .unwrap();
+    assert_eq!(terms.len(), 2);
+    let after: [u8; 32] = b"needle".as_slice().prf(&prf).into_result().unwrap();
+    assert_eq!(first, after);
+}
+
+/// Callers generic over "any PRF constructible from a key" bound on
+/// `PrfKeyInit`; both constructors agree with the inherent ones.
+#[test]
+fn prf_key_init_builds_the_backend_generically() {
+    fn keyed<P: PrfKeyInit>(key: P::Key) -> P {
+        P::new(key)
+    }
+    fn keyed_from_bytes<P: PrfKeyInit>(key: Protected<Vec<u8>>) -> Result<P, P::KeyError> {
+        P::try_from_bytes(key)
+    }
+
+    let via_trait: HmacSha256Prf = keyed(Protected::new(key_bytes()));
+    let via_trait_bytes: HmacSha256Prf = keyed_from_bytes(key()).unwrap();
+    let expected: [u8; 32] = b"needle".as_slice().prf(&local()).into_result().unwrap();
+    let a: [u8; 32] = b"needle".as_slice().prf(&via_trait).into_result().unwrap();
+    let b: [u8; 32] = b"needle"
+        .as_slice()
+        .prf(&via_trait_bytes)
+        .into_result()
+        .unwrap();
+    assert_eq!(a, expected);
+    assert_eq!(b, expected);
+
+    match keyed_from_bytes::<HmacSha256Prf>(Protected::new(vec![0x0b; 16])) {
+        Err(error) => assert_eq!(error.len(), 16),
+        Ok(_) => panic!("a 16-byte key must be rejected through the trait too"),
+    }
 }
 
 #[test]
@@ -652,11 +708,11 @@ fn both_constructors_agree_on_the_same_key() {
     let input = b"same key, same derivation".to_vec();
     let from_array = input
         .clone()
-        .prf(HmacSha256Prf::new(Protected::new(key_bytes())))
+        .prf(&HmacSha256Prf::new(Protected::new(key_bytes())))
         .into_result()
         .unwrap();
     let from_bytes = input
-        .prf(HmacSha256Prf::try_from_bytes(key()).unwrap())
+        .prf(&HmacSha256Prf::try_from_bytes(key()).unwrap())
         .into_result()
         .unwrap();
 
@@ -666,7 +722,7 @@ fn both_constructors_agree_on_the_same_key() {
 #[quickcheck]
 fn equal_sequence_values_share_terms(value: Vec<u8>, context: Vec<u8>) -> bool {
     let terms = vec![value.clone(), value]
-        .prf_visit_with_context(local(), context, BlocksVisitor)
+        .prf_visit_with_context(&local(), context, BlocksVisitor)
         .into_result()
         .unwrap();
     terms[0] == terms[1]
@@ -685,7 +741,7 @@ fn map_key_context_separates_equal_values() {
             map.map(|(_, node)| node.visit(BlockVisitor)).collect()
         }
     }
-    let terms = values.prf_visit(local(), MapBlocks).into_result().unwrap();
+    let terms = values.prf_visit(&local(), MapBlocks).into_result().unwrap();
     assert_ne!(terms[0], terms[1]);
 }
 
@@ -714,7 +770,7 @@ fn structural_and_visitor_errors_remain_distinct() {
 
     let wrong_visitor = b"leaf"
         .as_slice()
-        .prf_visit(local(), BlocksVisitor)
+        .prf_visit(&local(), BlocksVisitor)
         .into_result();
     assert!(matches!(
         wrong_visitor,

--- a/packages/hmac/tests/structured.rs
+++ b/packages/hmac/tests/structured.rs
@@ -651,7 +651,9 @@ fn one_prf_instance_serves_repeated_derivations_by_reference() {
 }
 
 /// Callers generic over "any PRF constructible from a key" bound on
-/// `PrfKeyInit`; both constructors agree with the inherent ones.
+/// `PrfKeyInit` alone (`Prf` is its supertrait). Its two constructor paths,
+/// the fixed-length `new` and the runtime-length `try_from_bytes`, key the
+/// backend identically, and `try_from_bytes` still rejects short keys.
 #[test]
 fn prf_key_init_builds_the_backend_generically() {
     fn keyed<P: PrfKeyInit>(key: P::Key) -> P {
@@ -660,16 +662,16 @@ fn prf_key_init_builds_the_backend_generically() {
     fn keyed_from_bytes<P: PrfKeyInit>(key: Protected<Vec<u8>>) -> Result<P, P::KeyError> {
         P::try_from_bytes(key)
     }
+    // `PrfKeyInit` alone is enough to derive with: `Prf` is its supertrait.
+    fn needle<P: PrfKeyInit>(prf: &P) -> P::Ok<P::Block> {
+        b"needle".as_slice().prf(prf)
+    }
 
     let via_trait: HmacSha256Prf = keyed(Protected::new(key_bytes()));
     let via_trait_bytes: HmacSha256Prf = keyed_from_bytes(key()).unwrap();
-    let expected: [u8; 32] = b"needle".as_slice().prf(&local()).into_result().unwrap();
-    let a: [u8; 32] = b"needle".as_slice().prf(&via_trait).into_result().unwrap();
-    let b: [u8; 32] = b"needle"
-        .as_slice()
-        .prf(&via_trait_bytes)
-        .into_result()
-        .unwrap();
+    let expected: [u8; 32] = needle(&local()).into_result().unwrap();
+    let a: [u8; 32] = needle(&via_trait).into_result().unwrap();
+    let b: [u8; 32] = needle(&via_trait_bytes).into_result().unwrap();
     assert_eq!(a, expected);
     assert_eq!(b, expected);
 

--- a/packages/hmac/tests/structured.rs
+++ b/packages/hmac/tests/structured.rs
@@ -619,11 +619,12 @@ fn derivation_is_deterministic(key_suffix: Vec<u8>, context: Vec<u8>, input: Vec
     first == second
 }
 
-/// The key is wiped when the PRF drops, full stop. `HmacSha256Prf` used to
-/// hold its key behind an `Arc` with a derived `Clone`, so the wipe only ran
-/// when the last outstanding clone dropped, which no call site could see.
+/// `HmacSha256Prf` declares `ZeroizeOnDrop`. The marker is hand-written,
+/// so this only checks the declaration exists; the single-owner property it
+/// rests on (no `Clone`) is pinned by the compile-fail case in
+/// `tests/ui/negative_space`.
 #[test]
-fn prf_owns_its_key_and_wipes_it_on_drop() {
+fn prf_declares_zeroize_on_drop() {
     fn assert_zeroize_on_drop<T: ZeroizeOnDrop>() {}
     assert_zeroize_on_drop::<HmacSha256Prf>();
 }

--- a/packages/hmac/tests/ui/negative_space/hmac_prf_is_not_clone.rs
+++ b/packages/hmac/tests/ui/negative_space/hmac_prf_is_not_clone.rs
@@ -1,0 +1,12 @@
+// `HmacSha256Prf` owns its key and wipes it when it drops. A `Clone` impl
+// would either copy the key or share it behind a hidden `Arc`, and either
+// way "wiped when this PRF drops" stops being true. Share with an explicit
+// `Arc<HmacSha256Prf>` instead, so the sharing is visible at the call site.
+use vitaminc_hmac::HmacSha256Prf;
+use vitaminc_prf::PrfKeyInit;
+use vitaminc_protected::Protected;
+
+fn main() {
+    let prf = HmacSha256Prf::new(Protected::new([7_u8; 32]));
+    let _copy = prf.clone();
+}

--- a/packages/hmac/tests/ui/negative_space/hmac_prf_is_not_clone.stderr
+++ b/packages/hmac/tests/ui/negative_space/hmac_prf_is_not_clone.stderr
@@ -1,0 +1,5 @@
+error[E0599]: no method named `clone` found for struct `HmacSha256Prf` in the current scope
+  --> tests/ui/negative_space/hmac_prf_is_not_clone.rs:11:21
+   |
+11 |     let _copy = prf.clone();
+   |                     ^^^^^ method not found in `HmacSha256Prf`

--- a/packages/prf/README.md
+++ b/packages/prf/README.md
@@ -6,12 +6,20 @@ domain-separated pseudorandom values. Inputs cross backend boundaries in
 backend output is always awaitable so local and remote batched implementations
 share one interface.
 
-This crate defines only the abstraction: the [`PrfValue`](https://docs.rs/vitaminc-prf/latest/vitaminc_prf/trait.PrfValue.html)
-and [`Prf`](https://docs.rs/vitaminc-prf/latest/vitaminc_prf/trait.Prf.html)
+This crate defines only the abstraction: the [`PrfValue`](https://docs.rs/vitaminc-prf/latest/vitaminc_prf/trait.PrfValue.html),
+[`Prf`](https://docs.rs/vitaminc-prf/latest/vitaminc_prf/trait.Prf.html), and
+[`PrfKeyInit`](https://docs.rs/vitaminc-prf/latest/vitaminc_prf/trait.PrfKeyInit.html)
 traits, context and encoding domains, and the visitor machinery. It contains
 no cryptography. Concrete backends live in their own crates; the local
 HMAC-SHA256 backend is [`vitaminc-hmac`](https://docs.rs/vitaminc-hmac),
 and its documentation carries runnable end-to-end examples.
+
+Key ownership lives in exactly one place. `PrfKeyInit` constructs a backend
+from key material taken **by value**, so the key moves into the backend and is
+wiped when the backend drops. Every `Prf` derivation method then borrows the
+backend (`&self`): a derivation is a pure function of the key and the input,
+so nothing is consumed and one instance serves any number of derivations
+without being cloned.
 
 Every protected leaf carries an explicit [`PrfEncoding`](https://docs.rs/vitaminc-prf/latest/vitaminc_prf/struct.PrfEncoding.html)
 domain. Built-in text, bytes, and fixed-width integers are separated even when
@@ -40,7 +48,7 @@ struct User {
 impl PrfValue for User {
     fn prf_visit_with_context<'a, P, V, C>(
         self,
-        prf: P,
+        prf: &P,
         context: C,
         visitor: V,
     ) -> P::Ok<V::Value>
@@ -99,4 +107,4 @@ impl<P> PrfVisitor<[u8; 32], P> for UserTermsVisitor {
 
 Executing the derivation requires a backend; with `vitaminc-hmac` in
 scope the value above resolves through
-`user.prf_visit_with_context(prf, "tenant/acme/users/v1", UserTermsVisitor).await`.
+`user.prf_visit_with_context(&prf, "tenant/acme/users/v1", UserTermsVisitor).await`.

--- a/packages/prf/src/impls.rs
+++ b/packages/prf/src/impls.rs
@@ -30,7 +30,12 @@ impl<T> PrfValue for Passthrough<T>
 where
     T: Send + 'static,
 {
-    fn prf_visit_with_context<'a, P, V, C>(self, prf: P, _context: C, visitor: V) -> P::Ok<V::Value>
+    fn prf_visit_with_context<'a, P, V, C>(
+        self,
+        prf: &P,
+        _context: C,
+        visitor: V,
+    ) -> P::Ok<V::Value>
     where
         P: Prf,
         V: PrfVisitor<P::Block, P::Passthrough>,
@@ -41,7 +46,7 @@ where
 }
 
 impl<const N: usize> PrfValue for [u8; N] {
-    fn prf_visit_with_context<'a, P, V, C>(self, prf: P, context: C, visitor: V) -> P::Ok<V::Value>
+    fn prf_visit_with_context<'a, P, V, C>(self, prf: &P, context: C, visitor: V) -> P::Ok<V::Value>
     where
         P: Prf,
         V: PrfVisitor<P::Block, P::Passthrough>,
@@ -57,7 +62,7 @@ impl<const N: usize> PrfValue for [u8; N] {
 }
 
 impl PrfValue for Box<[u8]> {
-    fn prf_visit_with_context<'a, P, V, C>(self, prf: P, context: C, visitor: V) -> P::Ok<V::Value>
+    fn prf_visit_with_context<'a, P, V, C>(self, prf: &P, context: C, visitor: V) -> P::Ok<V::Value>
     where
         P: Prf,
         V: PrfVisitor<P::Block, P::Passthrough>,
@@ -73,7 +78,7 @@ impl PrfValue for Box<[u8]> {
 }
 
 impl PrfValue for &[u8] {
-    fn prf_visit_with_context<'a, P, V, C>(self, prf: P, context: C, visitor: V) -> P::Ok<V::Value>
+    fn prf_visit_with_context<'a, P, V, C>(self, prf: &P, context: C, visitor: V) -> P::Ok<V::Value>
     where
         P: Prf,
         V: PrfVisitor<P::Block, P::Passthrough>,
@@ -93,7 +98,7 @@ macro_rules! integer_value {
         impl PrfValue for $ty {
             fn prf_visit_with_context<'a, P, V, C>(
                 self,
-                prf: P,
+                prf: &P,
                 context: C,
                 visitor: V,
             ) -> P::Ok<V::Value>
@@ -127,7 +132,7 @@ integer_value!(
 );
 
 impl<const N: usize> PrfValue for Protected<[u8; N]> {
-    fn prf_visit_with_context<'a, P, V, C>(self, prf: P, context: C, visitor: V) -> P::Ok<V::Value>
+    fn prf_visit_with_context<'a, P, V, C>(self, prf: &P, context: C, visitor: V) -> P::Ok<V::Value>
     where
         P: Prf,
         V: PrfVisitor<P::Block, P::Passthrough>,
@@ -143,7 +148,7 @@ impl<const N: usize> PrfValue for Protected<[u8; N]> {
 }
 
 impl PrfValue for Protected<Vec<u8>> {
-    fn prf_visit_with_context<'a, P, V, C>(self, prf: P, context: C, visitor: V) -> P::Ok<V::Value>
+    fn prf_visit_with_context<'a, P, V, C>(self, prf: &P, context: C, visitor: V) -> P::Ok<V::Value>
     where
         P: Prf,
         V: PrfVisitor<P::Block, P::Passthrough>,
@@ -163,7 +168,7 @@ macro_rules! protected_integer_value {
         impl PrfValue for Protected<$ty> {
             fn prf_visit_with_context<'a, P, V, C>(
                 self,
-                prf: P,
+                prf: &P,
                 context: C,
                 visitor: V,
             ) -> P::Ok<V::Value>
@@ -197,7 +202,7 @@ protected_integer_value!(
 );
 
 impl PrfValue for String {
-    fn prf_visit_with_context<'a, P, V, C>(self, prf: P, context: C, visitor: V) -> P::Ok<V::Value>
+    fn prf_visit_with_context<'a, P, V, C>(self, prf: &P, context: C, visitor: V) -> P::Ok<V::Value>
     where
         P: Prf,
         V: PrfVisitor<P::Block, P::Passthrough>,
@@ -213,7 +218,7 @@ impl PrfValue for String {
 }
 
 impl PrfValue for Protected<String> {
-    fn prf_visit_with_context<'a, P, V, C>(self, prf: P, context: C, visitor: V) -> P::Ok<V::Value>
+    fn prf_visit_with_context<'a, P, V, C>(self, prf: &P, context: C, visitor: V) -> P::Ok<V::Value>
     where
         P: Prf,
         V: PrfVisitor<P::Block, P::Passthrough>,
@@ -230,7 +235,7 @@ impl PrfValue for Protected<String> {
 }
 
 impl PrfValue for &str {
-    fn prf_visit_with_context<'a, P, V, C>(self, prf: P, context: C, visitor: V) -> P::Ok<V::Value>
+    fn prf_visit_with_context<'a, P, V, C>(self, prf: &P, context: C, visitor: V) -> P::Ok<V::Value>
     where
         P: Prf,
         V: PrfVisitor<P::Block, P::Passthrough>,
@@ -249,7 +254,7 @@ impl<T> PrfValue for Vec<T>
 where
     T: PrfValue + Send + 'static,
 {
-    fn prf_visit_with_context<'a, P, V, C>(self, prf: P, context: C, visitor: V) -> P::Ok<V::Value>
+    fn prf_visit_with_context<'a, P, V, C>(self, prf: &P, context: C, visitor: V) -> P::Ok<V::Value>
     where
         P: Prf,
         V: PrfVisitor<P::Block, P::Passthrough>,
@@ -290,7 +295,7 @@ impl<T> PrfValue for Option<T>
 where
     T: PrfValue,
 {
-    fn prf_visit_with_context<'a, P, V, C>(self, prf: P, context: C, visitor: V) -> P::Ok<V::Value>
+    fn prf_visit_with_context<'a, P, V, C>(self, prf: &P, context: C, visitor: V) -> P::Ok<V::Value>
     where
         P: Prf,
         V: PrfVisitor<P::Block, P::Passthrough>,
@@ -312,7 +317,7 @@ where
     K: Into<Cow<'static, str>> + Eq + Hash,
     T: PrfValue,
 {
-    fn prf_visit_with_context<'a, P, V, C>(self, prf: P, context: C, visitor: V) -> P::Ok<V::Value>
+    fn prf_visit_with_context<'a, P, V, C>(self, prf: &P, context: C, visitor: V) -> P::Ok<V::Value>
     where
         P: Prf,
         V: PrfVisitor<P::Block, P::Passthrough>,
@@ -341,7 +346,7 @@ where
     K: Into<Cow<'static, str>> + Ord,
     T: PrfValue,
 {
-    fn prf_visit_with_context<'a, P, V, C>(self, prf: P, context: C, visitor: V) -> P::Ok<V::Value>
+    fn prf_visit_with_context<'a, P, V, C>(self, prf: &P, context: C, visitor: V) -> P::Ok<V::Value>
     where
         P: Prf,
         V: PrfVisitor<P::Block, P::Passthrough>,
@@ -379,7 +384,7 @@ mod tests {
     }
 
     fn term<T: PrfValue>(value: T) -> [u8; 32] {
-        value.prf(backend()).into_result().unwrap()
+        value.prf(&backend()).into_result().unwrap()
     }
 
     struct BlocksVisitor;
@@ -432,7 +437,7 @@ mod tests {
     #[test]
     fn passthrough_impl_preserves_the_owned_value() {
         let value = Passthrough::new(42_u32)
-            .prf_visit(backend(), U32PassthroughVisitor)
+            .prf_visit(&backend(), U32PassthroughVisitor)
             .into_result()
             .unwrap();
         assert_eq!(value, 42);
@@ -498,7 +503,7 @@ mod tests {
         let values = vec![String::from("first"), String::from("second")];
         let expected = values.iter().cloned().map(term).collect::<Vec<_>>();
         let actual = values
-            .prf_visit(backend(), BlocksVisitor)
+            .prf_visit(&backend(), BlocksVisitor)
             .into_result()
             .unwrap();
         assert_eq!(actual, expected);
@@ -512,7 +517,7 @@ mod tests {
     #[test]
     fn option_none_impl_visits_absence() {
         None::<String>
-            .prf_visit(backend(), AbsentVisitor)
+            .prf_visit(&backend(), AbsentVisitor)
             .into_result()
             .unwrap();
     }
@@ -561,7 +566,7 @@ mod tests {
             (String::from("right"), String::from("same")),
         ]);
         let terms = values
-            .prf_visit(backend(), MapBlocksVisitor)
+            .prf_visit(&backend(), MapBlocksVisitor)
             .into_result()
             .unwrap();
         assert_eq!(terms.len(), 2);
@@ -587,11 +592,11 @@ mod tests {
             (String::from("mid"), String::from("3")),
         ];
         let ordered = HashMap::from(entries.clone())
-            .prf_visit(backend(), OrderedMapVisitor)
+            .prf_visit(&backend(), OrderedMapVisitor)
             .into_result()
             .unwrap();
         let from_btree = BTreeMap::from(entries)
-            .prf_visit(backend(), OrderedMapVisitor)
+            .prf_visit(&backend(), OrderedMapVisitor)
             .into_result()
             .unwrap();
         assert_eq!(
@@ -611,7 +616,7 @@ mod tests {
             ("right", String::from("same")),
         ]);
         let terms = values
-            .prf_visit(backend(), MapBlocksVisitor)
+            .prf_visit(&backend(), MapBlocksVisitor)
             .into_result()
             .unwrap();
         assert_eq!(

--- a/packages/prf/src/lib.rs
+++ b/packages/prf/src/lib.rs
@@ -17,5 +17,5 @@ pub use encoding::PrfEncoding;
 pub use error::{PrfBuildError, PrfError, PrfVisitorError};
 pub use impls::Passthrough;
 pub use ready::ReadyPrf;
-pub use traits::{MapPrf, Prf, PrfValue, SeqPrf};
+pub use traits::{MapPrf, Prf, PrfKeyInit, PrfValue, SeqPrf};
 pub use visitor::{BlockVisitor, MapAccess, PrfVisitor, ResolvedPrf, ResolvedVisitor, SeqAccess};

--- a/packages/prf/src/test_backend.rs
+++ b/packages/prf/src/test_backend.rs
@@ -48,15 +48,15 @@ impl Prf for MockPrf {
     type Block = [u8; 32];
     type BackendError = Infallible;
     type Passthrough = PassthroughValue;
-    type SeqPrf = MockSeqPrf;
-    type MapPrf = MockMapPrf;
+    type SeqPrf<'a> = MockSeqPrf<'a>;
+    type MapPrf<'a> = MockMapPrf<'a>;
     type Ok<T>
         = ReadyPrf<T, Infallible>
     where
         T: Send + 'static;
 
     fn prf_bytes_vec<V>(
-        self,
+        &self,
         data: Protected<Vec<u8>>,
         encoding: PrfEncoding,
         context: PrfContext<'static>,
@@ -70,7 +70,7 @@ impl Prf for MockPrf {
     }
 
     fn prf_bytes_array<const N: usize, V>(
-        self,
+        &self,
         data: Protected<[u8; N]>,
         encoding: PrfEncoding,
         context: PrfContext<'static>,
@@ -83,7 +83,7 @@ impl Prf for MockPrf {
         Self::resolved(visitor.visit_block(block).map_err(PrfError::Visitor))
     }
 
-    fn prf_seq(self, size_hint: Option<usize>) -> Self::SeqPrf {
+    fn prf_seq(&self, size_hint: Option<usize>) -> Self::SeqPrf<'_> {
         MockSeqPrf {
             backend: self,
             values: Vec::with_capacity(size_hint.unwrap_or(0)),
@@ -91,7 +91,7 @@ impl Prf for MockPrf {
         }
     }
 
-    fn prf_map(self, size_hint: Option<usize>) -> Self::MapPrf {
+    fn prf_map(&self, size_hint: Option<usize>) -> Self::MapPrf<'_> {
         MockMapPrf {
             backend: self,
             entries: Vec::with_capacity(size_hint.unwrap_or(0)),
@@ -100,14 +100,14 @@ impl Prf for MockPrf {
         }
     }
 
-    fn prf_none<V>(self, _context: PrfContext<'static>, visitor: V) -> Self::Ok<V::Value>
+    fn prf_none<V>(&self, _context: PrfContext<'static>, visitor: V) -> Self::Ok<V::Value>
     where
         V: PrfVisitor<Self::Block, Self::Passthrough>,
     {
         Self::resolved(visitor.visit_absent().map_err(PrfError::Visitor))
     }
 
-    fn passthrough<V>(self, value: Self::Passthrough, visitor: V) -> Self::Ok<V::Value>
+    fn passthrough<V>(&self, value: Self::Passthrough, visitor: V) -> Self::Ok<V::Value>
     where
         V: PrfVisitor<Self::Block, Self::Passthrough>,
     {
@@ -115,7 +115,7 @@ impl Prf for MockPrf {
     }
 
     fn passthrough_boxed<V>(
-        self,
+        &self,
         value: Box<dyn Any + Send + 'static>,
         visitor: V,
     ) -> Self::Ok<V::Value>
@@ -125,7 +125,7 @@ impl Prf for MockPrf {
         self.passthrough(value, visitor)
     }
 
-    fn failure<T>(self, error: PrfError<Self::BackendError>) -> Self::Ok<T>
+    fn failure<T>(&self, error: PrfError<Self::BackendError>) -> Self::Ok<T>
     where
         T: Send + 'static,
     {
@@ -133,13 +133,13 @@ impl Prf for MockPrf {
     }
 }
 
-pub(crate) struct MockSeqPrf {
-    backend: MockPrf,
+pub(crate) struct MockSeqPrf<'a> {
+    backend: &'a MockPrf,
     values: Vec<ResolvedPrf<[u8; 32], PassthroughValue>>,
     error: Option<PrfError<Infallible>>,
 }
 
-impl SeqPrf for MockSeqPrf {
+impl SeqPrf for MockSeqPrf<'_> {
     type Prf = MockPrf;
     type Block = [u8; 32];
     type BackendError = Infallible;
@@ -151,7 +151,7 @@ impl SeqPrf for MockSeqPrf {
     {
         if self.error.is_none() {
             match value
-                .prf_visit_with_context(self.backend.clone(), context, ResolvedVisitor)
+                .prf_visit_with_context(self.backend, context, ResolvedVisitor)
                 .into_result()
             {
                 Ok(value) => self.values.push(value),
@@ -187,14 +187,14 @@ impl SeqPrf for MockSeqPrf {
     }
 }
 
-pub(crate) struct MockMapPrf {
-    backend: MockPrf,
+pub(crate) struct MockMapPrf<'a> {
+    backend: &'a MockPrf,
     entries: Vec<(String, ResolvedPrf<[u8; 32], PassthroughValue>)>,
     pending_key: Option<String>,
     error: Option<PrfError<Infallible>>,
 }
 
-impl MockMapPrf {
+impl MockMapPrf<'_> {
     fn set_build_error(&mut self, error: PrfBuildError) {
         if self.error.is_none() {
             self.error = Some(PrfError::Build(error));
@@ -206,7 +206,7 @@ impl MockMapPrf {
     }
 }
 
-impl MapPrf for MockMapPrf {
+impl MapPrf for MockMapPrf<'_> {
     type Prf = MockPrf;
     type Block = [u8; 32];
     type BackendError = Infallible;
@@ -241,7 +241,7 @@ impl MapPrf for MockMapPrf {
         }
         let entry_context = context.for_map_entry(&key);
         match value
-            .prf_visit_with_context(self.backend.clone(), entry_context, ResolvedVisitor)
+            .prf_visit_with_context(self.backend, entry_context, ResolvedVisitor)
             .into_result()
         {
             Ok(value) => self.entries.push((key, value)),

--- a/packages/prf/src/traits.rs
+++ b/packages/prf/src/traits.rs
@@ -10,9 +10,13 @@ use crate::{IntoPrfContext, PrfContext, PrfEncoding, PrfError, PrfVisitor};
 /// The caller supplies a visitor because PRF output is policy-neutral: the
 /// same resolved block can become an equality term, Bloom positions, or an
 /// application-specific record.
+///
+/// Every entry point borrows the backend. A derivation is a pure function of
+/// the key and the input, so nothing is consumed; one backend instance serves
+/// any number of derivations without being cloned.
 pub trait PrfValue {
     /// Derive one raw backend block with no context.
-    fn prf<P>(self, prf: P) -> P::Ok<P::Block>
+    fn prf<P>(self, prf: &P) -> P::Ok<P::Block>
     where
         Self: Sized,
         P: Prf,
@@ -22,7 +26,7 @@ pub trait PrfValue {
 
     /// Derive a structured result with no context and interpret it with
     /// `visitor`.
-    fn prf_visit<P, V>(self, prf: P, visitor: V) -> P::Ok<V::Value>
+    fn prf_visit<P, V>(self, prf: &P, visitor: V) -> P::Ok<V::Value>
     where
         Self: Sized,
         P: Prf,
@@ -32,7 +36,7 @@ pub trait PrfValue {
     }
 
     /// Derive one raw backend block under `context`.
-    fn prf_with_context<'a, P, C>(self, prf: P, context: C) -> P::Ok<P::Block>
+    fn prf_with_context<'a, P, C>(self, prf: &P, context: C) -> P::Ok<P::Block>
     where
         Self: Sized,
         P: Prf,
@@ -44,31 +48,91 @@ pub trait PrfValue {
     /// Derive a structured result under `context` and interpret it with
     /// `visitor`. Implementations provide this method; the other entry points
     /// are conveniences built on it.
-    fn prf_visit_with_context<'a, P, V, C>(self, prf: P, context: C, visitor: V) -> P::Ok<V::Value>
+    fn prf_visit_with_context<'a, P, V, C>(
+        self,
+        prf: &P,
+        context: C,
+        visitor: V,
+    ) -> P::Ok<V::Value>
     where
         P: Prf,
         V: PrfVisitor<P::Block, P::Passthrough>,
         C: IntoPrfContext<'a>;
 }
 
+/// Construction of a [`Prf`] backend from key material.
+///
+/// This is the one place the key changes hands. Both constructors take the
+/// key **by value**, so the material moves into the backend rather than being
+/// copied at the boundary, and the backend owns it for the rest of its life:
+/// when the backend drops, the key is wiped. Backends must not hand out
+/// shared handles to the key (for example behind an `Arc`), because that
+/// turns "wiped when this backend drops" into "wiped when the last
+/// outstanding handle drops", which no call site can see.
+///
+/// The shape mirrors RustCrypto's `KeyInit`, with the deliberate difference
+/// that the key is owned rather than borrowed and copied in.
+pub trait PrfKeyInit: Sized {
+    /// Fixed-size key type whose length is guaranteed by construction, so
+    /// [`new`](PrfKeyInit::new) cannot fail. Always a controlled type; a
+    /// bare array cannot key a backend.
+    type Key: Controlled;
+
+    /// Reason [`try_from_bytes`](PrfKeyInit::try_from_bytes) can reject key
+    /// material, typically because it is too short.
+    type KeyError: std::error::Error + Send + Sync + 'static;
+
+    /// Key the backend with a full-strength key of the statically known
+    /// length.
+    fn new(key: Self::Key) -> Self;
+
+    /// Key the backend with material whose length is only known at runtime,
+    /// such as a KMS response or an environment variable.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KeyError`](PrfKeyInit::KeyError) if the material is not
+    /// acceptable as a key.
+    fn try_from_bytes(key: Protected<Vec<u8>>) -> Result<Self, Self::KeyError>;
+}
+
 /// Backend for structured pseudorandom derivation.
+///
+/// Every method borrows the backend. The structural drivers returned by
+/// [`prf_seq`](Prf::prf_seq) and [`prf_map`](Prf::prf_map) borrow it for the
+/// length of one derivation, which is why they carry a lifetime. Results do
+/// not: [`Ok`](Prf::Ok) has no lifetime parameter, so no borrow of the backend
+/// can escape into an awaitable output.
 pub trait Prf: Sized {
     type Block: Send + 'static;
     type BackendError: std::error::Error + Send + Sync + 'static;
     type Passthrough: Send + 'static;
-    type SeqPrf: SeqPrf<
-        Prf = Self,
-        Block = Self::Block,
-        BackendError = Self::BackendError,
-        Passthrough = Self::Passthrough,
-    >;
-    type MapPrf: MapPrf<
-        Prf = Self,
-        Block = Self::Block,
-        BackendError = Self::BackendError,
-        Passthrough = Self::Passthrough,
-    >;
 
+    /// Driver for sequence-shaped values, borrowing the backend for one
+    /// derivation.
+    type SeqPrf<'a>: SeqPrf<
+        Prf = Self,
+        Block = Self::Block,
+        BackendError = Self::BackendError,
+        Passthrough = Self::Passthrough,
+    >
+    where
+        Self: 'a;
+
+    /// Driver for map-shaped values, borrowing the backend for one
+    /// derivation.
+    type MapPrf<'a>: MapPrf<
+        Prf = Self,
+        Block = Self::Block,
+        BackendError = Self::BackendError,
+        Passthrough = Self::Passthrough,
+    >
+    where
+        Self: 'a;
+
+    /// Awaitable output. It carries no lifetime, so it must own everything it
+    /// needs to resolve; a deferred backend that resolves later must hold its
+    /// own key material rather than borrow this backend's.
     type Ok<T>: IntoFuture<Output = Result<T, PrfError<Self::BackendError>>>
     where
         T: Send + 'static;
@@ -77,7 +141,7 @@ pub trait Prf: Sized {
     /// domain. Backends must bind the encoding, context, and input with
     /// prefix-free framing.
     fn prf_bytes_vec<V>(
-        self,
+        &self,
         data: Protected<Vec<u8>>,
         encoding: PrfEncoding,
         context: PrfContext<'static>,
@@ -88,7 +152,7 @@ pub trait Prf: Sized {
 
     /// Fixed-array counterpart to [`prf_bytes_vec`](Prf::prf_bytes_vec).
     fn prf_bytes_array<const N: usize, V>(
-        self,
+        &self,
         data: Protected<[u8; N]>,
         encoding: PrfEncoding,
         context: PrfContext<'static>,
@@ -105,11 +169,11 @@ pub trait Prf: Sized {
         )
     }
 
-    fn prf_seq(self, size_hint: Option<usize>) -> Self::SeqPrf;
-    fn prf_map(self, size_hint: Option<usize>) -> Self::MapPrf;
+    fn prf_seq(&self, size_hint: Option<usize>) -> Self::SeqPrf<'_>;
+    fn prf_map(&self, size_hint: Option<usize>) -> Self::MapPrf<'_>;
 
     fn prf_some<T, V>(
-        self,
+        &self,
         value: T,
         context: PrfContext<'static>,
         visitor: V,
@@ -121,19 +185,19 @@ pub trait Prf: Sized {
         value.prf_visit_with_context(self, context, visitor)
     }
 
-    fn prf_none<V>(self, context: PrfContext<'static>, visitor: V) -> Self::Ok<V::Value>
+    fn prf_none<V>(&self, context: PrfContext<'static>, visitor: V) -> Self::Ok<V::Value>
     where
         V: PrfVisitor<Self::Block, Self::Passthrough>;
 
     /// Explicit, non-secret output channel. The value is not processed by the
     /// PRF and must never contain secret material.
-    fn passthrough<V>(self, value: Self::Passthrough, visitor: V) -> Self::Ok<V::Value>
+    fn passthrough<V>(&self, value: Self::Passthrough, visitor: V) -> Self::Ok<V::Value>
     where
         V: PrfVisitor<Self::Block, Self::Passthrough>;
 
     /// Type-erased passthrough for generic [`PrfValue`] implementations.
     fn passthrough_boxed<V>(
-        self,
+        &self,
         value: Box<dyn Any + Send + 'static>,
         visitor: V,
     ) -> Self::Ok<V::Value>
@@ -142,17 +206,19 @@ pub trait Prf: Sized {
 
     /// Construct an already-failed deferred output. This lets structural
     /// drivers preserve the uniform awaitable return type.
-    fn failure<T>(self, error: PrfError<Self::BackendError>) -> Self::Ok<T>
+    fn failure<T>(&self, error: PrfError<Self::BackendError>) -> Self::Ok<T>
     where
         T: Send + 'static;
 }
 
+/// Sequence driver. A driver is owned by one caller for the length of one
+/// derivation, so its builder methods consume and return `Self`; it borrows
+/// the backend it was created from.
 pub trait SeqPrf: Sized {
     type Prf: Prf<
         Block = Self::Block,
         BackendError = Self::BackendError,
         Passthrough = Self::Passthrough,
-        SeqPrf = Self,
     >;
     type Block: Send + 'static;
     type BackendError: std::error::Error + Send + Sync + 'static;
@@ -172,12 +238,12 @@ pub trait SeqPrf: Sized {
         V: PrfVisitor<Self::Block, Self::Passthrough>;
 }
 
+/// Map driver. See [`SeqPrf`] for the ownership convention.
 pub trait MapPrf: Sized {
     type Prf: Prf<
         Block = Self::Block,
         BackendError = Self::BackendError,
         Passthrough = Self::Passthrough,
-        MapPrf = Self,
     >;
     type Block: Send + 'static;
     type BackendError: std::error::Error + Send + Sync + 'static;

--- a/packages/prf/src/traits.rs
+++ b/packages/prf/src/traits.rs
@@ -72,7 +72,11 @@ pub trait PrfValue {
 ///
 /// The shape mirrors RustCrypto's `KeyInit`, with the deliberate difference
 /// that the key is owned rather than borrowed and copied in.
-pub trait PrfKeyInit: Sized {
+///
+/// [`Prf`] is a supertrait, so `P: PrfKeyInit` alone says "a PRF I can
+/// build from a key"; generic code does not need to spell out `P: Prf` as
+/// well.
+pub trait PrfKeyInit: Prf {
     /// Fixed-size key type whose length is guaranteed by construction, so
     /// [`new`](PrfKeyInit::new) cannot fail. Always a controlled type; a
     /// bare array cannot key a backend.


### PR DESCRIPTION
## Summary

Closes #307.

`HmacSha256Prf` took its key by value and then immediately put it behind an `Arc` with a derived `Clone`. The `Arc` existed only because every `Prf` derivation method consumed `self`, so any caller deriving more than once needed a clonable handle. The price was the constructor's ownership guarantee: the key was wiped when the last clone happened to drop, not when the PRF did, and nothing at any call site said which. The HMAC work itself was already a borrow (`derive(&self)`), so the receiver convention was the only thing forcing the share.

## Changes

**`vitaminc-prf`**

- `Prf` derivation methods take `&self`. `SeqPrf` and `MapPrf` are now lifetime GATs (`type SeqPrf<'a> where Self: 'a`) so the drivers can borrow the backend for one derivation. `Ok<T>` stays lifetime-free, so no borrow of the backend can escape into an awaitable result; the trait docs now say so.
- `PrfValue` entry points take `&P`.
- New `PrfKeyInit` trait holds the ownership contract in one place: `new(Self::Key)` and `try_from_bytes(Protected<Vec<u8>>)` both take the key by value (deliberately unlike RustCrypto's `KeyInit`, which borrows and copies), with `Key: Controlled` so a bare array cannot key a backend. Generic code can bound on "any PRF constructible from a key".
- `SeqPrf`/`MapPrf` drop the `SeqPrf = Self` back-reference on their `Prf` associated type, which cannot be stated against a GAT without HRTBs. Driver builder methods still consume `self`; a driver is owned by one caller for one derivation.

**`vitaminc-hmac`**

- `HmacSha256Prf { key: Protected<Vec<u8>> }`. No `Arc`, no `Clone`. Carries an honest `ZeroizeOnDrop` marker: the only field is `Protected`, and the ipad/opad expansion per derivation is already covered by `ZeroizingHmacSha256`.
- `HmacSeqPrf<'a>` / `HmacMapPrf<'a>` borrow the backend.
- `HmacSha256Prf` implements `PrfKeyInit` and that impl is its **only** constructor surface. The inherent `new` / `try_from_bytes` were removed in review as redundant with the trait; the bodies and docs moved onto the impl.
- The test-only deferred backend keeps `Clone` (behind `Arc`s) because its awaitable output must own what it resolves with. That is exactly the case the `Ok<T>` docs describe.

**Tests and docs**

- `prf_declares_zeroize_on_drop`, `one_prf_instance_serves_repeated_derivations_by_reference`, `prf_key_init_builds_the_backend_generically` added to `packages/hmac/tests/structured.rs`.
- trybuild compile-fail case asserting `HmacSha256Prf` cannot be cloned, so reintroducing `Clone` breaks CI.
- Both READMEs and all doctests updated for `&prf`, with a new ownership section.

## Breaking changes

None of this is released, but for the record:

- **`Prf` receivers.** Every derivation method takes `&self`; `SeqPrf`/`MapPrf` are lifetime GATs. `Prf` and `PrfValue` implementors must update signatures. Callers pass `&prf` instead of `prf`.
- **`HmacSha256Prf` is no longer `Clone`.** Share with an explicit `Arc<HmacSha256Prf>` (documented on the type with a doctest).
- **Constructors moved to the `PrfKeyInit` trait.** `HmacSha256Prf::new(..)` and `HmacSha256Prf::try_from_bytes(..)` keep their call syntax but now require `use vitaminc_prf::PrfKeyInit;` in scope. Deliberate: one constructor surface, not two that mirror each other.
- `SeqPrf`/`MapPrf` lose the `SeqPrf = Self` / `MapPrf = Self` back-reference bound on their `Prf` associated type.

## Downstream

In `stack-encrypt`, the eight `cipher.prf().clone()` call sites become `cipher.prf()`, construction sites add the `PrfKeyInit` import, and the index key is wiped when the `StackCipher` drops, full stop.

## Verification

- `cargo test -p vitaminc-prf -p vitaminc-hmac`: 52 + 3 unit, 20 integration, 5 doctests, all pass.
- Workspace `cargo test` is green except `vitaminc-kms::tests::test_finalize`, which fails identically on `main` because it needs LocalStack on `127.0.0.1:4566` (connection refused); `vitaminc-kms` does not depend on these crates.
- `cargo clippy --no-deps --all-targets --all-features -- -D warnings`, `cargo doc --workspace --all-features --no-deps`, and `cargo fmt --check` are clean.

https://claude.ai/code/session_01Ckno5am1eZQGtzki5mbH3C

