### PR TITLE
feat(aead): a context exposes its parts as an `AadPiece` tree, not only its bytes

### DIFF
--- a/packages/aead-value/src/aad.rs
+++ b/packages/aead-value/src/aad.rs
@@ -16,7 +16,9 @@
 //! makes a value self-describing; this AAD binding lets a schema enforce a
 //! type up front.
 
-use vitaminc_aead::{Aad, IntoAad};
+use std::borrow::Cow;
+
+use vitaminc_aead::{Aad, AadPiece, IntoAad};
 
 /// Domain-separation label for the leaf-type AAD binding. The leading label
 /// keeps the encoding disjoint from `Aad::for_map_entry` and from
@@ -58,6 +60,17 @@ impl<'a> IntoAad<'a> for LeafTypeAad<'a> {
         // semantics live here, in the value crate that owns the tag table.
         Aad::pae(&[LEAF_TYPE_DOMAIN, self.base.as_bytes(), &[self.tag]])
     }
+
+    /// The same three PAE parts as `into_aad`: domain label, base, tag. The
+    /// base was encoded by [`LeafTypeAad::new`], so it appears as opaque
+    /// bytes here rather than as its own parts.
+    fn into_aad_piece(self) -> AadPiece<'a> {
+        AadPiece::List(vec![
+            AadPiece::Bytes(Cow::Borrowed(LEAF_TYPE_DOMAIN)),
+            self.base.into_aad_piece(),
+            AadPiece::Bytes(Cow::Owned(vec![self.tag])),
+        ])
+    }
 }
 
 #[cfg(test)]
@@ -72,6 +85,25 @@ mod tests {
         let bound = LeafTypeAad::new(Aad::from_slice(b"ctx"), 0x05).into_aad();
         let expected = Aad::pae(&[b"vitaminc/aead-value/leaf-type/v1", b"ctx", &[0x05]]);
         assert_eq!(bound.as_bytes(), expected.as_bytes());
+    }
+
+    #[test]
+    fn leaf_type_parts_encode_to_the_pinned_bytes() {
+        // The parts view must agree with the bytes view byte for byte, as
+        // every override in the workspace does.
+        let bound = LeafTypeAad::new(Aad::from_slice(b"ctx"), 0x05);
+        let expected = Aad::pae(&[b"vitaminc/aead-value/leaf-type/v1", b"ctx", &[0x05]]);
+        assert_eq!(
+            bound.into_aad_piece().into_aad().as_bytes(),
+            expected.as_bytes()
+        );
+        assert_eq!(
+            LeafTypeAad::new("ctx", 0x05)
+                .into_aad_piece()
+                .leaves()
+                .count(),
+            3
+        );
     }
 
     #[test]

--- a/packages/aead/README.md
+++ b/packages/aead/README.md
@@ -222,6 +222,32 @@ use vitaminc_aead::Encrypt;
 "my-secret".encrypt_with_aad(&cipher, ())?;
 ```
 
+Every one of those types also describes itself as a tree of *parts*, before
+framing, through `IntoAad::into_aad_piece` — for a consumer that has to name what the
+bytes were built from (a key service logging the field a key was issued for,
+an audit trail, a structured binding built from the same parts as the AAD)
+rather than parse PAE back out of them:
+
+```rust
+use vitaminc_aead::{AadPiece, IntoAad};
+
+let piece = ("users/email", 7u64).into_aad_piece();
+assert_eq!(piece.to_string(), "(\"users/email\", 7u64)");
+assert_eq!(piece.leaves().count(), 2);
+// Same bytes, one extra view.
+assert_eq!(
+    piece.into_aad().as_bytes(),
+    ("users/email", 7u64).into_aad().as_bytes()
+);
+```
+
+`into_aad_piece` is a provided method on `IntoAad`, defaulting to the whole encoding as one opaque
+`Bytes` leaf, so a context type of your own keeps compiling with only `into_aad` and overrides
+`into_aad_piece` when it wants its parts named. A `ContextTag` hands its cipher a context whose
+`into_aad_piece()` is `List([extra_aad, tag])`, so a backend can read the parts directly, while
+`into_aad()` still writes the bytes in one allocation. `Display` is injective (Rust literal
+syntax), so two contexts that authenticate different bytes never share a log line.
+
 ### Working with Protected Types
 
 The crate integrates with `vitaminc-protected` so sensitive plaintext stays wrapped:

--- a/packages/aead/src/aad/mod.rs
+++ b/packages/aead/src/aad/mod.rs
@@ -1,6 +1,9 @@
 mod pae;
+mod piece;
 
 use std::borrow::Cow;
+
+pub use piece::AadPiece;
 
 use vitaminc_protected::NonEmpty;
 
@@ -190,11 +193,69 @@ impl<'a> Aad<'a> {
 /// integers, tuples, options). Composite implementations use Pre-Authentication
 /// Encoding (PAE) so structurally distinct inputs always encode to distinct
 /// byte strings.
+///
+/// A context has two views. [`into_aad`](Self::into_aad) is the *bytes*
+/// view, what the AEAD authenticates. [`into_aad_piece`](Self::into_aad_piece)
+/// is the *parts* view, an [`AadPiece`] tree for a consumer that needs to
+/// name what those bytes were built from (a log, an audit trail, a
+/// structured binding). The parts view is a provided method, defaulting to
+/// the whole encoding as one opaque `Bytes` leaf, so every `IntoAad` type
+/// has one and a type that implements only `into_aad` keeps compiling and
+/// keeps working. Override it to expose structure. The contract for an
+/// override: `x.into_aad_piece().into_aad()` is byte-for-byte
+/// `x.into_aad()`. Every built-in upholds it, pinned by quickcheck.
+///
+/// ```rust
+/// use std::borrow::Cow;
+/// use vitaminc_aead::{Aad, AadPiece, IntoAad};
+///
+/// // Bytes only: the parts view is the encoding as one opaque leaf.
+/// struct Opaque;
+/// impl<'a> IntoAad<'a> for Opaque {
+///     fn into_aad(self) -> Aad<'a> {
+///         "opaque".into_aad()
+///     }
+/// }
+/// assert_eq!(
+///     Opaque.into_aad_piece(),
+///     AadPiece::Bytes(Cow::Borrowed(b"opaque")),
+/// );
+///
+/// // Structured: override the parts view, and keep the bytes identical.
+/// struct TenantId(u64);
+/// impl<'a> IntoAad<'a> for TenantId {
+///     fn into_aad(self) -> Aad<'a> {
+///         ("tenant", self.0).into_aad()
+///     }
+///     fn into_aad_piece(self) -> AadPiece<'a> {
+///         ("tenant", self.0).into_aad_piece()
+///     }
+/// }
+/// let id = TenantId(7);
+/// assert_eq!(id.into_aad_piece().to_string(), "(\"tenant\", 7u64)");
+/// assert_eq!(
+///     TenantId(7).into_aad_piece().into_aad().as_bytes(),
+///     TenantId(7).into_aad().as_bytes(),
+/// );
+/// ```
 pub trait IntoAad<'a> {
     /// Convert `self` into an [`Aad`].
     fn into_aad(self) -> Aad<'a>
     where
         Self: Sized;
