### PR TITLE
chore: update chacha20 to 0.10.2 because 0.10.0 was yanked

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,9 +619,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",


### PR DESCRIPTION
## Why

`chacha20 v0.10.0` in `Cargo.lock` is yanked on crates.io. Cargo warns about it on every `cargo package` and `cargo publish`, including in the release workflow.

## What

`cargo update -p chacha20`, bumping 0.10.0 to 0.10.2. Lockfile-only change. `chacha20` is a transitive dependency via `rand`'s ChaCha-based RNG; no vitaminc crate depends on it directly. `cargo check --workspace --all-features` passes.

https://claude.ai/code/session_01AthJDZs25JztNCpiYc9smm