### PR TITLE
ci: run the Rust gates on stacked PRs, not only PRs targeting main

### DIFF
--- a/.github/workflows/crap.yml
+++ b/.github/workflows/crap.yml
@@ -12,9 +12,10 @@ name: "CRAP"
 # branch-protection settings. To soften it back to report-only, drop the
 # "Enforce CRAP threshold" step — the sticky comment keeps working either way.
 on:
+  # No branch filter: a stacked PR (a feature branch as base) must run this
+  # gate too. With `branches: [main]` here, retargeting a PR onto its
+  # parent branch silently switched every Rust gate off; see go.yml.
   pull_request:
-    branches:
-      - main
     paths:
       - "packages/**"
       - "Cargo.toml"

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -15,9 +15,10 @@ name: "Miri"
 # and `protected` is where the only unsafe lives. Expand the matrix if other
 # crates grow pure-Rust `unsafe`.
 on:
+  # No branch filter: a stacked PR (a feature branch as base) must run this
+  # gate too. With `branches: [main]` here, retargeting a PR onto its
+  # parent branch silently switched every Rust gate off; see go.yml.
   pull_request:
-    branches:
-      - main
     paths:
       - "packages/protected/**"
       - ".github/workflows/miri.yml"

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -17,9 +17,10 @@ name: "Mutants"
 # step; the sticky comment keeps working either way. To block merges, mark this
 # check ("🧬 Mutants gate") as required in the repo's branch-protection settings.
 on:
+  # No branch filter: a stacked PR (a feature branch as base) must run this
+  # gate too. With `branches: [main]` here, retargeting a PR onto its
+  # parent branch silently switched every Rust gate off; see go.yml.
   pull_request:
-    branches:
-      - main
     paths:
       - "packages/**"
       - "Cargo.toml"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,10 @@ on:
   push:
     branches:
       - main
+  # No branch filter: a stacked PR (a feature branch as base) must run this
+  # gate too. With `branches: [main]` here, retargeting a PR onto its
+  # parent branch silently switched every Rust gate off; see go.yml.
   pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 defaults:


### PR DESCRIPTION
## What

Drops the `branches: [main]` filter under `pull_request` in `crap.yml`, `test.yml`, `mutants.yml` and `miri.yml`, matching what `go.yml` already does. `push: [main]` and `workflow_dispatch` triggers are unchanged.

## Why

Retargeting #318 onto `non-empty-with` to stack it on #314 turned every Rust gate off: only the Go bindings and wasm checks ran on the new commits, and the PR looked green while the CRAP gate had a failing function. The gates had to be triggered by hand with `workflow_dispatch` to see it.

`mutants.yml` diffs against `github.base_ref`, which on a stacked PR is the parent branch, so its scope stays this PR's changes rather than the whole stack. Cost is one extra run of each gate per stacked PR.

https://claude.ai/code/session_01QvrvBVdcecdr4LfywiGnDd