+
+    /// Describe `self` as an [`AadPiece`] tree that encodes to the same
+    /// bytes as [`into_aad`](Self::into_aad).
+    ///
+    /// Provided: the whole encoding as a single [`AadPiece::Bytes`] leaf,
+    /// which is always correct and never exposes structure. Override it to
+    /// name the parts.
+    fn into_aad_piece(self) -> AadPiece<'a>
+    where
+        Self: Sized,
+    {
+        AadPiece::Bytes(self.into_aad().0)
+    }
 }
 
 // `Aad` deliberately does NOT implement `MaybeEmpty`: an already-encoded AAD can
@@ -213,12 +274,20 @@ where
     fn into_aad(self) -> Aad<'a> {
         self.into_inner().into_aad()
     }
+
+    fn into_aad_piece(self) -> AadPiece<'a> {
+        self.into_inner().into_aad_piece()
+    }
 }
 
 /// Self type is already an Aad
 impl<'a> IntoAad<'a> for Aad<'a> {
     fn into_aad(self) -> Aad<'a> {
         self
+    }
+
+    fn into_aad_piece(self) -> AadPiece<'a> {
+        AadPiece::Bytes(self.0)
     }
 }
 
@@ -227,11 +296,19 @@ impl<'a> IntoAad<'a> for () {
     fn into_aad(self) -> Aad<'a> {
         Aad::from_slice(&[])
     }
+
+    fn into_aad_piece(self) -> AadPiece<'a> {
+        AadPiece::Bytes(Cow::Borrowed(&[]))
+    }
 }
 
 impl<'a> IntoAad<'a> for &'a [u8] {
     fn into_aad(self) -> Aad<'a> {
         Aad::from_slice(self)
+    }
+
+    fn into_aad_piece(self) -> AadPiece<'a> {
+        AadPiece::Bytes(Cow::Borrowed(self))
     }
 }
 
@@ -239,11 +316,19 @@ impl<'a> IntoAad<'a> for Vec<u8> {
     fn into_aad(self) -> Aad<'a> {
         Aad::new_owned(self)
     }
+
+    fn into_aad_piece(self) -> AadPiece<'a> {
+        AadPiece::Bytes(Cow::Owned(self))
+    }
 }
 
 impl<'a, const N: usize> IntoAad<'a> for [u8; N] {
     fn into_aad(self) -> Aad<'a> {
         Aad::new_owned(self)
+    }
+
+    fn into_aad_piece(self) -> AadPiece<'a> {
+        AadPiece::Bytes(Cow::Owned(self.to_vec()))
     }
 }
 
@@ -251,11 +336,19 @@ impl<'a, const N: usize> IntoAad<'a> for &'a [u8; N] {
     fn into_aad(self) -> Aad<'a> {
         Aad::from_slice(self.as_slice())
     }
+
+    fn into_aad_piece(self) -> AadPiece<'a> {
+        AadPiece::Bytes(Cow::Borrowed(self.as_slice()))
+    }
 }
 
 impl<'a> IntoAad<'a> for String {
     fn into_aad(self) -> Aad<'a> {
         Aad::new_owned(self.into_bytes())
+    }
+
+    fn into_aad_piece(self) -> AadPiece<'a> {
+        AadPiece::Text(Cow::Owned(self))
     }
 }
 
@@ -263,16 +356,24 @@ impl<'a> IntoAad<'a> for Cow<'a, [u8]> {
     fn into_aad(self) -> Aad<'a> {
         Aad(self)
     }
+
+    fn into_aad_piece(self) -> AadPiece<'a> {
+        AadPiece::Bytes(self)
+    }
 }
 
 impl<'a> IntoAad<'a> for &'a str {
     fn into_aad(self) -> Aad<'a> {
         Aad::from_slice(self.as_bytes())
     }
+
+    fn into_aad_piece(self) -> AadPiece<'a> {
+        AadPiece::Text(Cow::Borrowed(self))
+    }
 }
 
 macro_rules! integer_aad {
-    ($($ty:ty),+ $(,)?) => {$(
+    ($($ty:ty => $variant:ident),+ $(,)?) => {$(
         /// An integer encodes as its raw little-endian bytes, with no type
         /// tag — matching the original `u64` wire format. Distinct integer
         /// types of the same width therefore encode identically; compose a
@@ -281,11 +382,20 @@ macro_rules! integer_aad {
             fn into_aad(self) -> Aad<'a> {
                 Aad::new_owned(self.to_le_bytes())
             }
+
+            /// The integer as its own [`AadPiece`] variant, so the parts
+            /// view keeps the type the encoding drops.
+            fn into_aad_piece(self) -> AadPiece<'a> {
+                AadPiece::$variant(self)
+            }
         }
     )+};
 }
 
-integer_aad!(u8, u16, u32, u64, u128, i8, i16, i32, i64, i128);
+integer_aad!(
+    u8 => U8, u16 => U16, u32 => U32, u64 => U64, u128 => U128,
+    i8 => I8, i16 => I16, i32 => I32, i64 => I64, i128 => I128,
+);
 
 impl<'a, T> IntoAad<'a> for Option<T>
 where
@@ -296,6 +406,10 @@ where
             Some(value) => Aad::pae(&[value.into_aad().as_bytes()]),
             None => Aad::pae(&[]),
         }
+    }
+
+    fn into_aad_piece(self) -> AadPiece<'a> {
+        AadPiece::List(self.into_iter().map(T::into_aad_piece).collect())
     }
 }
 
@@ -309,6 +423,11 @@ where
         let a = a.into_aad();
         let b = b.into_aad();
         Aad::pae(&[a.as_bytes(), b.as_bytes()])
+    }
+
+    fn into_aad_piece(self) -> AadPiece<'a> {
+        let (a, b) = self;
+        AadPiece::List(vec![a.into_aad_piece(), b.into_aad_piece()])
     }
 }
 

