### PR TITLE
test(random): pin SafeRand to the ChaCha20 stream and next_bounded_u32 to its sampling

### DIFF
--- a/packages/random/src/safe_rand.rs
+++ b/packages/random/src/safe_rand.rs
@@ -82,6 +82,91 @@ impl SeedableRng for SafeRand {
 #[cfg(test)]
 mod tests {
     use super::SafeRand;
+    use rand::{rngs::ChaCha20Rng, Rng, SeedableRng, TryRng};
+
+    const SEED: [u8; 32] = [7u8; 32];
+
+    /// `SafeRand` is a transparent wrapper: for the same seed it must yield
+    /// exactly the ChaCha20 stream, word for word and byte for byte. Pins the
+    /// `TryRng` impl to real output rather than to "some value", which is
+    /// what a mutant returning a constant would otherwise pass as.
+    #[test]
+    fn try_rng_yields_the_chacha20_stream_for_the_seed() {
+        let mut safe = SafeRand::from_seed(SEED);
+        let mut reference = ChaCha20Rng::from_seed(SEED);
+
+        for _ in 0..4 {
+            assert_eq!(safe.try_next_u32().unwrap(), reference.next_u32());
+        }
+        for _ in 0..4 {
+            assert_eq!(safe.try_next_u64().unwrap(), reference.next_u64());
+        }
+        let mut got = [0u8; 40];
+        let mut want = [0u8; 40];
+        safe.try_fill_bytes(&mut got).unwrap();
+        reference.fill_bytes(&mut want);
+        assert_eq!(got, want);
+        assert_ne!(got, [0u8; 40], "fill_bytes must write the buffer");
+    }
+
+    /// What `next_bounded_u32` does today for a bound that is not a power of
+    /// two, spelled out over the same seed: draw mod the next power of two
+    /// and reject until the draw is at most `max`. Comparing exact values
+    /// (not just `<= max`) pins the modulus and the rejection comparison.
+    ///
+    /// Two inputs are deliberately absent, both tracked in the issue linked
+    /// from the PR that added this test: a power-of-two `max` takes a branch
+    /// that reduces mod `max` and so never returns `max`, contradicting the
+    /// doc's "up to and including"; and any `max` above `1 << 31` overflows
+    /// `next_power_of_two` and panics. Neither is pinned here because
+    /// neither is the intended behaviour.
+    #[test]
+    fn next_bounded_u32_matches_reference_rejection_sampling() {
+        fn reference(rng: &mut ChaCha20Rng, max: u32) -> u32 {
+            let cap = max.next_power_of_two();
+            loop {
+                let value = rng.next_u32() % cap;
+                if value <= max {
+                    return value;
+                }
+            }
+        }
+        for max in [3u32, 5, 6, 100, 1000, (1 << 31) - 1] {
+            let mut safe = SafeRand::from_seed(SEED);
+            let mut reference_rng = ChaCha20Rng::from_seed(SEED);
+            for _ in 0..256 {
+                let got = safe.next_bounded_u32(max);
+                assert_eq!(got, reference(&mut reference_rng, max), "max = {max}");
+                assert!(got <= max, "max = {max}");
+            }
+        }
+    }
+
+    /// Every value in `0..=max` is reachable, including `max` itself, which a
+    /// strict `<` in the rejection test would silently exclude.
+    #[test]
+    fn next_bounded_u32_covers_the_whole_inclusive_range() {
+        let mut rng = SafeRand::from_seed(SEED);
+        let mut seen = [false; 6];
+        for _ in 0..512 {
+            seen[rng.next_bounded_u32(5) as usize] = true;
+        }
+        assert_eq!(seen, [true; 6]);
+    }
+
+    #[test]
+    fn different_seeds_diverge_and_the_same_seed_repeats() {
+        let mut a = SafeRand::from_seed(SEED);
+        let mut b = SafeRand::from_seed(SEED);
+        let mut c = SafeRand::from_seed([8u8; 32]);
+        let (x, y, z) = (
+            a.try_next_u64().unwrap(),
+            b.try_next_u64().unwrap(),
+            c.try_next_u64().unwrap(),
+        );
+        assert_eq!(x, y);
+        assert_ne!(x, z);
+    }
 
     #[test]
     fn test_next_bounded_u32() -> Result<(), crate::RandomError> {


### PR DESCRIPTION
Resolves #344

## What

Tests only. `SafeRand`'s `TryRng` impl is compared word for word and byte for byte with `ChaCha20Rng` for a fixed seed; `next_bounded_u32`'s rejection branch is compared with a reference re-implementation of the sampling over the same seed; a range test checks every value in `0..=max` is reachable.

## Why

The whole-workspace `cargo mutants` sweep run by hand for #318 found four survivors in `safe_rand.rs`: `try_next_u32`/`try_next_u64` replaced with `Ok(0)` or `Ok(1)`. The only tests drew from entropy and asserted `< max`, which any constant satisfies. Scoping the same run to this file showed seven more survivors in `next_bounded_u32`.

Result for `safe_rand.rs`: 14 of 19 mutants caught, 3 unviable, 2 remaining are `%` replacements in the rejection loop that make it spin forever, observable only as a timeout.

## What is not pinned, on purpose

Writing the reference found two behaviours that are bugs, not behaviour to lock in. Filed as https://github.com/cipherstash/vitaminc/issues/321 since fixing them changes what three crates rely on:

- A power-of-two `max` reduces mod `max` and never returns `max`, while the doc and the other branch are inclusive.
- Any `max` above `1 << 31` overflows `next_power_of_two` and panics.

https://claude.ai/code/session_01QvrvBVdcecdr4LfywiGnDd
