### PR TITLE
fix(aead-value): make vitaminc-encrypt dev-dependency path-only

### DIFF
--- a/packages/aead-value/Cargo.toml
+++ b/packages/aead-value/Cargo.toml
@@ -18,4 +18,4 @@ vitaminc-protected = { version = "0.3.0", path = "../protected" }
 zeroize = { workspace = true }
 
 [dev-dependencies]
-vitaminc-encrypt = { version = "0.3.0", path = "../encrypt" }
+vitaminc-encrypt = { path = "../encrypt" }


### PR DESCRIPTION
## Why

The v0.3.0 release run (https://github.com/cipherstash/vitaminc/actions/runs/34079588457) failed after publishing six crates:

```
failed to publish vitaminc-aead-value:
  failed to select a version for the requirement `vitaminc-encrypt = "^0.3.0"`
  candidate versions found which didn't match: 0.2.0, 0.2.0-pre.1, 0.2.0-pre, ...
```

`vitaminc-encrypt` is only a dev-dependency of `vitaminc-aead-value`. Dev-dependencies do not influence release-plz's publish ordering, so `aead-value` was published before `encrypt`. Cargo still resolves a versioned dev-dependency against crates.io while packaging, and `encrypt` 0.3.0 did not exist yet.

## What

Drop the `version` field from that dev-dependency. Path-only dev-dependencies are stripped from the published manifest, so publish order no longer matters for it. Verified locally with `cargo package -p vitaminc-aead-value --no-verify`.

## After merge

Re-run the release workflow. `release-plz release` skips the six crates already on crates.io and publishes the remaining eleven.

https://claude.ai/code/session_01AthJDZs25JztNCpiYc9smm