--- a/packages/aead/src/aad/piece.rs
+++ b/packages/aead/src/aad/piece.rs
@@ -1,0 +1,629 @@
+//! A context's *parts*, before framing.
+//!
+//! [`IntoAad`] hands a consumer the final, PAE-framed byte string of a
+//! context and nothing else — exactly what the AEAD wants, and nothing a
+//! consumer that needs to *name* the parts can use: a key-management
+//! service logging which field a data key was issued for, an audit trail,
+//! a structured binding built from the same parts as the AAD. Recovering
+//! the parts from the bytes would mean parsing PAE heuristically, which is
+//! neither injective nor this crate's contract.
+//!
+//! [`IntoAad::into_aad_piece`] is the second view: the same context as an
+//! [`AadPiece`] tree — text, bytes and integers at the leaves, PAE-framed
+//! lists at the branches — which encodes to **exactly** the bytes
+//! [`IntoAad::into_aad`] produces. It is a provided method, defaulting to
+//! the whole encoding as one opaque `Bytes` leaf, so every context type has
+//! a parts view and only the ones that override it expose structure.
+//!
+//! A [`ContextTag`](crate::ContextTag) hands its cipher a context whose
+//! parts view is the whole tree, `List([extra_aad, tag])`, so a backend
+//! that logs or binds the parts (a key-management service) reads them
+//! straight from what it is given, while a backend that only wants bytes
+//! pays nothing for the view.
+
+use std::borrow::Cow;
+use std::fmt;
+
+use super::{Aad, IntoAad};
+
+/// One part of a context, or a PAE-framed list of parts.
+///
+/// Built by [`IntoAad::into_aad_piece`]; encodes through [`IntoAad`]
+/// to the same bytes the source value does, so it can stand in for the
+/// value anywhere an AAD is taken. A list encodes in one allocation
+/// however deep the tree. [`Display`](fmt::Display) renders it injectively
+/// — `("users/email", 7u64)` — and [`leaves`](Self::leaves) walks the parts
+/// in encoding order for a consumer building its own rendering or binding.
+///
+/// Integers keep their source type as their variant, so every tree
+/// expressible here encodes without truncation or failure: `U8(7)` is one
+/// byte and `U64(7)` is eight, exactly as `7u8` and `7u64` are.
+///
+/// `PartialEq` is tree identity, not encoding identity. `Text("ab")` and
+/// `Bytes(b"ab")` compare unequal, as do `U64(7)` and `I64(7)`, though each
+/// pair encodes to the same bytes. To compare what the AEAD authenticates,
+/// compare `into_aad().as_bytes()`.
+///
+/// The enum is `#[non_exhaustive]`: the crate's own derived contexts
+/// (`Aad::for_map_entry`, `Aad::for_leaf`, …) have no faithful shape here
+/// yet, and adding one must not break a downstream `match`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum AadPiece<'a> {
+    /// Text; encodes as its UTF-8 bytes. `&str`, `String`.
+    Text(Cow<'a, str>),
+    /// Opaque bytes; encode as themselves. Byte slices and arrays,
+    /// `Vec<u8>`, `Cow<[u8]>`, an already-encoded [`Aad`], and `()` (no
+    /// bytes at all).
+    Bytes(Cow<'a, [u8]>),
+    /// A `u8`; encodes as one little-endian byte, with no type tag — see
+    /// the integer [`IntoAad`] impls.
+    U8(u8),
+    /// A `u16`; two little-endian bytes.
+    U16(u16),
+    /// A `u32`; four little-endian bytes.
+    U32(u32),
+    /// A `u64`; eight little-endian bytes.
+    U64(u64),
+    /// A `u128`; sixteen little-endian bytes.
+    U128(u128),
+    /// An `i8`; one two's-complement byte.
+    I8(i8),
+    /// An `i16`; two little-endian two's-complement bytes.
+    I16(i16),
+    /// An `i32`; four little-endian two's-complement bytes.
+    I32(i32),
+    /// An `i64`; eight little-endian two's-complement bytes.
+    I64(i64),
+    /// An `i128`; sixteen little-endian two's-complement bytes.
+    I128(i128),
+    /// A list of parts; encodes as their PAE. A tuple is the list of its
+    /// halves, `Some(x)` the one-element list, `None` the empty list.
+    List(Vec<AadPiece<'a>>),
+}
+
+impl<'a> AadPiece<'a> {
+    /// Copy every borrowed part, so the tree can outlive its source.
+    pub fn into_owned(self) -> AadPiece<'static> {
+        match self {
+            AadPiece::Text(text) => AadPiece::Text(Cow::Owned(text.into_owned())),
+            AadPiece::Bytes(bytes) => AadPiece::Bytes(Cow::Owned(bytes.into_owned())),
+            AadPiece::U8(v) => AadPiece::U8(v),
+            AadPiece::U16(v) => AadPiece::U16(v),
+            AadPiece::U32(v) => AadPiece::U32(v),
+            AadPiece::U64(v) => AadPiece::U64(v),
+            AadPiece::U128(v) => AadPiece::U128(v),
+            AadPiece::I8(v) => AadPiece::I8(v),
+            AadPiece::I16(v) => AadPiece::I16(v),
+            AadPiece::I32(v) => AadPiece::I32(v),
+            AadPiece::I64(v) => AadPiece::I64(v),
+            AadPiece::I128(v) => AadPiece::I128(v),
+            AadPiece::List(parts) => {
+                AadPiece::List(parts.into_iter().map(AadPiece::into_owned).collect())
+            }
+        }
+    }
+
+    /// The non-list parts, depth first, in the order they are encoded.
+    /// A leaf piece yields itself; an empty list yields nothing.
+    ///
+    /// Nesting is dropped, so distinct contexts can share a leaf sequence:
+    /// `(("a", 1u8), "b")` and `("a", (1u8, "b"))` both yield `a, 1, b`
+    /// while encoding to different bytes. Use this to render or bind the
+    /// parts, not to identify the context; the bytes from [`IntoAad`] are
+    /// its identity.
+    pub fn leaves(&self) -> impl Iterator<Item = &AadPiece<'a>> {
+        fn walk<'p, 'a>(piece: &'p AadPiece<'a>, out: &mut Vec<&'p AadPiece<'a>>) {
+            match piece {
+                AadPiece::List(parts) => parts.iter().for_each(|part| walk(part, out)),
+                leaf => out.push(leaf),
+            }
+        }
+        let mut out = Vec::new();
+        walk(self, &mut out);
+        out.into_iter()
+    }
+
+    /// The length of this piece's encoding, without producing it. A list is
+    /// `8 + Σ(8 + part)`: the PAE count word plus a length word per part.
+    fn encoded_len(&self) -> usize {
+        match self {
+            AadPiece::Text(text) => text.len(),
+            AadPiece::Bytes(bytes) => bytes.len(),
+            AadPiece::U8(_) | AadPiece::I8(_) => 1,
+            AadPiece::U16(_) | AadPiece::I16(_) => 2,
+            AadPiece::U32(_) | AadPiece::I32(_) => 4,
+            AadPiece::U64(_) | AadPiece::I64(_) => 8,
+            AadPiece::U128(_) | AadPiece::I128(_) => 16,
+            AadPiece::List(parts) => {
+                8 + parts
+                    .iter()
+                    .map(|part| 8 + part.encoded_len())
+                    .sum::<usize>()
+            }
+        }
+    }
+
+    /// The PAE of `head` followed by this piece, in one allocation: the
+    /// bytes `List([Bytes(head), self])` encodes to, without building that
+    /// list. `ContextTag` uses it to fold `(extra_aad, tag)` at the cost of
+    /// the plain tuple encoding.
+    pub(crate) fn pae_after(&self, head: &[u8]) -> Aad<'static> {
+        let tail_len = self.encoded_len();
+        let len = 8 + (8 + head.len()) + (8 + tail_len);
+        let mut buf = Vec::with_capacity(len);
+        buf.extend_from_slice(&2u64.to_le_bytes());
+        buf.extend_from_slice(&(head.len() as u64).to_le_bytes());
+        buf.extend_from_slice(head);
+        buf.extend_from_slice(&(tail_len as u64).to_le_bytes());
+        self.write_into(&mut buf);
+        debug_assert_eq!(buf.len(), len, "encoded_len must equal the bytes written");
+        Aad::new_owned(buf)
+    }
+
+    /// Appends this piece's encoding to `buf`: the same bytes `into_aad`
+    /// produces, written in place so a nested list costs no intermediate
+    /// buffers. Lists follow PAE exactly as [`Aad::pae`] does —
+    /// `LE64(count) || (LE64(len(part)) || part)*` — which the
+    /// `list_encodes_as_pae_of_its_parts` property pins.
+    ///
+    /// Each part's length word is reserved before the part is written and
+    /// filled in after, from the bytes actually produced, so a tree of any
+    /// shape is written in one pass. Computing `encoded_len` per part
+    /// instead would rescan the subtree at every level, quadratic in depth
+    /// for a left-deep list, and `AadPiece` is public, so callers can build
+    /// one.
+    fn write_into(&self, buf: &mut Vec<u8>) {
+        match self {
+            AadPiece::Text(text) => buf.extend_from_slice(text.as_bytes()),
+            AadPiece::Bytes(bytes) => buf.extend_from_slice(bytes),
+            AadPiece::U8(v) => buf.extend_from_slice(&v.to_le_bytes()),
+            AadPiece::U16(v) => buf.extend_from_slice(&v.to_le_bytes()),
+            AadPiece::U32(v) => buf.extend_from_slice(&v.to_le_bytes()),
+            AadPiece::U64(v) => buf.extend_from_slice(&v.to_le_bytes()),
+            AadPiece::U128(v) => buf.extend_from_slice(&v.to_le_bytes()),
+            AadPiece::I8(v) => buf.extend_from_slice(&v.to_le_bytes()),
+            AadPiece::I16(v) => buf.extend_from_slice(&v.to_le_bytes()),
+            AadPiece::I32(v) => buf.extend_from_slice(&v.to_le_bytes()),
+            AadPiece::I64(v) => buf.extend_from_slice(&v.to_le_bytes()),
+            AadPiece::I128(v) => buf.extend_from_slice(&v.to_le_bytes()),
+            AadPiece::List(parts) => {
+                buf.extend_from_slice(&(parts.len() as u64).to_le_bytes());
+                for part in parts {
+                    let length_word = buf.len();
+                    buf.extend_from_slice(&[0u8; 8]);
+                    let start = buf.len();
+                    part.write_into(buf);
+                    let written = (buf.len() - start) as u64;
+                    buf[length_word..start].copy_from_slice(&written.to_le_bytes());
+                }
+            }
+        }
+    }
+}
+
+/// Encodes to the bytes of the value the piece was built from. A leaf hands
+/// its storage to that value's own [`IntoAad`] impl without copying; a list
+/// is written into one buffer sized up front, however deep it nests. The
+/// parts view of a piece is the piece.
+impl<'a> IntoAad<'a> for AadPiece<'a> {
+    fn into_aad_piece(self) -> AadPiece<'a> {
+        self
+    }
+
+    fn into_aad(self) -> Aad<'a> {
+        match self {
+            AadPiece::Text(Cow::Borrowed(text)) => text.into_aad(),
+            AadPiece::Text(Cow::Owned(text)) => text.into_aad(),
+            AadPiece::Bytes(bytes) => bytes.into_aad(),
+            AadPiece::U8(v) => v.into_aad(),
+            AadPiece::U16(v) => v.into_aad(),
+            AadPiece::U32(v) => v.into_aad(),
+            AadPiece::U64(v) => v.into_aad(),
+            AadPiece::U128(v) => v.into_aad(),
+            AadPiece::I8(v) => v.into_aad(),
+            AadPiece::I16(v) => v.into_aad(),
+            AadPiece::I32(v) => v.into_aad(),
+            AadPiece::I64(v) => v.into_aad(),
+            AadPiece::I128(v) => v.into_aad(),
+            list @ AadPiece::List(_) => {
+                let len = list.encoded_len();
+                let mut buf = Vec::with_capacity(len);
+                list.write_into(&mut buf);
+                debug_assert_eq!(buf.len(), len, "encoded_len must equal the bytes written");
+                Aad::new_owned(buf)
+            }
+        }
+    }
+}
+
+/// An injective rendering, in Rust literal syntax: text quoted and escaped
+/// as `Debug` does, integers with their type suffix, bytes as `0x`-prefixed
+/// hex, a list parenthesised and comma-separated — `("users/email", 7u64)`
+/// shows as `("users/email", 7u64)`, and `None` as `()`.
+///
+/// Distinct trees render distinctly: the four leaf kinds start with `"`,
+/// a digit or `-`, `0x` and `(` respectively, integer suffixes keep types
+/// of equal width apart, and quoting keeps separators inside text from
+/// reading as structure. Two contexts that authenticate different bytes
+/// therefore never share a log line.
+impl fmt::Display for AadPiece<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AadPiece::Text(text) => write!(f, "{text:?}"),
+            AadPiece::Bytes(bytes) => {
+                f.write_str("0x")?;
+                bytes.iter().try_for_each(|byte| write!(f, "{byte:02x}"))
+            }
+            AadPiece::U8(v) => write!(f, "{v}u8"),
+            AadPiece::U16(v) => write!(f, "{v}u16"),
+            AadPiece::U32(v) => write!(f, "{v}u32"),
+            AadPiece::U64(v) => write!(f, "{v}u64"),
+            AadPiece::U128(v) => write!(f, "{v}u128"),
+            AadPiece::I8(v) => write!(f, "{v}i8"),
+            AadPiece::I16(v) => write!(f, "{v}i16"),
+            AadPiece::I32(v) => write!(f, "{v}i32"),
+            AadPiece::I64(v) => write!(f, "{v}i64"),
+            AadPiece::I128(v) => write!(f, "{v}i128"),
+            AadPiece::List(parts) => {
+                f.write_str("(")?;
+                for (i, part) in parts.iter().enumerate() {
+                    if i > 0 {
+                        f.write_str(", ")?;
+                    }
+                    fmt::Display::fmt(part, f)?;
+                }
+                f.write_str(")")
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    use quickcheck_macros::quickcheck;
+    use vitaminc_protected::NonEmpty;
+
+    use super::*;
+
+    /// The contract: the tree encodes to the value's own bytes.
+    fn agrees<'a, T>(value: T) -> bool
+    where
+        T: IntoAad<'a> + Clone,
+    {
+        value.clone().into_aad_piece().into_aad().as_bytes() == value.into_aad().as_bytes()
+    }
+
+    #[quickcheck]
+    fn text_agrees(s: String) -> bool {
+        agrees(s.as_str()) && agrees(s)
+    }
+
+    #[quickcheck]
+    fn bytes_agree(b: Vec<u8>) -> bool {
+        agrees(b.as_slice()) && agrees(Cow::Borrowed(b.as_slice())) && agrees(b)
+    }
+
+    #[quickcheck]
+    fn unsigned_integers_agree(a: u8, b: u16, c: u32, d: u64, e: u128) -> bool {
+        agrees(a) && agrees(b) && agrees(c) && agrees(d) && agrees(e)
+    }
+
+    #[quickcheck]
+    fn signed_integers_agree(a: i8, b: i16, c: i32, d: i64, e: i128) -> bool {
+        agrees(a) && agrees(b) && agrees(c) && agrees(d) && agrees(e)
+    }
+
+    #[quickcheck]
+    fn composites_agree(s: String, n: u64, o: Option<String>, b: Vec<u8>) -> bool {
+        agrees((s.as_str(), n))
+            && agrees(o.clone())
+            && agrees(((s.as_str(), n), b.as_slice()))
+            && agrees(Some((o, n)))
+            && agrees((s, ()))
+    }
+
+    #[test]
+    fn fixed_shapes_agree() {
+        assert!(agrees(()));
+        assert!(agrees([1u8, 2, 3]));
+        assert!(agrees(&[4u8, 5, 6]));
+        assert!(agrees(Aad::from_slice(b"raw")));
+        assert!(agrees(Option::<&str>::None));
+        assert!(agrees(NonEmpty::new("users/email").unwrap()));
+        assert!(agrees(NonEmpty::new(("users/email", 7u64)).unwrap()));
+    }
+
+    #[test]
+    fn a_composite_context_names_its_parts() {
+        let piece = ("users/email", 7u64).into_aad_piece();
+        assert_eq!(
+            piece,
+            AadPiece::List(vec![
+                AadPiece::Text(Cow::Borrowed("users/email")),
+                AadPiece::U64(7),
+            ])
+        );
+        assert_eq!(piece.to_string(), "(\"users/email\", 7u64)");
+    }
+
+    #[test]
+    fn integers_keep_their_type() {
+        assert_eq!(7u32.into_aad_piece(), AadPiece::U32(7));
+        assert_eq!((-7i16).into_aad_piece(), AadPiece::I16(-7));
+        // Distinct widths, distinct bytes — as for `IntoAad`.
+        assert_ne!(
+            7u32.into_aad_piece().into_aad().as_bytes(),
+            7u64.into_aad_piece().into_aad().as_bytes()
+        );
+    }
+
+    #[test]
+    fn options_are_lists() {
+        assert_eq!(
+            Option::<&str>::None.into_aad_piece(),
+            AadPiece::List(vec![])
+        );
+        assert_eq!(
+            Some("a").into_aad_piece(),
+            AadPiece::List(vec![AadPiece::Text(Cow::Borrowed("a"))])
+        );
+        assert_eq!(Option::<&str>::None.into_aad_piece().to_string(), "()");
+        assert_eq!(Some("a").into_aad_piece().to_string(), "(\"a\")");
+    }
+
+    #[test]
+    fn the_empty_aad_is_no_bytes_not_an_empty_list() {
+        // `()` encodes as zero bytes; `None` as PAE of zero pieces. The
+        // trees keep them apart the way the encodings do.
+        assert_eq!(().into_aad_piece(), AadPiece::Bytes(Cow::Borrowed(&[])));
+        assert_ne!(().into_aad_piece(), Option::<()>::None.into_aad_piece());
+        assert_eq!(().into_aad_piece().to_string(), "0x");
+    }
+
+    #[test]
+    fn equality_is_tree_identity_not_encoding_identity() {
+        // Pinned because the type doc promises it: `==` tells trees apart
+        // that the AEAD would not.
+        let pairs: [(AadPiece<'_>, AadPiece<'_>); 2] = [
+            ("ab".into_aad_piece(), b"ab".as_slice().into_aad_piece()),
+            (7u64.into_aad_piece(), 7i64.into_aad_piece()),
+        ];
+        for (left, right) in pairs {
+            assert_ne!(left, right);
+            assert_eq!(left.into_aad().as_bytes(), right.into_aad().as_bytes());
+        }
+    }
+
+    #[test]
+    fn non_empty_is_transparent() {
+        assert_eq!(
+            NonEmpty::new(("users/email", 7u64))
+                .unwrap()
+                .into_aad_piece(),
+            ("users/email", 7u64).into_aad_piece()
+        );
+    }
+
+    #[test]
+    fn bytes_display_as_hex() {
+        assert_eq!(
+            [0xdeu8, 0xad, 0xbe, 0xef].into_aad_piece().to_string(),
+            "0xdeadbeef"
+        );
+        assert_eq!(
+            Aad::from_slice(b"\x01\x02").into_aad_piece().to_string(),
+            "0x0102"
+        );
+    }
+
+    #[test]
+    fn leaves_walk_in_encoding_order_and_drop_nesting() {
+        let piece = ((("a", 1u8), Option::<&str>::None), (Some("b"), [9u8])).into_aad_piece();
+        let leaves: Vec<String> = piece.leaves().map(ToString::to_string).collect();
+        assert_eq!(leaves, ["\"a\"", "1u8", "\"b\"", "0x09"]);
+        // A leaf is its own only leaf.
+        assert_eq!("x".into_aad_piece().leaves().count(), 1);
+        assert_eq!(Option::<&str>::None.into_aad_piece().leaves().count(), 0);
+        // Nesting is not recoverable from the leaves, as the doc says.
+        let left = (("a", 1u8), "b").into_aad_piece();
+        let right = ("a", (1u8, "b")).into_aad_piece();
+        assert!(left.leaves().eq(right.leaves()));
+        assert_ne!(left.into_aad().as_bytes(), right.into_aad().as_bytes());
+    }
+
+    #[test]
+    fn display_is_injective_where_it_used_to_collide() {
+        // Same width, different type; text that looks like an integer; text
+        // that looks like hex; `Some("")` against `None`; text containing
+        // the separators. Each pair encodes differently and must print
+        // differently.
+        let pairs: [(AadPiece<'_>, AadPiece<'_>); 5] = [
+            (7u64.into_aad_piece(), 7i64.into_aad_piece()),
+            (("x", 7u64).into_aad_piece(), ("x", "7").into_aad_piece()),
+            ("0xdead".into_aad_piece(), [0xdeu8, 0xad].into_aad_piece()),
+            (
+                Some("").into_aad_piece(),
+                Option::<&str>::None.into_aad_piece(),
+            ),
+            (
+                ("a, b", "c").into_aad_piece(),
+                ("a", "b, c").into_aad_piece(),
+            ),
+        ];
+        for (left, right) in pairs {
+            assert_ne!(left.to_string(), right.to_string());
+        }
+        assert_eq!(
+            ("a, b", (7u8, [1u8])).into_aad_piece().to_string(),
+            "(\"a, b\", (7u8, 0x01))"
+        );
+        assert_eq!(Some("").into_aad_piece().to_string(), "(\"\")");
+        assert_eq!((-7i16).into_aad_piece().to_string(), "-7i16");
+    }
+
+    /// A random tree, depth-bounded, over every leaf kind, for the
+    /// encoding, ownership and rendering properties.
+    #[derive(Debug, Clone)]
+    struct Tree(AadPiece<'static>);
+
+    impl quickcheck::Arbitrary for Tree {
+        fn arbitrary(g: &mut quickcheck::Gen) -> Self {
+            fn gen(g: &mut quickcheck::Gen, depth: u8) -> AadPiece<'static> {
+                let kinds = if depth == 0 { 12 } else { 13 };
+                match u8::arbitrary(g) % kinds {
+                    0 => AadPiece::Text(Cow::Owned(String::arbitrary(g))),
+                    1 => AadPiece::Bytes(Cow::Owned(Vec::arbitrary(g))),
+                    2 => AadPiece::U8(u8::arbitrary(g)),
+                    3 => AadPiece::U16(u16::arbitrary(g)),
+                    4 => AadPiece::U32(u32::arbitrary(g)),
+                    5 => AadPiece::U64(u64::arbitrary(g)),
+                    6 => AadPiece::U128(u128::arbitrary(g)),
+                    7 => AadPiece::I8(i8::arbitrary(g)),
+                    8 => AadPiece::I16(i16::arbitrary(g)),
+                    9 => AadPiece::I32(i32::arbitrary(g)),
+                    10 => AadPiece::I64(i64::arbitrary(g)),
+                    11 => AadPiece::I128(i128::arbitrary(g)),
+                    _ => {
+                        let n = usize::arbitrary(g) % 4;
+                        AadPiece::List((0..n).map(|_| gen(g, depth - 1)).collect())
+                    }
+                }
+            }
+            Tree(gen(g, 3))
+        }
+    }
+
+    /// One of each variant, for the exhaustive per-arm checks below.
+    fn every_kind() -> Vec<AadPiece<'static>> {
+        vec![
+            AadPiece::Text(Cow::Borrowed("t")),
+            AadPiece::Bytes(Cow::Borrowed(b"b")),
+            AadPiece::U8(1),
+            AadPiece::U16(2),
+            AadPiece::U32(3),
+            AadPiece::U64(4),
+            AadPiece::U128(5),
+            AadPiece::I8(-1),
+            AadPiece::I16(-2),
+            AadPiece::I32(-3),
+            AadPiece::I64(-4),
+            AadPiece::I128(-5),
+            AadPiece::List(vec![AadPiece::U8(9)]),
+        ]
+    }
+
+    #[test]
+    fn every_kind_round_trips_through_into_owned_and_encodes_its_own_bytes() {
+        for piece in every_kind() {
+            let owned = piece.clone().into_owned();
+            assert_eq!(owned, piece, "into_owned must not change the tree");
+            assert_eq!(
+                owned.into_aad().as_bytes(),
+                piece.clone().into_aad().as_bytes(),
+                "into_owned must not change the bytes"
+            );
+            // The single-buffer writer agrees with the leaf's own encoder.
+            let mut buf = Vec::new();
+            piece.write_into(&mut buf);
+            assert_eq!(buf.len(), piece.encoded_len());
+            assert_eq!(buf, piece.clone().into_aad().as_bytes());
+        }
+        let rendered: Vec<String> = every_kind().iter().map(ToString::to_string).collect();
+        assert_eq!(
+            rendered,
+            [
+                "\"t\"", "0x62", "1u8", "2u16", "3u32", "4u64", "5u128", "-1i8", "-2i16", "-3i32",
+                "-4i64", "-5i128", "(9u8)",
+            ]
+        );
+    }
+
+    #[quickcheck]
+    fn into_owned_preserves_any_tree(tree: Tree) -> bool {
+        let owned = tree.0.clone().into_owned();
+        owned == tree.0 && owned.into_aad().as_bytes() == tree.0.into_aad().as_bytes()
+    }
+
+    #[quickcheck]
+    fn display_is_injective(a: Tree, b: Tree) -> bool {
+        // The rustdoc promise: distinct trees never render alike.
+        a.0 == b.0 || a.0.to_string() != b.0.to_string()
+    }
+
+    #[quickcheck]
+    fn list_encodes_as_pae_of_its_parts(tree: Tree) -> bool {
+        // The single-buffer writer must produce exactly what `Aad::pae` over
+        // the separately encoded parts produces, at every level.
+        fn via_pae(piece: &AadPiece<'static>) -> Aad<'static> {
+            match piece {
+                AadPiece::List(parts) => {
+                    let encoded: Vec<Aad<'static>> = parts.iter().map(via_pae).collect();
+                    let refs: Vec<&[u8]> = encoded.iter().map(Aad::as_bytes).collect();
+                    Aad::pae(&refs)
+                }
+                leaf => leaf.clone().into_aad().into_owned(),
+            }
+        }
+        let expected = via_pae(&tree.0);
+        let piece = tree.0;
+        let len = piece.encoded_len();
+        let actual = piece.into_aad();
+        actual.as_bytes() == expected.as_bytes() && actual.as_bytes().len() == len
+    }
+
+    #[quickcheck]
+    fn pae_after_is_the_two_element_list(head: Vec<u8>, tree: Tree) -> bool {
+        let expected =
+            AadPiece::List(vec![AadPiece::Bytes(Cow::Borrowed(&head)), tree.0.clone()]).into_aad();
+        tree.0.pae_after(&head).as_bytes() == expected.as_bytes()
+    }
+
+    /// A deep left-nested list, the shape that made per-part `encoded_len`
+    /// quadratic, still encodes as PAE at every level and in one pass.
+    #[test]
+    fn deep_left_nested_lists_encode_as_pae() {
+        let mut piece = AadPiece::U8(1);
+        for i in 0..=255u8 {
+            piece = AadPiece::List(vec![piece, AadPiece::U8(i)]);
+        }
+        // Reference: encode bottom-up with `Aad::pae`, one level at a time.
+        let mut expected = 1u8.into_aad().into_owned();
+        for i in 0..=255u8 {
+            let leaf = i.into_aad();
+            expected = Aad::pae(&[expected.as_bytes(), leaf.as_bytes()]);
+        }
+        let len = piece.encoded_len();
+        let actual = piece.into_aad();
+        assert_eq!(actual.as_bytes(), expected.as_bytes());
+        assert_eq!(actual.as_bytes().len(), len);
+    }
+
+    #[test]
+    fn into_owned_preserves_the_tree_and_the_bytes() {
+        let text = String::from("users/email");
+        let piece = (text.as_str(), 7u64).into_aad_piece();
+        let owned: AadPiece<'static> = piece.clone().into_owned();
+        assert_eq!(owned, piece);
+        assert_eq!(
+            owned.into_aad().as_bytes(),
+            (text.as_str(), 7u64).into_aad().as_bytes()
+        );
+    }
+
+    #[test]
+    fn a_piece_is_an_aad_wherever_one_is_taken() {
+        // The tree stands in for the value: the same encoding either way.
+        let from_value = ("users/email", 7u64).into_aad();
+        let from_piece = ("users/email", 7u64).into_aad_piece().into_aad();
+        assert_eq!(from_value.as_bytes(), from_piece.as_bytes());
+        // And a hand-built tree encodes as the value it describes.
+        let hand_built = AadPiece::List(vec![
+            AadPiece::Text(Cow::Borrowed("users/email")),
+            AadPiece::U64(7),
+        ]);
+        assert_eq!(hand_built.into_aad().as_bytes(), from_value.as_bytes());
+    }
+}

--- a/packages/aead/src/context.rs
+++ b/packages/aead/src/context.rs
@@ -48,8 +48,14 @@
 //!   ──► tag = ("a", "b")
 //!   ──► final_aad = PAE(extra_aad, PAE("a", "b"))
 //! ```
+//!
+//! The cipher receives that context with its parts intact: `into_aad_piece()` on the value it is
+//! handed is `List([extra_aad, List(["a", "b"])])` for the example, so a backend that names the
+//! parts (a key-management service logging which field a key was issued for) reads them directly
+//! rather than from pre-encoded bytes. A backend that only wants bytes calls `into_aad()`, which
+//! writes `PAE(extra_aad, tag)` into one buffer — the same allocations as the plain tuple.
 
-use crate::{Aad, Cipher, Decipher, Decrypt, Encrypt, IntoAad};
+use crate::{Aad, AadPiece, Cipher, Decipher, Decrypt, Encrypt, IntoAad};
 
 /// Folds a context `tag` and `extra_aad` into the AAD layout bound by `ContextTag`.
 ///
@@ -61,16 +67,43 @@ use crate::{Aad, Cipher, Decipher, Decrypt, Encrypt, IntoAad};
 /// a parallel construction kept in lockstep only by the `*_helper_matches_encrypt_binding` tests —
 /// if you change the layout here, update those builders too.
 ///
-/// The tag is encoded into an owned/`'static` `Aad` and re-borrowed for the call's `'a` lifetime
-/// (`Aad` is covariant in its lifetime, so `'static: 'a` permits the narrowing); the result is
-/// `(extra_aad, tag)`, which [`IntoAad`] PAE-encodes.
-fn fold_tag_aad<'a, Tag, A>(tag: Tag, extra_aad: A) -> (A, Aad<'a>)
+/// The tag becomes an owned/`'static` [`AadPiece`] and is re-borrowed for the call's `'a`
+/// lifetime (`AadPiece` is covariant in its lifetime, so `'static: 'a` permits the narrowing);
+/// the result is a [`FoldedAad`], whose bytes are `PAE(extra_aad, tag)` — the same as the tuple
+/// `(extra_aad, tag)` — and whose parts are `List([extra_aad, tag])`.
+fn fold_tag_aad<'a, Tag, A>(tag: Tag, extra_aad: A) -> FoldedAad<'a, A>
 where
     Tag: IntoAad<'static>,
 {
-    let tag_aad: Aad<'static> = tag.into_aad();
-    let tag_aad: Aad<'a> = tag_aad;
-    (extra_aad, tag_aad)
+    let tag: AadPiece<'static> = tag.into_aad_piece();
+    let tag: AadPiece<'a> = tag;
+    FoldedAad { extra_aad, tag }
+}
+
+/// The context a [`ContextTag`] hands its cipher: `extra_aad` and the tag, in that order.
+///
+/// Bytes and parts are produced by different paths so the parts view costs nothing unless asked
+/// for: `into_aad` writes `PAE(extra_aad, tag)` straight into one buffer (no intermediate list, no
+/// second copy of the tag), while `into_aad_piece` builds `List([extra_aad, tag])`. Both agree
+/// with the tuple `(extra_aad, tag)` byte for byte — `cipher_receives_the_context_as_parts` and the
+/// `*_helper_matches_encrypt_binding` tests pin it.
+struct FoldedAad<'a, A> {
+    extra_aad: A,
+    tag: AadPiece<'a>,
+}
+
+impl<'a, A> IntoAad<'a> for FoldedAad<'a, A>
+where
+    A: IntoAad<'a>,
+{
+    fn into_aad(self) -> Aad<'a> {
+        let extra_aad = self.extra_aad.into_aad();
+        self.tag.pae_after(extra_aad.as_bytes())
+    }
+
+    fn into_aad_piece(self) -> AadPiece<'a> {
+        AadPiece::List(vec![self.extra_aad.into_aad_piece(), self.tag])
+    }
 }
 
 /// A wrapper that pairs a plaintext value with a context tag used as additional authenticated
@@ -295,16 +328,17 @@ impl<Tag, T> Encrypt for ContextTag<Tag, T>
 where
     T: Encrypt,
     // `Encrypt::encrypt_with_aad` chooses the AAD lifetime at the call site, but the tag is owned
-    // by the wrapper. Requiring `IntoAad<'static>` lets the tag be encoded into an owned (or
-    // `'static`-borrowed) `Aad` that we then re-borrow for the call's lifetime via covariance.
+    // by the wrapper. Requiring `IntoAad<'static>` lets the tag become an owned (or
+    // `'static`-borrowed) `AadPiece` that we then re-borrow for the call's lifetime via covariance.
     // Owned tags (`String`, `u64`, `Vec<u8>`, tuples thereof) and `&'static str` satisfy this;
     // non-`'static` borrows do not — promote them to `String` or a `&'static str`.
     Tag: IntoAad<'static>,
 {
     /// Encrypts the inner value, folding the embedded tag into the AAD.
     ///
-    /// The final AAD is `(extra_aad, tag)`, PAE-encoded by [`IntoAad`] into an unambiguous byte
-    /// representation that binds both pieces.
+    /// The final AAD is `(extra_aad, tag)`, PAE-encoded into an unambiguous byte representation
+    /// that binds both pieces. The cipher receives it with its parts intact — `into_aad_piece()`
+    /// gives `List([extra_aad, tag])` — and `into_aad()` writes the bytes in one allocation.
     fn encrypt_with_aad<'a, C, A>(self, cipher: C, extra_aad: A) -> Result<C::Ok, C::Error>
     where
         C: Cipher,
@@ -322,6 +356,43 @@ mod tests {
     use crate::DecipherVisitor;
     use std::cell::RefCell;
     use std::rc::Rc;
+
+    #[test]
+    fn cipher_receives_the_context_as_parts() {
+        // The motivating consumer: a backend that names the parts must find
+        // them intact — the tag as a nested list of its refinements, not as
+        // pre-encoded bytes.
+        use crate::test_util::PartsCipher;
+        use std::borrow::Cow;
+        let parts = PartsCipher::new();
+        ContextTag::new("secret", "table:users")
+            .refine("column:email")
+            .encrypt_with_aad(&parts, "row:99")
+            .expect("mock cipher cannot fail");
+        let piece = parts.captured_piece().expect("aad captured");
+        assert_eq!(
+            piece,
+            AadPiece::List(vec![
+                AadPiece::Text(Cow::Borrowed("row:99")),
+                AadPiece::List(vec![
+                    AadPiece::Text(Cow::Borrowed("table:users")),
+                    AadPiece::Text(Cow::Borrowed("column:email")),
+                ]),
+            ])
+        );
+        let names: Vec<String> = piece.leaves().map(ToString::to_string).collect();
+        assert_eq!(names, ["\"row:99\"", "\"table:users\"", "\"column:email\""]);
+        // Both views agree with the tuple: the parts tree re-encoded, and the
+        // bytes a byte-oriented cipher gets from `FoldedAad::into_aad`.
+        let expected = ("row:99", ("table:users", "column:email")).into_aad();
+        assert_eq!(piece.into_aad().as_bytes(), expected.as_bytes());
+        let bytes = MockCipher::new();
+        ContextTag::new("secret", "table:users")
+            .refine("column:email")
+            .encrypt_with_aad(&bytes, "row:99")
+            .expect("mock cipher cannot fail");
+        assert_eq!(bytes.captured_aad(), expected.as_bytes());
+    }
 
     #[test]
     fn encrypts_inner_value_and_binds_tag() {

--- a/packages/aead/src/lib.rs
+++ b/packages/aead/src/lib.rs
@@ -17,7 +17,7 @@ mod passthrough;
 mod test_util;
 
 #[doc(inline)]
-pub use aad::{Aad, IntoAad};
+pub use aad::{Aad, AadPiece, IntoAad};
 #[doc(inline)]
 pub use cipher::{Cipher, MapCipher, SeqCipher, Unspecified};
 #[doc(inline)]

--- a/packages/aead/src/test_util.rs
+++ b/packages/aead/src/test_util.rs
@@ -10,7 +10,7 @@ use vitaminc_protected::{Controlled, Protected};
 use crate::{
     cipher::{Cipher, MapCipher, SeqCipher},
     decipher::{Decipher, DecipherVisitor, MapAccess},
-    Encrypt, IntoAad, Unspecified,
+    AadPiece, Encrypt, IntoAad, Unspecified,
 };
 
 /// A minimal [`Cipher`] that records the AAD bytes it is handed and echoes the
@@ -19,6 +19,9 @@ use crate::{
 /// sequence/map sub-ciphers exist solely to satisfy the trait and are never
 /// driven.
 pub(crate) struct MockCipher {
+    /// Recorded through `aad.into_aad()`, the path a byte-oriented cipher
+    /// takes, so the layout tests pin a wrapper's optimised byte encoding
+    /// (`FoldedAad::into_aad`) and not a re-encoding of its parts view.
     captured_aad: RefCell<Vec<u8>>,
     /// How many times `encrypt_bytes_array` was called directly, as opposed
     /// to the trait's default forwarding through `encrypt_bytes_vec`. Lets a
@@ -38,8 +41,89 @@ impl MockCipher {
         self.captured_aad.borrow().clone()
     }
 
+    fn capture<'a, A: IntoAad<'a>>(&self, aad: A) {
+        *self.captured_aad.borrow_mut() = aad.into_aad().as_bytes().to_vec();
+    }
+
     pub(crate) fn array_entry_hits(&self) -> usize {
         self.array_entry_hits.get()
+    }
+}
+
+/// A [`Cipher`] that records the AAD's *parts* view, `aad.into_aad_piece()`,
+/// and nothing else. A consumed `A` can expose only one view, so this is a
+/// separate spy from [`MockCipher`]: use it to prove a wrapper handed the
+/// parts through intact, and `MockCipher` to prove the bytes.
+pub(crate) struct PartsCipher {
+    captured_piece: RefCell<Option<AadPiece<'static>>>,
+}
+
+impl PartsCipher {
+    pub(crate) fn new() -> Self {
+        PartsCipher {
+            captured_piece: RefCell::new(None),
+        }
+    }
+
+    pub(crate) fn captured_piece(&self) -> Option<AadPiece<'static>> {
+        self.captured_piece.borrow().clone()
+    }
+
+    fn capture<'a, A: IntoAad<'a>>(&self, aad: A) {
+        *self.captured_piece.borrow_mut() = Some(aad.into_aad_piece().into_owned());
+    }
+}
+
+impl Cipher for &PartsCipher {
+    type Ok = Vec<u8>;
+    type Error = Unspecified;
+    type Passthrough = ();
+    type SeqCipher = UnusedSeq;
+    type MapCipher = UnusedMap;
+
+    fn encrypt_bytes_vec<'a, A>(
+        self,
+        data: Protected<Vec<u8>>,
+        aad: A,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        A: IntoAad<'a>,
+    {
+        self.capture(aad);
+        Ok(data.risky_unwrap())
+    }
+
+    fn encrypt_seq<'a, A>(self, _size_hint: Option<usize>, _aad: A) -> Self::SeqCipher
+    where
+        A: IntoAad<'a>,
+    {
+        UnusedSeq
+    }
+
+    fn encrypt_map<'a, A>(self, _aad: A) -> Self::MapCipher
+    where
+        A: IntoAad<'a>,
+    {
+        UnusedMap
+    }
+
+    fn encrypt_none<'a, A>(self, aad: A) -> Result<Self::Ok, Self::Error>
+    where
+        A: IntoAad<'a>,
+    {
+        self.capture(aad);
+        Ok(Vec::new())
+    }
+
+    fn passthrough(self, _value: Self::Passthrough) -> Result<Self::Ok, Self::Error> {
+        Ok(Vec::new())
+    }
+
+    fn passthrough_boxed(
+        self,
+        _value: Box<dyn Any + Send + 'static>,
+    ) -> Result<Self::Ok, Self::Error> {
+        Ok(Vec::new())
     }
 }
 
@@ -61,7 +145,7 @@ impl Cipher for &MockCipher {
     where
         A: IntoAad<'a>,
     {
-        *self.captured_aad.borrow_mut() = aad.into_aad().as_bytes().to_vec();
+        self.capture(aad);
         Ok(data.risky_unwrap())
     }
 
@@ -74,7 +158,7 @@ impl Cipher for &MockCipher {
         A: IntoAad<'a>,
     {
         self.array_entry_hits.set(self.array_entry_hits.get() + 1);
-        *self.captured_aad.borrow_mut() = aad.into_aad().as_bytes().to_vec();
+        self.capture(aad);
         Ok(data.risky_ref().to_vec())
     }
 
@@ -96,7 +180,7 @@ impl Cipher for &MockCipher {
     where
         A: IntoAad<'a>,
     {
-        *self.captured_aad.borrow_mut() = aad.into_aad().as_bytes().to_vec();
+        self.capture(aad);
         Ok(Vec::new())
     }
 


### PR DESCRIPTION
Closes #317. Stacked on #314 (`non-empty-with`); retargets to `main` once that merges.

## What

- **`IntoAad::into_aad_piece`**, a provided method returning an `AadPiece` tree. Default is the whole encoding as one opaque `Bytes` leaf, so every existing `IntoAad` type, in-tree or out, keeps compiling and gains a parts view; built-ins override it to name their parts. Contract for an override: byte identity with `into_aad`, pinned by quickcheck for every built-in. `LeafTypeAad` in `vitaminc-aead-value` overrides it too.
- **`AadPiece<'a>`**, `#[non_exhaustive]`: `Text`, `Bytes`, one variant per integer type (`U8(u8)` … `I128(i128)`), `List(Vec<AadPiece>)`. Encodes through `IntoAad` to the bytes of the value it was built from; a list of any depth encodes in one pass into one buffer. `Display` is injective, Rust literal syntax: `("users/email", 7u64)` shows as `("users/email", 7u64)`. `leaves()` walks the parts in encoding order (it drops nesting, and says so). `into_owned()` detaches the borrow. `PartialEq` is tree identity, and says so.
- **`ContextTag`** hands its cipher the context with parts intact: `into_aad_piece()` on what the cipher receives is `List([extra_aad, List([tag, refinement, …])])`, while `into_aad()` writes `PAE(extra_aad, tag)` into one buffer. Measured through `Aes256Cipher` with a counting allocator: allocations per encrypt unchanged for one-level tags, one fewer for two-level.
- Re-exported from the crate root; a paragraph in the README.

**Additive.** No encoding changes anywhere. No new bounds anywhere. An out-of-tree `impl IntoAad` is untouched and its parts view is its bytes until it opts in.

## Why the parts view is a method, not a second trait

#317 proposed a separate `IntoAadPiece` trait with both implemented for built-ins. Every cipher and encrypt entry point is bounded `A: IntoAad<'a>` only, so under two independent traits a backend holding an `A: IntoAad` cannot call `into_aad_piece()` at all: the view exists but is unreachable at the one place it is needed. Making it reachable would mean `A: IntoAad + IntoAadPiece` on `Cipher` and `Encrypt`, breaking every implementor of both, including hand-written `Encrypt` impls downstream. A supertrait reaches it but breaks every out-of-tree `IntoAad` impl. A provided method reaches it under every existing bound and breaks nothing. #317 is amended accordingly.

## Why

stack-encrypt now sends every leaf's context to ZeroKMS as the data key's `descriptor` (cipherstash-suite#2180), which ZeroKMS HMACs into the key tag and logs per retrieval. A `&str` context is readable there; a composite — `nonempty!("users/email").with(record_id)` — is one PAE blob, so the log shows `b64:AgAAAAAAAAALAAAA…`. With the parts in hand the descriptor renders `users/email/7`, and the next ZeroKMS's structured binding (`{label, value}` per part) maps one to one onto the leaves — from the same value that built the AAD, so the two commit to identical bytes. CTS routes through `ContextTag`, so the parts have to survive the fold, and its seal path is allocation-sensitive, so they have to survive it for free.

Labels for tuple positions are a follow-up (a `Labelled<T>` wrapper), noted in #317; `#[non_exhaustive]` means that variant lands additively.

https://claude.ai/code/session_019VRX1tXygj5bew3YhyK1B6
https://claude.ai/code/session_01QvrvBVdcecdr4LfywiGnDd