### PR TITLE
feat(aead,prf)!: `AadPiece` is the identity of a context on both derivations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2460,6 +2460,7 @@ dependencies = [
  "serde",
  "trybuild",
  "vitaminc-aead-derive",
+ "vitaminc-prf",
  "vitaminc-protected",
  "vitaminc-random",
  "zeroize",

--- a/packages/aead/Cargo.toml
+++ b/packages/aead/Cargo.toml
@@ -13,6 +13,9 @@ categories.workspace = true
 
 [dependencies]
 vitaminc-aead-derive = { version = "0.3.0", path = "../aead-derive" }
+# For `AadPiece`'s PRF derivation: a context's parts view is its identity on
+# both derivations, so the parts type carries both.
+vitaminc-prf = { version = "0.3.0", path = "../prf" }
 vitaminc-protected = { version = "0.3.0", path = "../protected" }
 vitaminc-random = { version = "0.3.0", path = "../random" }
 

--- a/packages/aead/README.md
+++ b/packages/aead/README.md
@@ -251,8 +251,9 @@ syntax), so two contexts that authenticate different bytes never share a log lin
 The parts view is the *identity* of a context, on both derivations a context feeds: `AadPiece`
 implements `IntoPrfContext` as well as `IntoAad`, and every built-in context type upholds
 `x.into_aad_piece().into_aad() == x.into_aad()` and
-`x.into_aad_piece().into_prf_context() == x.into_prf_context()` (pinned by quickcheck; `()` is
-the one documented exception, being the empty PRF context by definition). So a context assembled
+`x.into_aad_piece().into_prf_context() == x.into_prf_context()` (pinned by quickcheck; `()`, and
+any composite containing it, is the one documented exception, `()` being the empty PRF context by
+definition while its parts view is an empty `Bytes` leaf; see #339). So a context assembled
 at runtime from parts — one that arrived as data across an FFI boundary — *is* the static value
 with those parts: a list of one is `Some(x)`, the empty list is `None`, a list of two is `(a, b)`,
 and `nonempty!(a).with(b).with(c)` is the left-nested `((a, b), c)`. `AadPiece` also implements

--- a/packages/aead/README.md
+++ b/packages/aead/README.md
@@ -241,23 +241,23 @@ assert_eq!(
 );
 ```
 
-`into_aad_piece` is a provided method on `IntoAad`, defaulting to the whole encoding as one opaque
-`Bytes` leaf, so a context type of your own keeps compiling with only `into_aad` and overrides
+`into_aad_piece` has a default on `IntoAad` that returns the whole encoding as one opaque `Bytes`
+leaf, so a context type of your own keeps compiling with only `into_aad`, and overrides
 `into_aad_piece` when it wants its parts named. A `ContextTag` hands its cipher a context whose
 `into_aad_piece()` is `List([extra_aad, tag])`, so a backend can read the parts directly, while
-`into_aad()` still writes the bytes in one allocation. `Display` is injective (Rust literal
-syntax), so two contexts that authenticate different bytes never share a log line.
+`into_aad()` still writes the bytes in one allocation. `Display` renders different trees
+differently (in Rust literal syntax), so two contexts that authenticate different bytes never share
+a log line.
 
-The parts view is the *identity* of a context, on both derivations a context feeds: `AadPiece`
-implements `IntoPrfContext` as well as `IntoAad`, and every built-in context type upholds
+A parts tree is the same context as the value it came from, on both sides a context is used.
+`AadPiece` implements `IntoPrfContext` as well as `IntoAad`, and for every built-in context type
 `x.into_aad_piece().into_aad() == x.into_aad()` and
-`x.into_aad_piece().into_prf_context() == x.into_prf_context()` (pinned by quickcheck; `()`, and
-any composite containing it, is the one documented exception, `()` being the empty PRF context by
-definition while its parts view is an empty `Bytes` leaf; see #339). So a context assembled
-at runtime from parts — one that arrived as data across an FFI boundary — *is* the static value
-with those parts: a list of one is `Some(x)`, the empty list is `None`, a list of two is `(a, b)`,
-and `nonempty!(a).with(b).with(c)` is the left-nested `((a, b), c)`. `AadPiece` also implements
-`MaybeEmpty` by the same rule the static types use, so a parts tree can be proven `NonEmpty`.
+`x.into_aad_piece().into_prf_context() == x.into_prf_context()` (checked by quickcheck). So a
+context that arrives as data, for example across an FFI boundary, needs no mirror type: a list of
+one is `Some(x)`, the empty list is `None`, a list of two is `(a, b)`,
+`nonempty!(a).with(b).with(c)` is the nested `((a, b), c)`, and `AadPiece::Unit` is `()`.
+`AadPiece` also implements `MaybeEmpty` by the same rule the static types use, so a tree can be
+wrapped in `NonEmpty`.
 
 ### Working with Protected Types
 

--- a/packages/aead/README.md
+++ b/packages/aead/README.md
@@ -248,6 +248,16 @@ assert_eq!(
 `into_aad()` still writes the bytes in one allocation. `Display` is injective (Rust literal
 syntax), so two contexts that authenticate different bytes never share a log line.
 
+The parts view is the *identity* of a context, on both derivations a context feeds: `AadPiece`
+implements `IntoPrfContext` as well as `IntoAad`, and every built-in context type upholds
+`x.into_aad_piece().into_aad() == x.into_aad()` and
+`x.into_aad_piece().into_prf_context() == x.into_prf_context()` (pinned by quickcheck; `()` is
+the one documented exception, being the empty PRF context by definition). So a context assembled
+at runtime from parts — one that arrived as data across an FFI boundary — *is* the static value
+with those parts: a list of one is `Some(x)`, the empty list is `None`, a list of two is `(a, b)`,
+and `nonempty!(a).with(b).with(c)` is the left-nested `((a, b), c)`. `AadPiece` also implements
+`MaybeEmpty` by the same rule the static types use, so a parts tree can be proven `NonEmpty`.
+
 ### Working with Protected Types
 
 The crate integrates with `vitaminc-protected` so sensitive plaintext stays wrapped:

--- a/packages/aead/src/aad/mod.rs
+++ b/packages/aead/src/aad/mod.rs
@@ -194,21 +194,21 @@ impl<'a> Aad<'a> {
 /// Encoding (PAE) so structurally distinct inputs always encode to distinct
 /// byte strings.
 ///
-/// A context has two views. [`into_aad`](Self::into_aad) is the *bytes*
-/// view, what the AEAD authenticates. [`into_aad_piece`](Self::into_aad_piece)
-/// is the *parts* view, an [`AadPiece`] tree for a consumer that needs to
-/// name what those bytes were built from (a log, an audit trail, a
-/// structured binding). The parts view is a provided method, defaulting to
-/// the whole encoding as one opaque `Bytes` leaf, so every `IntoAad` type
-/// has one and a type that implements only `into_aad` keeps compiling and
-/// keeps working. Override it to expose structure. The contract for an
-/// override: `x.into_aad_piece().into_aad()` is byte-for-byte
-/// `x.into_aad()`, and if the type is also a PRF context,
-/// `x.into_aad_piece().into_prf_context()` is `x.into_prf_context()` — the
-/// parts view is the identity of the context on both derivations (see
-/// [`AadPiece`]). Every built-in upholds both, pinned by quickcheck, with
-/// `()`, and any composite containing it, the one documented exception on
-/// the PRF side.
+/// A context has two views. [`into_aad`](Self::into_aad) gives the bytes
+/// the AEAD authenticates. [`into_aad_piece`](Self::into_aad_piece) gives
+/// the same context as an [`AadPiece`] tree, for a consumer that needs to
+/// know what those bytes were built from (a log, an audit trail, a
+/// structured binding). `into_aad_piece` has a default that returns the
+/// whole encoding as one opaque `Bytes` leaf, so a type that implements
+/// only `into_aad` keeps compiling and working. Override it to expose
+/// structure.
+///
+/// An override must keep the two views consistent: `x.into_aad_piece().into_aad()`
+/// must be byte-for-byte `x.into_aad()`, and if the type is also a PRF
+/// context, `x.into_aad_piece().into_prf_context()` must equal
+/// `x.into_prf_context()`. In other words, the tree is the same context as
+/// the value (see [`AadPiece`]). Every built-in type follows this, checked
+/// by quickcheck.
 ///
 /// ```rust
 /// use std::borrow::Cow;
@@ -303,7 +303,7 @@ impl<'a> IntoAad<'a> for () {
     }
 
     fn into_aad_piece(self) -> AadPiece<'a> {
-        AadPiece::Bytes(Cow::Borrowed(&[]))
+        AadPiece::Unit
     }
 }
 

--- a/packages/aead/src/aad/mod.rs
+++ b/packages/aead/src/aad/mod.rs
@@ -206,8 +206,7 @@ impl<'a> Aad<'a> {
 /// `x.into_aad()`, and if the type is also a PRF context,
 /// `x.into_aad_piece().into_prf_context()` is `x.into_prf_context()` — the
 /// parts view is the identity of the context on both derivations (see
-/// [`AadPiece`]'s module docs). Every built-in upholds both, pinned by
-/// quickcheck.
+/// [`AadPiece`]). Every built-in upholds both, pinned by quickcheck.
 ///
 /// ```rust
 /// use std::borrow::Cow;

--- a/packages/aead/src/aad/mod.rs
+++ b/packages/aead/src/aad/mod.rs
@@ -207,7 +207,8 @@ impl<'a> Aad<'a> {
 /// `x.into_aad_piece().into_prf_context()` is `x.into_prf_context()` — the
 /// parts view is the identity of the context on both derivations (see
 /// [`AadPiece`]). Every built-in upholds both, pinned by quickcheck, with
-/// `()` the one documented exception on the PRF side.
+/// `()`, and any composite containing it, the one documented exception on
+/// the PRF side.
 ///
 /// ```rust
 /// use std::borrow::Cow;

--- a/packages/aead/src/aad/mod.rs
+++ b/packages/aead/src/aad/mod.rs
@@ -206,7 +206,8 @@ impl<'a> Aad<'a> {
 /// `x.into_aad()`, and if the type is also a PRF context,
 /// `x.into_aad_piece().into_prf_context()` is `x.into_prf_context()` — the
 /// parts view is the identity of the context on both derivations (see
-/// [`AadPiece`]). Every built-in upholds both, pinned by quickcheck.
+/// [`AadPiece`]). Every built-in upholds both, pinned by quickcheck, with
+/// `()` the one documented exception on the PRF side.
 ///
 /// ```rust
 /// use std::borrow::Cow;

--- a/packages/aead/src/aad/mod.rs
+++ b/packages/aead/src/aad/mod.rs
@@ -203,7 +203,11 @@ impl<'a> Aad<'a> {
 /// has one and a type that implements only `into_aad` keeps compiling and
 /// keeps working. Override it to expose structure. The contract for an
 /// override: `x.into_aad_piece().into_aad()` is byte-for-byte
-/// `x.into_aad()`. Every built-in upholds it, pinned by quickcheck.
+/// `x.into_aad()`, and if the type is also a PRF context,
+/// `x.into_aad_piece().into_prf_context()` is `x.into_prf_context()` — the
+/// parts view is the identity of the context on both derivations (see
+/// [`AadPiece`]'s module docs). Every built-in upholds both, pinned by
+/// quickcheck.
 ///
 /// ```rust
 /// use std::borrow::Cow;

--- a/packages/aead/src/aad/piece.rs
+++ b/packages/aead/src/aad/piece.rs
@@ -29,33 +29,35 @@ use vitaminc_protected::MaybeEmpty;
 
 use super::{Aad, IntoAad};
 
-/// One part of a context, or a PAE-framed list of parts.
+/// One part of a context, or a list of parts.
 ///
-/// Built by [`IntoAad::into_aad_piece`]; encodes through [`IntoAad`]
-/// to the same bytes the source value does, and through
-/// [`IntoPrfContext`] to the same PRF context, so it can stand in for the
-/// value anywhere a context is taken (the law is [below](#the-parts-view-is-the-identity-of-a-context)).
-/// A list encodes in one allocation however deep the tree.
-/// [`Display`](fmt::Display) renders it injectively
-/// — `("users/email", 7u64)` — and [`leaves`](Self::leaves) walks the parts
-/// in encoding order for a consumer building its own rendering or binding.
+/// [`IntoAad::into_aad_piece`] builds one from any context. The tree is a
+/// stand-in for the value it was built from: it encodes to the same AAD
+/// bytes through [`IntoAad`] and to the same PRF context through
+/// [`IntoPrfContext`], so it can be passed anywhere a context is expected
+/// (see [the rule below](#a-parts-tree-is-the-same-context-as-the-value-it-came-from)).
+/// On the AAD side a list is written into a single buffer, however deeply
+/// it nests. [`Display`](fmt::Display) renders a tree so that different
+/// trees never print the same, for example `("users/email", 7u64)`, and
+/// [`leaves`](Self::leaves) walks the parts in encoding order for a caller
+/// that wants to render or bind them itself.
 ///
-/// Integers keep their source type as their variant, so every tree
-/// expressible here encodes without truncation or failure: `U8(7)` is one
-/// byte and `U64(7)` is eight, exactly as `7u8` and `7u64` are.
+/// Integers keep their source type as their variant, so every tree that
+/// can be built here encodes without truncation: `U8(7)` is one byte and
+/// `U64(7)` is eight, exactly as `7u8` and `7u64` are.
 ///
-/// `PartialEq` is tree identity, not encoding identity. `Text("ab")` and
-/// `Bytes(b"ab")` compare unequal, as do `U64(7)` and `I64(7)`, though each
-/// pair encodes to the same bytes. To compare what the AEAD authenticates,
-/// compare `into_aad().as_bytes()`.
+/// `PartialEq` compares trees, not encodings. `Text("ab")` and
+/// `Bytes(b"ab")` are unequal, as are `U64(7)` and `I64(7)`, even though
+/// each pair encodes to the same bytes. To compare what the AEAD
+/// authenticates, compare `into_aad().as_bytes()`.
 ///
-/// # The parts view is the identity of a context
+/// # A parts tree is the same context as the value it came from
 ///
-/// A context feeds two derivations: the AEAD's associated data
-/// ([`IntoAad`]) and a PRF's domain-separation context
-/// ([`IntoPrfContext`]). [`AadPiece`] implements both, and the law every
-/// context type upholds is that each derivation of the value equals the
-/// same derivation of its parts view:
+/// A context is used in two places: as the associated data an AEAD
+/// authenticates ([`IntoAad`]) and as the context a PRF mixes into its key
+/// derivation ([`IntoPrfContext`]). [`AadPiece`] implements both, and every
+/// built-in context type follows one rule: converting the value gives the
+/// same result as converting its parts tree, on both sides.
 ///
 /// ```rust
 /// use std::borrow::Cow;
@@ -69,7 +71,8 @@ use super::{Aad, IntoAad};
 /// );
 /// assert_eq!(x.into_aad_piece().into_prf_context(), x.into_prf_context());
 ///
-/// // So a list assembled at runtime *is* the static value with those parts.
+/// // A list built at runtime is therefore the same context as the
+/// // static value with those parts.
 /// let runtime = AadPiece::List(vec![
 ///     AadPiece::Text(Cow::Borrowed("users/email")),
 ///     AadPiece::U64(7),
@@ -78,42 +81,40 @@ use super::{Aad, IntoAad};
 /// assert_eq!(runtime.into_prf_context(), x.into_prf_context());
 /// ```
 ///
-/// So a context assembled at runtime from parts — one that arrived as data
-/// across an FFI boundary, say — is the *same* context as the static Rust
-/// value with those parts, on both sides, and needs no type of its own:
-/// `Some(x)` is the one-element list, `None` the empty list, `(a, b)` the
-/// two-element list, and `nonempty!(a).with(b).with(c)` the left-nested
-/// `((a, b), c)`. A flat list of three or more parts is a context too,
-/// reachable from Rust through [`AadPiece::List`] directly. The law is
-/// pinned by quickcheck over every built-in context type.
+/// This matters for a context that arrives as data rather than as a Rust
+/// type, for example across an FFI boundary. It needs no mirror type of its
+/// own, because a tree with the same parts is the same context:
 ///
-/// The one exception is `()`, and any composite that contains it. `()` is
-/// the *empty* PRF context by definition (no encoding at all), while its
-/// parts view is an empty `Bytes` leaf, which the PRF side encodes as typed
-/// empty bytes. Bare `()` is empty and so never reaches `NonEmpty`, but
-/// `("x", ())` is non-empty by the pair rule and derives different PRF
-/// bytes from its parts view than from the static value. Do not put `()`
-/// inside a context a runtime consumer must reproduce. The divergence is
-/// pinned, and removed for good by the shared context encoding in
-/// [#339](https://github.com/cipherstash/vitaminc/issues/339).
+/// - `Some(x)` is the one-element list and `None` is the empty list;
+/// - `(a, b)` is the two-element list;
+/// - `nonempty!(a).with(b).with(c)` is the nested list `((a, b), c)`;
+/// - `()` is [`AadPiece::Unit`].
 ///
-/// [`MaybeEmpty`] completes the set, so a parts tree can be proven
-/// [`NonEmpty`](vitaminc_protected::NonEmpty) by the same rule the static
-/// types use: text and bytes are empty at zero length, an integer never is,
-/// and a list is empty only when every part is.
+/// A flat list of three or more parts is also a valid context. It has no
+/// tuple spelling in Rust, so build it with [`AadPiece::List`] directly.
+/// The rule is checked by quickcheck for every built-in context type.
 ///
-/// The enum is `#[non_exhaustive]`: the crate's own derived contexts
-/// (`Aad::for_map_entry`, `Aad::for_leaf`, …) have no faithful shape here
-/// yet, and adding one must not break a downstream `match`.
+/// [`MaybeEmpty`] is implemented by the same rule the static types use, so
+/// a tree can be wrapped in [`NonEmpty`](vitaminc_protected::NonEmpty):
+/// text and bytes are empty at zero length, unit is empty, an integer never
+/// is, and a list is empty only when every part is.
+///
+/// The enum is `#[non_exhaustive]`. The crate's own derived contexts
+/// (`Aad::for_map_entry`, `Aad::for_leaf`, and so on) have no faithful
+/// shape here yet, and adding one must not break a downstream `match`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum AadPiece<'a> {
     /// Text; encodes as its UTF-8 bytes. `&str`, `String`.
     Text(Cow<'a, str>),
     /// Opaque bytes; encode as themselves. Byte slices and arrays,
-    /// `Vec<u8>`, `Cow<[u8]>`, an already-encoded [`Aad`], and `()` (no
-    /// bytes at all).
+    /// `Vec<u8>`, `Cow<[u8]>`, and an already-encoded [`Aad`].
     Bytes(Cow<'a, [u8]>),
+    /// The unit context, `()`. Encodes as no bytes at all on the AAD side
+    /// and as the empty context on the PRF side. Not the same as empty
+    /// bytes, which the PRF side frames, or the empty list, which both
+    /// sides frame.
+    Unit,
     /// A `u8`; encodes as one little-endian byte, with no type tag — see
     /// the integer [`IntoAad`] impls.
     U8(u8),
@@ -146,6 +147,7 @@ impl<'a> AadPiece<'a> {
         match self {
             AadPiece::Text(text) => AadPiece::Text(Cow::Owned(text.into_owned())),
             AadPiece::Bytes(bytes) => AadPiece::Bytes(Cow::Owned(bytes.into_owned())),
+            AadPiece::Unit => AadPiece::Unit,
             AadPiece::U8(v) => AadPiece::U8(v),
             AadPiece::U16(v) => AadPiece::U16(v),
             AadPiece::U32(v) => AadPiece::U32(v),
@@ -188,6 +190,7 @@ impl<'a> AadPiece<'a> {
         match self {
             AadPiece::Text(text) => text.len(),
             AadPiece::Bytes(bytes) => bytes.len(),
+            AadPiece::Unit => 0,
             AadPiece::U8(_) | AadPiece::I8(_) => 1,
             AadPiece::U16(_) | AadPiece::I16(_) => 2,
             AadPiece::U32(_) | AadPiece::I32(_) => 4,
@@ -235,6 +238,7 @@ impl<'a> AadPiece<'a> {
         match self {
             AadPiece::Text(text) => buf.extend_from_slice(text.as_bytes()),
             AadPiece::Bytes(bytes) => buf.extend_from_slice(bytes),
+            AadPiece::Unit => {}
             AadPiece::U8(v) => buf.extend_from_slice(&v.to_le_bytes()),
             AadPiece::U16(v) => buf.extend_from_slice(&v.to_le_bytes()),
             AadPiece::U32(v) => buf.extend_from_slice(&v.to_le_bytes()),
@@ -260,10 +264,10 @@ impl<'a> AadPiece<'a> {
     }
 }
 
-/// Encodes to the bytes of the value the piece was built from. A leaf hands
-/// its storage to that value's own [`IntoAad`] impl without copying; a list
-/// is written into one buffer sized up front, however deep it nests. The
-/// parts view of a piece is the piece.
+/// Encodes to the same bytes as the value the tree was built from. A leaf
+/// hands its storage to that value's own [`IntoAad`] impl without copying.
+/// A list is written into one buffer sized up front, however deeply it
+/// nests. The parts tree of a tree is itself.
 impl<'a> IntoAad<'a> for AadPiece<'a> {
     fn into_aad_piece(self) -> AadPiece<'a> {
         self
@@ -274,6 +278,7 @@ impl<'a> IntoAad<'a> for AadPiece<'a> {
             AadPiece::Text(Cow::Borrowed(text)) => text.into_aad(),
             AadPiece::Text(Cow::Owned(text)) => text.into_aad(),
             AadPiece::Bytes(bytes) => bytes.into_aad(),
+            AadPiece::Unit => ().into_aad(),
             AadPiece::U8(v) => v.into_aad(),
             AadPiece::U16(v) => v.into_aad(),
             AadPiece::U32(v) => v.into_aad(),
@@ -295,18 +300,19 @@ impl<'a> IntoAad<'a> for AadPiece<'a> {
     }
 }
 
-/// A piece derives the PRF context its source value would: a leaf hands
-/// itself to the standard type's own [`IntoPrfContext`] impl (text as a
-/// `str`, bytes as a `[u8]`, an integer as itself, so each keeps its typed
-/// encoding) and a list is [`PrfContext::pae`] of its parts, which is what
-/// the pair and `Option` impls produce. Nothing is re-derived here; the
-/// framing is the one `pae` every list impl uses.
+/// Derives the same PRF context as the value the tree was built from. A
+/// leaf hands itself to the standard type's own [`IntoPrfContext`] impl
+/// (text as a `str`, bytes as a `[u8]`, an integer as itself), so each
+/// keeps its typed encoding. A list is [`PrfContext::pae`] over its parts,
+/// which is exactly how the pair and `Option` impls frame theirs. Nothing
+/// is encoded differently here.
 impl<'a> IntoPrfContext<'a> for AadPiece<'a> {
     fn into_prf_context(self) -> PrfContext<'a> {
         match self {
             AadPiece::Text(Cow::Borrowed(text)) => text.into_prf_context(),
             AadPiece::Text(Cow::Owned(text)) => text.into_prf_context(),
             AadPiece::Bytes(bytes) => bytes.into_prf_context(),
+            AadPiece::Unit => ().into_prf_context(),
             AadPiece::U8(v) => v.into_prf_context(),
             AadPiece::U16(v) => v.into_prf_context(),
             AadPiece::U32(v) => v.into_prf_context(),
@@ -329,16 +335,17 @@ impl<'a> IntoPrfContext<'a> for AadPiece<'a> {
     }
 }
 
-/// The rule the static types follow, on the tree: text and bytes are empty
-/// at zero length, an integer is never empty (it is caller information),
-/// and a list is empty only when every part is — so `[]` (`None`) and
-/// `[""]` (`Some("")`) are empty and `["", 7u64]` is not, as
-/// `Option<T>` and `(A, B)` decide.
+/// The same emptiness rule the static types use, applied to the tree. Text
+/// and bytes are empty at zero length. Unit is empty. An integer is never
+/// empty, because even zero is information the caller chose. A list is
+/// empty only when every part is, so `None` and `Some("")` are empty and
+/// `("", 7u64)` is not, matching what `Option<T>` and `(A, B)` decide.
 impl MaybeEmpty for AadPiece<'_> {
     fn is_empty(&self) -> bool {
         match self {
             AadPiece::Text(text) => text.is_empty(),
             AadPiece::Bytes(bytes) => bytes.is_empty(),
+            AadPiece::Unit => true,
             AadPiece::U8(_)
             | AadPiece::U16(_)
             | AadPiece::U32(_)
@@ -354,16 +361,19 @@ impl MaybeEmpty for AadPiece<'_> {
     }
 }
 
-/// An injective rendering, in Rust literal syntax: text quoted and escaped
-/// as `Debug` does, integers with their type suffix, bytes as `0x`-prefixed
-/// hex, a list parenthesised and comma-separated — `("users/email", 7u64)`
-/// shows as `("users/email", 7u64)`, and `None` as `()`.
+/// Renders the tree in Rust literal syntax, and different trees never
+/// render the same. Text is quoted and escaped as `Debug` does, integers
+/// carry their type suffix, bytes print as `0x`-prefixed hex, unit prints
+/// as `()`, a list is parenthesised and comma-separated, and the empty list
+/// prints as `None` (the context it is). So `("users/email", 7u64)` prints
+/// as `("users/email", 7u64)`.
 ///
-/// Distinct trees render distinctly: the four leaf kinds start with `"`,
-/// a digit or `-`, `0x` and `(` respectively, integer suffixes keep types
-/// of equal width apart, and quoting keeps separators inside text from
-/// reading as structure. Two contexts that authenticate different bytes
-/// therefore never share a log line.
+/// Each kind starts differently: `"` for text, a digit or `-` for an
+/// integer, `0x` for bytes, `()` for unit, `(` followed by a part for a
+/// list, and `None` for the empty list. Integer suffixes keep types of the
+/// same width apart, and quoting keeps separators inside text from reading
+/// as structure. Two contexts that authenticate different bytes therefore
+/// never share a log line.
 impl fmt::Display for AadPiece<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -372,6 +382,7 @@ impl fmt::Display for AadPiece<'_> {
                 f.write_str("0x")?;
                 bytes.iter().try_for_each(|byte| write!(f, "{byte:02x}"))
             }
+            AadPiece::Unit => f.write_str("()"),
             AadPiece::U8(v) => write!(f, "{v}u8"),
             AadPiece::U16(v) => write!(f, "{v}u16"),
             AadPiece::U32(v) => write!(f, "{v}u32"),
@@ -382,6 +393,7 @@ impl fmt::Display for AadPiece<'_> {
             AadPiece::I32(v) => write!(f, "{v}i32"),
             AadPiece::I64(v) => write!(f, "{v}i64"),
             AadPiece::I128(v) => write!(f, "{v}i128"),
+            AadPiece::List(parts) if parts.is_empty() => f.write_str("None"),
             AadPiece::List(parts) => {
                 f.write_str("(")?;
                 for (i, part) in parts.iter().enumerate() {
@@ -405,7 +417,7 @@ mod tests {
 
     use super::*;
 
-    /// One half of the law: the tree encodes to the value's own AAD bytes.
+    /// The AAD half of the rule: the tree encodes to the value's own AAD bytes.
     fn agrees<'a, T>(value: T) -> bool
     where
         T: IntoAad<'a> + Clone,
@@ -413,7 +425,7 @@ mod tests {
         value.clone().into_aad_piece().into_aad().as_bytes() == value.into_aad().as_bytes()
     }
 
-    /// The other half: the tree derives the value's own PRF context.
+    /// The PRF half of the rule: the tree derives the value's own PRF context.
     fn prf_agrees<'a, T>(value: T) -> bool
     where
         T: IntoAad<'a> + IntoPrfContext<'a> + Clone,
@@ -421,8 +433,8 @@ mod tests {
         value.clone().into_aad_piece().into_prf_context() == value.into_prf_context()
     }
 
-    /// Both halves together: the parts view is the identity of the context
-    /// on both derivations.
+    /// Both halves: converting the value and converting its tree give the
+    /// same result on both sides.
     fn is_identity<'a, T>(value: T) -> bool
     where
         T: IntoAad<'a> + IntoPrfContext<'a> + Clone,
@@ -434,8 +446,7 @@ mod tests {
         AadPiece::Text(Cow::Borrowed(s))
     }
 
-    /// The parts-view law, per built-in context type: each derivation of
-    /// the value equals the same derivation of `into_aad_piece()`.
+    /// The rule from the type docs, checked per built-in context type.
     mod given_a_text_context {
         use super::*;
 
@@ -466,8 +477,9 @@ mod tests {
         }
 
         #[test]
-        fn a_raw_aad_agrees_on_the_aad_derivation() {
-            // `Aad` is not a PRF context, so only the AAD half applies.
+        fn a_raw_aad_agrees_on_the_aad_side() {
+            // `Aad` does not implement `IntoPrfContext`, so only the AAD
+            // half of the rule applies to it.
             assert!(
                 agrees(Aad::from_slice(b"raw")),
                 "a raw `Aad` is one opaque `Bytes` leaf"
@@ -500,8 +512,8 @@ mod tests {
 
         #[quickcheck]
         fn both_derivations_agree(s: String, n: u64, o: Option<String>, b: Vec<u8>) -> bool {
-            // Pairs, options, nesting in both directions, and the proven
-            // wrapper — the shapes a runtime list has to be able to spell.
+            // Pairs, options, nesting in both directions, and `NonEmpty`:
+            // every shape a runtime list has to be able to express.
             is_identity((s.as_str(), n))
                 && is_identity(o.clone())
                 && is_identity(((s.as_str(), n), b.as_slice()))
@@ -621,48 +633,57 @@ mod tests {
         use super::*;
 
         #[test]
-        fn the_aad_half_of_the_law_holds() {
-            assert!(agrees(()), "`()` is zero AAD bytes on both sides");
+        fn is_the_unit_leaf() {
+            assert_eq!(().into_aad_piece(), AadPiece::Unit, "`()` has its own leaf");
+            assert_eq!(AadPiece::Unit.to_string(), "()", "unit prints as `()`");
         }
 
         #[test]
-        fn the_prf_half_is_the_documented_exception() {
-            // `()` is the empty PRF context by definition, and its parts view
-            // is an empty `Bytes` leaf, which encodes as typed empty bytes.
+        fn both_sides_agree_on_its_own() {
             assert!(
-                !prf_agrees(()),
-                "`()` derives no PRF bytes statically and typed empty bytes from its parts"
+                is_identity(()),
+                "`()` is no AAD bytes and the empty PRF context"
             );
         }
 
         #[test]
-        fn never_reaches_non_empty_on_its_own() {
+        fn both_sides_agree_inside_a_composite() {
+            // `()` on its own is empty, so it never reaches `NonEmpty`. Inside
+            // a pair or a `with` chain it does, so the rule has to hold there.
+            assert!(is_identity(("x", ())), "`()` as the second half of a pair");
+            assert!(is_identity(((), "x")), "`()` as the first half of a pair");
+            assert!(is_identity(Some(())), "`()` inside `Some`");
             assert!(
-                ().into_aad_piece().is_empty(),
-                "bare `()` is empty, so it never reaches `NonEmpty`"
+                is_identity(NonEmpty::new("x").unwrap().with(())),
+                "`()` appended with `with`"
+            );
+            assert!(
+                is_identity(NonEmpty::new("x").unwrap().with(Some(()))),
+                "`Some(())` appended with `with`"
             );
         }
 
         #[test]
-        fn a_pair_containing_it_is_non_empty() {
-            assert!(
-                NonEmpty::new(("x", ())).is_ok(),
-                "a pair with one non-empty part is non-empty"
+        fn is_not_empty_bytes_and_not_the_empty_list() {
+            // Three different contexts: `()` encodes as no bytes, empty
+            // bytes are framed on the PRF side, and the empty list is framed
+            // on both. The tree keeps them apart, and so does `Display`.
+            let empty_bytes = AadPiece::Bytes(Cow::Borrowed(&[]));
+            let none = Option::<()>::None.into_aad_piece();
+            assert_ne!(AadPiece::Unit, empty_bytes, "unit is not empty bytes");
+            assert_ne!(AadPiece::Unit, none, "unit is not the empty list");
+            assert_ne!(
+                AadPiece::Unit.into_prf_context(),
+                empty_bytes.clone().into_prf_context(),
+                "unit and empty bytes are different PRF contexts"
             );
-        }
-
-        #[test]
-        fn a_pair_containing_it_diverges_on_the_prf_side() {
-            // The exception reaches `NonEmpty` through a composite: the pair
-            // rule makes `("x", ())` non-empty, and the divergence in `()`
-            // carries through. Pinned so the exception's reach is visible;
-            // removed for good by the shared encoding in #339.
-            let pair = ("x", ());
-            assert!(agrees(pair), "the AAD half still holds through a pair");
-            assert!(
-                !prf_agrees(pair),
-                "the PRF half does not, because `()` inside a pair encodes as typed empty bytes"
+            assert_ne!(
+                AadPiece::Unit.into_aad().as_bytes(),
+                none.clone().into_aad().as_bytes(),
+                "unit and the empty list are different AAD"
             );
+            assert_ne!(AadPiece::Unit.to_string(), empty_bytes.to_string());
+            assert_ne!(AadPiece::Unit.to_string(), none.to_string());
         }
     }
 
@@ -671,10 +692,12 @@ mod tests {
 
         #[quickcheck]
         fn a_list_derives_the_pae_of_its_parts(tree: Tree) -> bool {
-            // The PRF side of `list_encodes_as_pae_of_its_parts`: a list's
-            // context is `LE64(count) || (LE64(len) || part)*` over each
-            // part's context, at every level. The oracle frames by hand so
-            // it does not share `PrfContext::pae` with the impl under test.
+            // The PRF-side twin of `list_encodes_as_pae_of_its_parts`: a
+            // list's PRF context is `LE64(count) || (LE64(len) || part)*`
+            // over its parts' PRF contexts, at every level. The expected
+            // value is framed by hand here rather than with
+            // `PrfContext::pae`, so the test does not share code with the
+            // impl it checks.
             fn expected(piece: &AadPiece<'_>) -> Vec<u8> {
                 match piece {
                     AadPiece::List(parts) => {
@@ -768,17 +791,8 @@ mod tests {
             Some("a").into_aad_piece(),
             AadPiece::List(vec![AadPiece::Text(Cow::Borrowed("a"))])
         );
-        assert_eq!(Option::<&str>::None.into_aad_piece().to_string(), "()");
+        assert_eq!(Option::<&str>::None.into_aad_piece().to_string(), "None");
         assert_eq!(Some("a").into_aad_piece().to_string(), "(\"a\")");
-    }
-
-    #[test]
-    fn the_empty_aad_is_no_bytes_not_an_empty_list() {
-        // `()` encodes as zero bytes; `None` as PAE of zero pieces. The
-        // trees keep them apart the way the encodings do.
-        assert_eq!(().into_aad_piece(), AadPiece::Bytes(Cow::Borrowed(&[])));
-        assert_ne!(().into_aad_piece(), Option::<()>::None.into_aad_piece());
-        assert_eq!(().into_aad_piece().to_string(), "0x");
     }
 
     #[test]
@@ -835,10 +849,10 @@ mod tests {
     #[test]
     fn display_is_injective_where_it_used_to_collide() {
         // Same width, different type; text that looks like an integer; text
-        // that looks like hex; `Some("")` against `None`; text containing
-        // the separators. Each pair encodes differently and must print
-        // differently.
-        let pairs: [(AadPiece<'_>, AadPiece<'_>); 5] = [
+        // that looks like hex; `Some("")` against `None`; `()` against
+        // `None`; text containing the separators. Each pair encodes
+        // differently and must print differently.
+        let pairs: [(AadPiece<'_>, AadPiece<'_>); 6] = [
             (7u64.into_aad_piece(), 7i64.into_aad_piece()),
             (("x", 7u64).into_aad_piece(), ("x", "7").into_aad_piece()),
             ("0xdead".into_aad_piece(), [0xdeu8, 0xad].into_aad_piece()),
@@ -846,6 +860,7 @@ mod tests {
                 Some("").into_aad_piece(),
                 Option::<&str>::None.into_aad_piece(),
             ),
+            (().into_aad_piece(), Option::<&str>::None.into_aad_piece()),
             (
                 ("a, b", "c").into_aad_piece(),
                 ("a", "b, c").into_aad_piece(),
@@ -870,20 +885,21 @@ mod tests {
     impl quickcheck::Arbitrary for Tree {
         fn arbitrary(g: &mut quickcheck::Gen) -> Self {
             fn gen(g: &mut quickcheck::Gen, depth: u8) -> AadPiece<'static> {
-                let kinds = if depth == 0 { 12 } else { 13 };
+                let kinds = if depth == 0 { 13 } else { 14 };
                 match u8::arbitrary(g) % kinds {
                     0 => AadPiece::Text(Cow::Owned(String::arbitrary(g))),
                     1 => AadPiece::Bytes(Cow::Owned(Vec::arbitrary(g))),
-                    2 => AadPiece::U8(u8::arbitrary(g)),
-                    3 => AadPiece::U16(u16::arbitrary(g)),
-                    4 => AadPiece::U32(u32::arbitrary(g)),
-                    5 => AadPiece::U64(u64::arbitrary(g)),
-                    6 => AadPiece::U128(u128::arbitrary(g)),
-                    7 => AadPiece::I8(i8::arbitrary(g)),
-                    8 => AadPiece::I16(i16::arbitrary(g)),
-                    9 => AadPiece::I32(i32::arbitrary(g)),
-                    10 => AadPiece::I64(i64::arbitrary(g)),
-                    11 => AadPiece::I128(i128::arbitrary(g)),
+                    2 => AadPiece::Unit,
+                    3 => AadPiece::U8(u8::arbitrary(g)),
+                    4 => AadPiece::U16(u16::arbitrary(g)),
+                    5 => AadPiece::U32(u32::arbitrary(g)),
+                    6 => AadPiece::U64(u64::arbitrary(g)),
+                    7 => AadPiece::U128(u128::arbitrary(g)),
+                    8 => AadPiece::I8(i8::arbitrary(g)),
+                    9 => AadPiece::I16(i16::arbitrary(g)),
+                    10 => AadPiece::I32(i32::arbitrary(g)),
+                    11 => AadPiece::I64(i64::arbitrary(g)),
+                    12 => AadPiece::I128(i128::arbitrary(g)),
                     _ => {
                         let n = usize::arbitrary(g) % 4;
                         AadPiece::List((0..n).map(|_| gen(g, depth - 1)).collect())
@@ -899,6 +915,7 @@ mod tests {
         vec![
             AadPiece::Text(Cow::Borrowed("t")),
             AadPiece::Bytes(Cow::Borrowed(b"b")),
+            AadPiece::Unit,
             AadPiece::U8(1),
             AadPiece::U16(2),
             AadPiece::U32(3),
@@ -933,8 +950,8 @@ mod tests {
         assert_eq!(
             rendered,
             [
-                "\"t\"", "0x62", "1u8", "2u16", "3u32", "4u64", "5u128", "-1i8", "-2i16", "-3i32",
-                "-4i64", "-5i128", "(9u8)",
+                "\"t\"", "0x62", "()", "1u8", "2u16", "3u32", "4u64", "5u128", "-1i8", "-2i16",
+                "-3i32", "-4i64", "-5i128", "(9u8)",
             ]
         );
     }

--- a/packages/aead/src/aad/piece.rs
+++ b/packages/aead/src/aad/piece.rs
@@ -20,37 +20,6 @@
 //! that logs or binds the parts (a key-management service) reads them
 //! straight from what it is given, while a backend that only wants bytes
 //! pays nothing for the view.
-//!
-//! # The parts view is the identity of a context
-//!
-//! A context feeds two derivations: the AEAD's associated data
-//! ([`IntoAad`]) and a PRF's domain-separation context
-//! ([`IntoPrfContext`]). [`AadPiece`] implements both, and the law every
-//! context type upholds is that each derivation of the value equals the
-//! same derivation of its parts view:
-//!
-//! ```text
-//! x.into_aad()         == x.into_aad_piece().into_aad()
-//! x.into_prf_context() == x.into_aad_piece().into_prf_context()
-//! ```
-//!
-//! So a context assembled at runtime from parts — one that arrived as data
-//! across an FFI boundary, say — is the *same* context as the static Rust
-//! value with those parts, on both sides, and needs no type of its own:
-//! `Some(x)` is the one-element list, `None` the empty list, `(a, b)` the
-//! two-element list, and `nonempty!(a).with(b).with(c)` the left-nested
-//! `((a, b), c)`. A flat list of three or more parts is a context too,
-//! reachable from Rust through [`AadPiece::List`] directly. The one
-//! exception is `()`: its PRF context is the *empty* context by definition
-//! (no encoding at all), while its parts view is an empty `Bytes` leaf,
-//! which the PRF side encodes as typed empty bytes. `()` is never a
-//! context a caller proves non-empty, so nothing built from parts meets
-//! it. The law is pinned by quickcheck over every built-in context type.
-//!
-//! [`MaybeEmpty`] completes the set, so a parts tree can be proven
-//! [`NonEmpty`](vitaminc_protected::NonEmpty) by the same rule the static
-//! types use: text and bytes are empty at zero length, an integer never is,
-//! and a list is empty only when every part is.
 
 use std::borrow::Cow;
 use std::fmt;
@@ -65,8 +34,9 @@ use super::{Aad, IntoAad};
 /// Built by [`IntoAad::into_aad_piece`]; encodes through [`IntoAad`]
 /// to the same bytes the source value does, and through
 /// [`IntoPrfContext`] to the same PRF context, so it can stand in for the
-/// value anywhere a context is taken (see the [module docs](self) for the
-/// law). A list encodes in one allocation however deep the tree. [`Display`](fmt::Display) renders it injectively
+/// value anywhere a context is taken (the law is [below](#the-parts-view-is-the-identity-of-a-context)).
+/// A list encodes in one allocation however deep the tree.
+/// [`Display`](fmt::Display) renders it injectively
 /// — `("users/email", 7u64)` — and [`leaves`](Self::leaves) walks the parts
 /// in encoding order for a consumer building its own rendering or binding.
 ///
@@ -78,6 +48,37 @@ use super::{Aad, IntoAad};
 /// `Bytes(b"ab")` compare unequal, as do `U64(7)` and `I64(7)`, though each
 /// pair encodes to the same bytes. To compare what the AEAD authenticates,
 /// compare `into_aad().as_bytes()`.
+///
+/// # The parts view is the identity of a context
+///
+/// A context feeds two derivations: the AEAD's associated data
+/// ([`IntoAad`]) and a PRF's domain-separation context
+/// ([`IntoPrfContext`]). [`AadPiece`] implements both, and the law every
+/// context type upholds is that each derivation of the value equals the
+/// same derivation of its parts view:
+///
+/// ```text
+/// x.into_aad()         == x.into_aad_piece().into_aad()
+/// x.into_prf_context() == x.into_aad_piece().into_prf_context()
+/// ```
+///
+/// So a context assembled at runtime from parts — one that arrived as data
+/// across an FFI boundary, say — is the *same* context as the static Rust
+/// value with those parts, on both sides, and needs no type of its own:
+/// `Some(x)` is the one-element list, `None` the empty list, `(a, b)` the
+/// two-element list, and `nonempty!(a).with(b).with(c)` the left-nested
+/// `((a, b), c)`. A flat list of three or more parts is a context too,
+/// reachable from Rust through [`AadPiece::List`] directly. The one
+/// exception is `()`: its PRF context is the *empty* context by definition
+/// (no encoding at all), while its parts view is an empty `Bytes` leaf,
+/// which the PRF side encodes as typed empty bytes. `()` is never a
+/// context a caller proves non-empty, so nothing built from parts meets
+/// it. The law is pinned by quickcheck over every built-in context type.
+///
+/// [`MaybeEmpty`] completes the set, so a parts tree can be proven
+/// [`NonEmpty`](vitaminc_protected::NonEmpty) by the same rule the static
+/// types use: text and bytes are empty at zero length, an integer never is,
+/// and a list is empty only when every part is.
 ///
 /// The enum is `#[non_exhaustive]`: the crate's own derived contexts
 /// (`Aad::for_map_entry`, `Aad::for_leaf`, …) have no faithful shape here

--- a/packages/aead/src/aad/piece.rs
+++ b/packages/aead/src/aad/piece.rs
@@ -20,18 +20,53 @@
 //! that logs or binds the parts (a key-management service) reads them
 //! straight from what it is given, while a backend that only wants bytes
 //! pays nothing for the view.
+//!
+//! # The parts view is the identity of a context
+//!
+//! A context feeds two derivations: the AEAD's associated data
+//! ([`IntoAad`]) and a PRF's domain-separation context
+//! ([`IntoPrfContext`]). [`AadPiece`] implements both, and the law every
+//! context type upholds is that each derivation of the value equals the
+//! same derivation of its parts view:
+//!
+//! ```text
+//! x.into_aad()         == x.into_aad_piece().into_aad()
+//! x.into_prf_context() == x.into_aad_piece().into_prf_context()
+//! ```
+//!
+//! So a context assembled at runtime from parts — one that arrived as data
+//! across an FFI boundary, say — is the *same* context as the static Rust
+//! value with those parts, on both sides, and needs no type of its own:
+//! `Some(x)` is the one-element list, `None` the empty list, `(a, b)` the
+//! two-element list, and `nonempty!(a).with(b).with(c)` the left-nested
+//! `((a, b), c)`. A flat list of three or more parts is a context too,
+//! reachable from Rust through [`AadPiece::List`] directly. The one
+//! exception is `()`: its PRF context is the *empty* context by definition
+//! (no encoding at all), while its parts view is an empty `Bytes` leaf,
+//! which the PRF side encodes as typed empty bytes. `()` is never a
+//! context a caller proves non-empty, so nothing built from parts meets
+//! it. The law is pinned by quickcheck over every built-in context type.
+//!
+//! [`MaybeEmpty`] completes the set, so a parts tree can be proven
+//! [`NonEmpty`](vitaminc_protected::NonEmpty) by the same rule the static
+//! types use: text and bytes are empty at zero length, an integer never is,
+//! and a list is empty only when every part is.
 
 use std::borrow::Cow;
 use std::fmt;
+
+use vitaminc_prf::{IntoPrfContext, PrfContext};
+use vitaminc_protected::MaybeEmpty;
 
 use super::{Aad, IntoAad};
 
 /// One part of a context, or a PAE-framed list of parts.
 ///
 /// Built by [`IntoAad::into_aad_piece`]; encodes through [`IntoAad`]
-/// to the same bytes the source value does, so it can stand in for the
-/// value anywhere an AAD is taken. A list encodes in one allocation
-/// however deep the tree. [`Display`](fmt::Display) renders it injectively
+/// to the same bytes the source value does, and through
+/// [`IntoPrfContext`] to the same PRF context, so it can stand in for the
+/// value anywhere a context is taken (see the [module docs](self) for the
+/// law). A list encodes in one allocation however deep the tree. [`Display`](fmt::Display) renders it injectively
 /// — `("users/email", 7u64)` — and [`leaves`](Self::leaves) walks the parts
 /// in encoding order for a consumer building its own rendering or binding.
 ///
@@ -237,6 +272,65 @@ impl<'a> IntoAad<'a> for AadPiece<'a> {
     }
 }
 
+/// A piece derives the PRF context its source value would: a leaf hands
+/// itself to the standard type's own [`IntoPrfContext`] impl (text as a
+/// `str`, bytes as a `[u8]`, an integer as itself, so each keeps its typed
+/// encoding) and a list is [`PrfContext::pae`] of its parts, which is what
+/// the pair and `Option` impls produce. Nothing is re-derived here; the
+/// framing is the one `pae` every list impl uses.
+impl<'a> IntoPrfContext<'a> for AadPiece<'a> {
+    fn into_prf_context(self) -> PrfContext<'a> {
+        match self {
+            AadPiece::Text(Cow::Borrowed(text)) => text.into_prf_context(),
+            AadPiece::Text(Cow::Owned(text)) => text.into_prf_context(),
+            AadPiece::Bytes(bytes) => bytes.into_prf_context(),
+            AadPiece::U8(v) => v.into_prf_context(),
+            AadPiece::U16(v) => v.into_prf_context(),
+            AadPiece::U32(v) => v.into_prf_context(),
+            AadPiece::U64(v) => v.into_prf_context(),
+            AadPiece::U128(v) => v.into_prf_context(),
+            AadPiece::I8(v) => v.into_prf_context(),
+            AadPiece::I16(v) => v.into_prf_context(),
+            AadPiece::I32(v) => v.into_prf_context(),
+            AadPiece::I64(v) => v.into_prf_context(),
+            AadPiece::I128(v) => v.into_prf_context(),
+            AadPiece::List(parts) => {
+                let parts: Vec<PrfContext<'a>> = parts
+                    .into_iter()
+                    .map(IntoPrfContext::into_prf_context)
+                    .collect();
+                let pieces: Vec<&[u8]> = parts.iter().map(PrfContext::as_bytes).collect();
+                PrfContext::pae(&pieces)
+            }
+        }
+    }
+}
+
+/// The rule the static types follow, on the tree: text and bytes are empty
+/// at zero length, an integer is never empty (it is caller information),
+/// and a list is empty only when every part is — so `[]` (`None`) and
+/// `[""]` (`Some("")`) are empty and `["", 7u64]` is not, as
+/// `Option<T>` and `(A, B)` decide.
+impl MaybeEmpty for AadPiece<'_> {
+    fn is_empty(&self) -> bool {
+        match self {
+            AadPiece::Text(text) => text.is_empty(),
+            AadPiece::Bytes(bytes) => bytes.is_empty(),
+            AadPiece::U8(_)
+            | AadPiece::U16(_)
+            | AadPiece::U32(_)
+            | AadPiece::U64(_)
+            | AadPiece::U128(_)
+            | AadPiece::I8(_)
+            | AadPiece::I16(_)
+            | AadPiece::I32(_)
+            | AadPiece::I64(_)
+            | AadPiece::I128(_) => false,
+            AadPiece::List(parts) => parts.iter().all(MaybeEmpty::is_empty),
+        }
+    }
+}
+
 /// An injective rendering, in Rust literal syntax: text quoted and escaped
 /// as `Debug` does, integers with their type suffix, bytes as `0x`-prefixed
 /// hex, a list parenthesised and comma-separated — `("users/email", 7u64)`
@@ -294,6 +388,196 @@ mod tests {
         T: IntoAad<'a> + Clone,
     {
         value.clone().into_aad_piece().into_aad().as_bytes() == value.into_aad().as_bytes()
+    }
+
+    /// The other half of the law: the tree derives the value's own PRF
+    /// context. Together with [`agrees`], the parts view is the identity
+    /// of the context on both derivations.
+    fn prf_agrees<'a, T>(value: T) -> bool
+    where
+        T: IntoAad<'a> + IntoPrfContext<'a> + Clone,
+    {
+        value.clone().into_aad_piece().into_prf_context() == value.into_prf_context()
+    }
+
+    #[quickcheck]
+    fn text_derives_the_same_prf_context(s: String) -> bool {
+        prf_agrees(s.as_str()) && prf_agrees(s)
+    }
+
+    #[quickcheck]
+    fn bytes_derive_the_same_prf_context(b: Vec<u8>) -> bool {
+        prf_agrees(b.as_slice()) && prf_agrees(Cow::Borrowed(b.as_slice())) && prf_agrees(b)
+    }
+
+    #[quickcheck]
+    fn unsigned_integers_derive_the_same_prf_context(
+        a: u8,
+        b: u16,
+        c: u32,
+        d: u64,
+        e: u128,
+    ) -> bool {
+        prf_agrees(a) && prf_agrees(b) && prf_agrees(c) && prf_agrees(d) && prf_agrees(e)
+    }
+
+    #[quickcheck]
+    fn signed_integers_derive_the_same_prf_context(a: i8, b: i16, c: i32, d: i64, e: i128) -> bool {
+        prf_agrees(a) && prf_agrees(b) && prf_agrees(c) && prf_agrees(d) && prf_agrees(e)
+    }
+
+    #[quickcheck]
+    fn composites_derive_the_same_prf_context(
+        s: String,
+        n: u64,
+        o: Option<String>,
+        b: Vec<u8>,
+    ) -> bool {
+        // Pairs, options, nesting in both directions, and the proven
+        // wrapper — the shapes a runtime list has to be able to spell.
+        prf_agrees((s.as_str(), n))
+            && prf_agrees(o.clone())
+            && prf_agrees(((s.as_str(), n), b.as_slice()))
+            && prf_agrees((s.as_str(), (n, b.as_slice())))
+            && prf_agrees(Some((o.clone(), n)))
+            && prf_agrees(Some(Some(n)))
+            && prf_agrees(Option::<(String, u64)>::None)
+            && (s.is_empty() || {
+                let proven = NonEmpty::new(s.as_str()).unwrap();
+                prf_agrees(proven)
+                    && prf_agrees(proven.with(n))
+                    && prf_agrees(proven.with(n).with(o))
+            })
+    }
+
+    #[test]
+    fn the_law_says_what_a_runtime_list_spells() {
+        // What the module docs promise, pinned by value: a list of one is
+        // `Some`, the empty list is `None`, a list of two is the pair, and
+        // `with` chains nest to the left.
+        let some = AadPiece::List(vec![AadPiece::U64(7)]);
+        assert_eq!(some.clone().into_aad_piece(), Some(7u64).into_aad_piece());
+        assert_eq!(some.into_prf_context(), Some(7u64).into_prf_context());
+
+        let none = AadPiece::List(vec![]);
+        assert_eq!(
+            none.into_prf_context(),
+            Option::<u64>::None.into_prf_context()
+        );
+
+        let pair = AadPiece::List(vec![
+            AadPiece::Text(Cow::Borrowed("users/age")),
+            AadPiece::U64(7),
+        ]);
+        assert_eq!(
+            pair.clone().into_prf_context(),
+            ("users/age", 7u64).into_prf_context()
+        );
+        assert_eq!(
+            pair.into_prf_context(),
+            NonEmpty::new("users/age")
+                .unwrap()
+                .with(7u64)
+                .into_prf_context()
+        );
+
+        let chained = AadPiece::List(vec![
+            AadPiece::List(vec![
+                AadPiece::Text(Cow::Borrowed("users/age")),
+                AadPiece::U64(7),
+            ]),
+            AadPiece::Text(Cow::Borrowed("eu")),
+        ]);
+        assert_eq!(
+            chained.into_prf_context(),
+            NonEmpty::new("users/age")
+                .unwrap()
+                .with(7u64)
+                .with("eu")
+                .into_prf_context()
+        );
+        let flat = AadPiece::List(vec![
+            AadPiece::Text(Cow::Borrowed("users/age")),
+            AadPiece::U64(7),
+            AadPiece::Text(Cow::Borrowed("eu")),
+        ]);
+        assert_ne!(
+            flat.into_prf_context(),
+            NonEmpty::new("users/age")
+                .unwrap()
+                .with(7u64)
+                .with("eu")
+                .into_prf_context(),
+            "a flat n-ary list is its own context, not a chain"
+        );
+    }
+
+    #[test]
+    fn unit_is_the_documented_exception() {
+        // `()` is the empty PRF context by definition, and its parts view
+        // is an empty `Bytes` leaf, which encodes as typed empty bytes. The
+        // AAD half of the law still holds; the PRF half does not, and no
+        // context built from parts can reach `()`, which is empty anyway.
+        assert!(agrees(()));
+        assert!(!prf_agrees(()));
+        assert!(().into_aad_piece().is_empty());
+    }
+
+    #[quickcheck]
+    fn a_tree_is_empty_by_the_static_rule(tree: Tree) -> bool {
+        fn rule(piece: &AadPiece<'_>) -> bool {
+            match piece {
+                AadPiece::Text(t) => t.is_empty(),
+                AadPiece::Bytes(b) => b.is_empty(),
+                AadPiece::List(parts) => parts.iter().all(rule),
+                _ => false,
+            }
+        }
+        tree.0.is_empty() == rule(&tree.0)
+    }
+
+    #[quickcheck]
+    fn emptiness_agrees_with_the_static_types(s: String, n: u64, o: Option<String>) -> bool {
+        s.is_empty() == s.as_str().into_aad_piece().is_empty()
+            && !n.into_aad_piece().is_empty()
+            && o.is_empty() == o.clone().into_aad_piece().is_empty()
+            && (s.as_str(), n).is_empty() == (s.as_str(), n).into_aad_piece().is_empty()
+            && (o.clone(), s.as_str()).is_empty() == (o, s.as_str()).into_aad_piece().is_empty()
+    }
+
+    #[test]
+    fn emptiness_fixed_shapes() {
+        assert!(AadPiece::List(vec![]).is_empty());
+        assert!(AadPiece::List(vec![AadPiece::Text(Cow::Borrowed(""))]).is_empty());
+        assert!(
+            !AadPiece::List(vec![AadPiece::Text(Cow::Borrowed("")), AadPiece::U64(0)]).is_empty()
+        );
+        assert!(
+            !AadPiece::List(vec![AadPiece::List(vec![AadPiece::Bytes(Cow::Borrowed(
+                b"x"
+            ))])])
+            .is_empty()
+        );
+        assert!(NonEmpty::new(AadPiece::List(vec![AadPiece::U8(0)])).is_ok());
+        assert!(NonEmpty::new(AadPiece::Text(Cow::Borrowed(""))).is_err());
+    }
+
+    #[quickcheck]
+    fn a_list_derives_the_pae_of_its_parts(tree: Tree) -> bool {
+        // The PRF side of `list_encodes_as_pae_of_its_parts`: a list's
+        // context is `PrfContext::pae` of each part's context, at every
+        // level, which is exactly the pair impl's framing.
+        fn expected(piece: &AadPiece<'_>) -> PrfContext<'static> {
+            match piece {
+                AadPiece::List(parts) => {
+                    let parts: Vec<PrfContext<'static>> = parts.iter().map(expected).collect();
+                    let pieces: Vec<&[u8]> = parts.iter().map(PrfContext::as_bytes).collect();
+                    PrfContext::pae(&pieces)
+                }
+                leaf => leaf.clone().into_prf_context().into_owned(),
+            }
+        }
+        tree.0.clone().into_prf_context() == expected(&tree.0)
     }
 
     #[quickcheck]

--- a/packages/aead/src/aad/piece.rs
+++ b/packages/aead/src/aad/piece.rs
@@ -538,7 +538,7 @@ mod tests {
         use super::*;
 
         #[test]
-        fn one_part_spells_some_and_no_parts_spells_none() {
+        fn one_part_spells_some() {
             let some = AadPiece::List(vec![AadPiece::U64(7)]);
             assert_eq!(
                 some.clone().into_aad_piece(),
@@ -550,7 +550,10 @@ mod tests {
                 Some(7u64).into_prf_context(),
                 "a list of one is `Some` as a PRF context"
             );
+        }
 
+        #[test]
+        fn no_parts_spells_none() {
             let none = AadPiece::List(vec![]);
             assert_eq!(
                 none.into_prf_context(),
@@ -560,13 +563,18 @@ mod tests {
         }
 
         #[test]
-        fn two_parts_spell_the_pair_and_the_proven_chain() {
+        fn two_parts_spell_the_pair() {
             let pair = AadPiece::List(vec![text("users/age"), AadPiece::U64(7)]);
             assert_eq!(
-                pair.clone().into_prf_context(),
+                pair.into_prf_context(),
                 ("users/age", 7u64).into_prf_context(),
                 "a list of two is the pair"
             );
+        }
+
+        #[test]
+        fn two_parts_spell_the_proven_chain() {
+            let pair = AadPiece::List(vec![text("users/age"), AadPiece::U64(7)]);
             assert_eq!(
                 pair.into_prf_context(),
                 NonEmpty::new("users/age")
@@ -613,14 +621,22 @@ mod tests {
         use super::*;
 
         #[test]
-        fn the_aad_half_holds_and_the_prf_half_is_the_documented_exception() {
+        fn the_aad_half_of_the_law_holds() {
+            assert!(agrees(()), "`()` is zero AAD bytes on both sides");
+        }
+
+        #[test]
+        fn the_prf_half_is_the_documented_exception() {
             // `()` is the empty PRF context by definition, and its parts view
             // is an empty `Bytes` leaf, which encodes as typed empty bytes.
-            assert!(agrees(()), "`()` is zero AAD bytes on both sides");
             assert!(
                 !prf_agrees(()),
                 "`()` derives no PRF bytes statically and typed empty bytes from its parts"
             );
+        }
+
+        #[test]
+        fn never_reaches_non_empty_on_its_own() {
             assert!(
                 ().into_aad_piece().is_empty(),
                 "bare `()` is empty, so it never reaches `NonEmpty`"
@@ -628,16 +644,20 @@ mod tests {
         }
 
         #[test]
-        fn a_pair_containing_unit_is_non_empty_and_diverges_on_the_prf_side() {
+        fn a_pair_containing_it_is_non_empty() {
+            assert!(
+                NonEmpty::new(("x", ())).is_ok(),
+                "a pair with one non-empty part is non-empty"
+            );
+        }
+
+        #[test]
+        fn a_pair_containing_it_diverges_on_the_prf_side() {
             // The exception reaches `NonEmpty` through a composite: the pair
             // rule makes `("x", ())` non-empty, and the divergence in `()`
             // carries through. Pinned so the exception's reach is visible;
             // removed for good by the shared encoding in #339.
             let pair = ("x", ());
-            assert!(
-                NonEmpty::new(pair).is_ok(),
-                "a pair with one non-empty part is non-empty"
-            );
             assert!(agrees(pair), "the AAD half still holds through a pair");
             assert!(
                 !prf_agrees(pair),

--- a/packages/aead/src/aad/piece.rs
+++ b/packages/aead/src/aad/piece.rs
@@ -57,9 +57,25 @@ use super::{Aad, IntoAad};
 /// context type upholds is that each derivation of the value equals the
 /// same derivation of its parts view:
 ///
-/// ```text
-/// x.into_aad()         == x.into_aad_piece().into_aad()
-/// x.into_prf_context() == x.into_aad_piece().into_prf_context()
+/// ```rust
+/// use std::borrow::Cow;
+/// use vitaminc_aead::{AadPiece, IntoAad};
+/// use vitaminc_prf::IntoPrfContext;
+///
+/// let x = ("users/email", 7u64);
+/// assert_eq!(
+///     x.into_aad_piece().into_aad().as_bytes(),
+///     x.into_aad().as_bytes()
+/// );
+/// assert_eq!(x.into_aad_piece().into_prf_context(), x.into_prf_context());
+///
+/// // So a list assembled at runtime *is* the static value with those parts.
+/// let runtime = AadPiece::List(vec![
+///     AadPiece::Text(Cow::Borrowed("users/email")),
+///     AadPiece::U64(7),
+/// ]);
+/// assert_eq!(runtime.clone().into_aad().as_bytes(), x.into_aad().as_bytes());
+/// assert_eq!(runtime.into_prf_context(), x.into_prf_context());
 /// ```
 ///
 /// So a context assembled at runtime from parts — one that arrived as data
@@ -68,12 +84,18 @@ use super::{Aad, IntoAad};
 /// `Some(x)` is the one-element list, `None` the empty list, `(a, b)` the
 /// two-element list, and `nonempty!(a).with(b).with(c)` the left-nested
 /// `((a, b), c)`. A flat list of three or more parts is a context too,
-/// reachable from Rust through [`AadPiece::List`] directly. The one
-/// exception is `()`: its PRF context is the *empty* context by definition
-/// (no encoding at all), while its parts view is an empty `Bytes` leaf,
-/// which the PRF side encodes as typed empty bytes. `()` is never a
-/// context a caller proves non-empty, so nothing built from parts meets
-/// it. The law is pinned by quickcheck over every built-in context type.
+/// reachable from Rust through [`AadPiece::List`] directly. The law is
+/// pinned by quickcheck over every built-in context type.
+///
+/// The one exception is `()`, and any composite that contains it. `()` is
+/// the *empty* PRF context by definition (no encoding at all), while its
+/// parts view is an empty `Bytes` leaf, which the PRF side encodes as typed
+/// empty bytes. Bare `()` is empty and so never reaches `NonEmpty`, but
+/// `("x", ())` is non-empty by the pair rule and derives different PRF
+/// bytes from its parts view than from the static value. Do not put `()`
+/// inside a context a runtime consumer must reproduce. The divergence is
+/// pinned, and removed for good by the shared context encoding in
+/// [#339](https://github.com/cipherstash/vitaminc/issues/339).
 ///
 /// [`MaybeEmpty`] completes the set, so a parts tree can be proven
 /// [`NonEmpty`](vitaminc_protected::NonEmpty) by the same rule the static
@@ -383,7 +405,7 @@ mod tests {
 
     use super::*;
 
-    /// The contract: the tree encodes to the value's own bytes.
+    /// One half of the law: the tree encodes to the value's own AAD bytes.
     fn agrees<'a, T>(value: T) -> bool
     where
         T: IntoAad<'a> + Clone,
@@ -391,9 +413,7 @@ mod tests {
         value.clone().into_aad_piece().into_aad().as_bytes() == value.into_aad().as_bytes()
     }
 
-    /// The other half of the law: the tree derives the value's own PRF
-    /// context. Together with [`agrees`], the parts view is the identity
-    /// of the context on both derivations.
+    /// The other half: the tree derives the value's own PRF context.
     fn prf_agrees<'a, T>(value: T) -> bool
     where
         T: IntoAad<'a> + IntoPrfContext<'a> + Clone,
@@ -401,224 +421,297 @@ mod tests {
         value.clone().into_aad_piece().into_prf_context() == value.into_prf_context()
     }
 
-    #[quickcheck]
-    fn text_derives_the_same_prf_context(s: String) -> bool {
-        prf_agrees(s.as_str()) && prf_agrees(s)
+    /// Both halves together: the parts view is the identity of the context
+    /// on both derivations.
+    fn is_identity<'a, T>(value: T) -> bool
+    where
+        T: IntoAad<'a> + IntoPrfContext<'a> + Clone,
+    {
+        agrees(value.clone()) && prf_agrees(value)
     }
 
-    #[quickcheck]
-    fn bytes_derive_the_same_prf_context(b: Vec<u8>) -> bool {
-        prf_agrees(b.as_slice()) && prf_agrees(Cow::Borrowed(b.as_slice())) && prf_agrees(b)
+    fn text(s: &'static str) -> AadPiece<'static> {
+        AadPiece::Text(Cow::Borrowed(s))
     }
 
-    #[quickcheck]
-    fn unsigned_integers_derive_the_same_prf_context(
-        a: u8,
-        b: u16,
-        c: u32,
-        d: u64,
-        e: u128,
-    ) -> bool {
-        prf_agrees(a) && prf_agrees(b) && prf_agrees(c) && prf_agrees(d) && prf_agrees(e)
-    }
+    /// The parts-view law, per built-in context type: each derivation of
+    /// the value equals the same derivation of `into_aad_piece()`.
+    mod given_a_text_context {
+        use super::*;
 
-    #[quickcheck]
-    fn signed_integers_derive_the_same_prf_context(a: i8, b: i16, c: i32, d: i64, e: i128) -> bool {
-        prf_agrees(a) && prf_agrees(b) && prf_agrees(c) && prf_agrees(d) && prf_agrees(e)
-    }
-
-    #[quickcheck]
-    fn composites_derive_the_same_prf_context(
-        s: String,
-        n: u64,
-        o: Option<String>,
-        b: Vec<u8>,
-    ) -> bool {
-        // Pairs, options, nesting in both directions, and the proven
-        // wrapper — the shapes a runtime list has to be able to spell.
-        prf_agrees((s.as_str(), n))
-            && prf_agrees(o.clone())
-            && prf_agrees(((s.as_str(), n), b.as_slice()))
-            && prf_agrees((s.as_str(), (n, b.as_slice())))
-            && prf_agrees(Some((o.clone(), n)))
-            && prf_agrees(Some(Some(n)))
-            && prf_agrees(Option::<(String, u64)>::None)
-            && (s.is_empty() || {
-                let proven = NonEmpty::new(s.as_str()).unwrap();
-                prf_agrees(proven)
-                    && prf_agrees(proven.with(n))
-                    && prf_agrees(proven.with(n).with(o))
-            })
-    }
-
-    #[test]
-    fn the_law_says_what_a_runtime_list_spells() {
-        // What the module docs promise, pinned by value: a list of one is
-        // `Some`, the empty list is `None`, a list of two is the pair, and
-        // `with` chains nest to the left.
-        let some = AadPiece::List(vec![AadPiece::U64(7)]);
-        assert_eq!(some.clone().into_aad_piece(), Some(7u64).into_aad_piece());
-        assert_eq!(some.into_prf_context(), Some(7u64).into_prf_context());
-
-        let none = AadPiece::List(vec![]);
-        assert_eq!(
-            none.into_prf_context(),
-            Option::<u64>::None.into_prf_context()
-        );
-
-        let pair = AadPiece::List(vec![
-            AadPiece::Text(Cow::Borrowed("users/age")),
-            AadPiece::U64(7),
-        ]);
-        assert_eq!(
-            pair.clone().into_prf_context(),
-            ("users/age", 7u64).into_prf_context()
-        );
-        assert_eq!(
-            pair.into_prf_context(),
-            NonEmpty::new("users/age")
-                .unwrap()
-                .with(7u64)
-                .into_prf_context()
-        );
-
-        let chained = AadPiece::List(vec![
-            AadPiece::List(vec![
-                AadPiece::Text(Cow::Borrowed("users/age")),
-                AadPiece::U64(7),
-            ]),
-            AadPiece::Text(Cow::Borrowed("eu")),
-        ]);
-        assert_eq!(
-            chained.into_prf_context(),
-            NonEmpty::new("users/age")
-                .unwrap()
-                .with(7u64)
-                .with("eu")
-                .into_prf_context()
-        );
-        let flat = AadPiece::List(vec![
-            AadPiece::Text(Cow::Borrowed("users/age")),
-            AadPiece::U64(7),
-            AadPiece::Text(Cow::Borrowed("eu")),
-        ]);
-        assert_ne!(
-            flat.into_prf_context(),
-            NonEmpty::new("users/age")
-                .unwrap()
-                .with(7u64)
-                .with("eu")
-                .into_prf_context(),
-            "a flat n-ary list is its own context, not a chain"
-        );
-    }
-
-    #[test]
-    fn unit_is_the_documented_exception() {
-        // `()` is the empty PRF context by definition, and its parts view
-        // is an empty `Bytes` leaf, which encodes as typed empty bytes. The
-        // AAD half of the law still holds; the PRF half does not, and no
-        // context built from parts can reach `()`, which is empty anyway.
-        assert!(agrees(()));
-        assert!(!prf_agrees(()));
-        assert!(().into_aad_piece().is_empty());
-    }
-
-    #[quickcheck]
-    fn a_tree_is_empty_by_the_static_rule(tree: Tree) -> bool {
-        fn rule(piece: &AadPiece<'_>) -> bool {
-            match piece {
-                AadPiece::Text(t) => t.is_empty(),
-                AadPiece::Bytes(b) => b.is_empty(),
-                AadPiece::List(parts) => parts.iter().all(rule),
-                _ => false,
-            }
+        #[quickcheck]
+        fn both_derivations_agree(s: String) -> bool {
+            is_identity(s.as_str()) && is_identity(s)
         }
-        tree.0.is_empty() == rule(&tree.0)
     }
 
-    #[quickcheck]
-    fn emptiness_agrees_with_the_static_types(s: String, n: u64, o: Option<String>) -> bool {
-        s.is_empty() == s.as_str().into_aad_piece().is_empty()
-            && !n.into_aad_piece().is_empty()
-            && o.is_empty() == o.clone().into_aad_piece().is_empty()
-            && (s.as_str(), n).is_empty() == (s.as_str(), n).into_aad_piece().is_empty()
-            && (o.clone(), s.as_str()).is_empty() == (o, s.as_str()).into_aad_piece().is_empty()
+    mod given_a_bytes_context {
+        use super::*;
+
+        #[quickcheck]
+        fn both_derivations_agree(b: Vec<u8>) -> bool {
+            is_identity(b.as_slice()) && is_identity(Cow::Borrowed(b.as_slice())) && is_identity(b)
+        }
+
+        #[test]
+        fn fixed_arrays_agree_on_both_derivations() {
+            assert!(
+                is_identity([1u8, 2, 3]),
+                "an owned array is its parts view on both derivations"
+            );
+            assert!(
+                is_identity(&[4u8, 5, 6]),
+                "a borrowed array is its parts view on both derivations"
+            );
+        }
+
+        #[test]
+        fn a_raw_aad_agrees_on_the_aad_derivation() {
+            // `Aad` is not a PRF context, so only the AAD half applies.
+            assert!(
+                agrees(Aad::from_slice(b"raw")),
+                "a raw `Aad` is one opaque `Bytes` leaf"
+            );
+        }
     }
 
-    #[test]
-    fn emptiness_fixed_shapes() {
-        assert!(AadPiece::List(vec![]).is_empty());
-        assert!(AadPiece::List(vec![AadPiece::Text(Cow::Borrowed(""))]).is_empty());
-        assert!(
-            !AadPiece::List(vec![AadPiece::Text(Cow::Borrowed("")), AadPiece::U64(0)]).is_empty()
-        );
-        assert!(
-            !AadPiece::List(vec![AadPiece::List(vec![AadPiece::Bytes(Cow::Borrowed(
-                b"x"
-            ))])])
-            .is_empty()
-        );
-        assert!(NonEmpty::new(AadPiece::List(vec![AadPiece::U8(0)])).is_ok());
-        assert!(NonEmpty::new(AadPiece::Text(Cow::Borrowed(""))).is_err());
+    mod given_an_integer_context {
+        use super::*;
+
+        #[quickcheck]
+        fn unsigned_widths_agree_on_both_derivations(
+            a: u8,
+            b: u16,
+            c: u32,
+            d: u64,
+            e: u128,
+        ) -> bool {
+            is_identity(a) && is_identity(b) && is_identity(c) && is_identity(d) && is_identity(e)
+        }
+
+        #[quickcheck]
+        fn signed_widths_agree_on_both_derivations(a: i8, b: i16, c: i32, d: i64, e: i128) -> bool {
+            is_identity(a) && is_identity(b) && is_identity(c) && is_identity(d) && is_identity(e)
+        }
     }
 
-    #[quickcheck]
-    fn a_list_derives_the_pae_of_its_parts(tree: Tree) -> bool {
-        // The PRF side of `list_encodes_as_pae_of_its_parts`: a list's
-        // context is `PrfContext::pae` of each part's context, at every
-        // level, which is exactly the pair impl's framing.
-        fn expected(piece: &AadPiece<'_>) -> PrfContext<'static> {
-            match piece {
-                AadPiece::List(parts) => {
-                    let parts: Vec<PrfContext<'static>> = parts.iter().map(expected).collect();
-                    let pieces: Vec<&[u8]> = parts.iter().map(PrfContext::as_bytes).collect();
-                    PrfContext::pae(&pieces)
+    mod given_a_composite_context {
+        use super::*;
+
+        #[quickcheck]
+        fn both_derivations_agree(s: String, n: u64, o: Option<String>, b: Vec<u8>) -> bool {
+            // Pairs, options, nesting in both directions, and the proven
+            // wrapper — the shapes a runtime list has to be able to spell.
+            is_identity((s.as_str(), n))
+                && is_identity(o.clone())
+                && is_identity(((s.as_str(), n), b.as_slice()))
+                && is_identity((s.as_str(), (n, b.as_slice())))
+                && is_identity(Some((o.clone(), n)))
+                && is_identity(Some(Some(n)))
+                && is_identity(Option::<(String, u64)>::None)
+                && (s.is_empty() || {
+                    let proven = NonEmpty::new(s.as_str()).unwrap();
+                    is_identity(proven)
+                        && is_identity(proven.with(n))
+                        && is_identity(proven.with(n).with(o))
+                })
+        }
+
+        #[test]
+        fn fixed_shapes_agree_on_both_derivations() {
+            assert!(
+                is_identity(Option::<&str>::None),
+                "`None` is the empty list on both derivations"
+            );
+            assert!(
+                is_identity(NonEmpty::new("users/email").unwrap()),
+                "a proven leaf is transparent on both derivations"
+            );
+            assert!(
+                is_identity(NonEmpty::new(("users/email", 7u64)).unwrap()),
+                "a proven pair is transparent on both derivations"
+            );
+        }
+    }
+
+    mod given_a_runtime_list {
+        use super::*;
+
+        #[test]
+        fn one_part_spells_some_and_no_parts_spells_none() {
+            let some = AadPiece::List(vec![AadPiece::U64(7)]);
+            assert_eq!(
+                some.clone().into_aad_piece(),
+                Some(7u64).into_aad_piece(),
+                "a list of one is `Some` as a tree"
+            );
+            assert_eq!(
+                some.into_prf_context(),
+                Some(7u64).into_prf_context(),
+                "a list of one is `Some` as a PRF context"
+            );
+
+            let none = AadPiece::List(vec![]);
+            assert_eq!(
+                none.into_prf_context(),
+                Option::<u64>::None.into_prf_context(),
+                "the empty list is `None` as a PRF context"
+            );
+        }
+
+        #[test]
+        fn two_parts_spell_the_pair_and_the_proven_chain() {
+            let pair = AadPiece::List(vec![text("users/age"), AadPiece::U64(7)]);
+            assert_eq!(
+                pair.clone().into_prf_context(),
+                ("users/age", 7u64).into_prf_context(),
+                "a list of two is the pair"
+            );
+            assert_eq!(
+                pair.into_prf_context(),
+                NonEmpty::new("users/age")
+                    .unwrap()
+                    .with(7u64)
+                    .into_prf_context(),
+                "a list of two is `nonempty!(a).with(b)`"
+            );
+        }
+
+        #[test]
+        fn a_nested_list_spells_the_left_nested_chain() {
+            let chained = AadPiece::List(vec![
+                AadPiece::List(vec![text("users/age"), AadPiece::U64(7)]),
+                text("eu"),
+            ]);
+            assert_eq!(
+                chained.into_prf_context(),
+                NonEmpty::new("users/age")
+                    .unwrap()
+                    .with(7u64)
+                    .with("eu")
+                    .into_prf_context(),
+                "`with` chains nest to the left"
+            );
+        }
+
+        #[test]
+        fn a_flat_list_is_its_own_context_not_a_chain() {
+            let flat = AadPiece::List(vec![text("users/age"), AadPiece::U64(7), text("eu")]);
+            assert_ne!(
+                flat.into_prf_context(),
+                NonEmpty::new("users/age")
+                    .unwrap()
+                    .with(7u64)
+                    .with("eu")
+                    .into_prf_context(),
+                "a flat n-ary list is its own context, not a chain"
+            );
+        }
+    }
+
+    mod given_the_unit_context {
+        use super::*;
+
+        #[test]
+        fn the_aad_half_holds_and_the_prf_half_is_the_documented_exception() {
+            // `()` is the empty PRF context by definition, and its parts view
+            // is an empty `Bytes` leaf, which encodes as typed empty bytes.
+            assert!(agrees(()), "`()` is zero AAD bytes on both sides");
+            assert!(
+                !prf_agrees(()),
+                "`()` derives no PRF bytes statically and typed empty bytes from its parts"
+            );
+            assert!(
+                ().into_aad_piece().is_empty(),
+                "bare `()` is empty, so it never reaches `NonEmpty`"
+            );
+        }
+
+        #[test]
+        fn a_pair_containing_unit_is_non_empty_and_diverges_on_the_prf_side() {
+            // The exception reaches `NonEmpty` through a composite: the pair
+            // rule makes `("x", ())` non-empty, and the divergence in `()`
+            // carries through. Pinned so the exception's reach is visible;
+            // removed for good by the shared encoding in #339.
+            let pair = ("x", ());
+            assert!(
+                NonEmpty::new(pair).is_ok(),
+                "a pair with one non-empty part is non-empty"
+            );
+            assert!(agrees(pair), "the AAD half still holds through a pair");
+            assert!(
+                !prf_agrees(pair),
+                "the PRF half does not, because `()` inside a pair encodes as typed empty bytes"
+            );
+        }
+    }
+
+    mod given_a_tree {
+        use super::*;
+
+        #[quickcheck]
+        fn a_list_derives_the_pae_of_its_parts(tree: Tree) -> bool {
+            // The PRF side of `list_encodes_as_pae_of_its_parts`: a list's
+            // context is `LE64(count) || (LE64(len) || part)*` over each
+            // part's context, at every level. The oracle frames by hand so
+            // it does not share `PrfContext::pae` with the impl under test.
+            fn expected(piece: &AadPiece<'_>) -> Vec<u8> {
+                match piece {
+                    AadPiece::List(parts) => {
+                        let parts: Vec<Vec<u8>> = parts.iter().map(expected).collect();
+                        let mut out = (parts.len() as u64).to_le_bytes().to_vec();
+                        for part in parts {
+                            out.extend_from_slice(&(part.len() as u64).to_le_bytes());
+                            out.extend_from_slice(&part);
+                        }
+                        out
+                    }
+                    leaf => leaf.clone().into_prf_context().as_bytes().to_vec(),
                 }
-                leaf => leaf.clone().into_prf_context().into_owned(),
             }
+            tree.0.clone().into_prf_context().as_bytes() == expected(&tree.0).as_slice()
         }
-        tree.0.clone().into_prf_context() == expected(&tree.0)
     }
 
-    #[quickcheck]
-    fn text_agrees(s: String) -> bool {
-        agrees(s.as_str()) && agrees(s)
-    }
+    mod given_emptiness {
+        use super::*;
 
-    #[quickcheck]
-    fn bytes_agree(b: Vec<u8>) -> bool {
-        agrees(b.as_slice()) && agrees(Cow::Borrowed(b.as_slice())) && agrees(b)
-    }
+        #[quickcheck]
+        fn agrees_with_the_static_types(s: String, n: u64, o: Option<String>) -> bool {
+            s.is_empty() == s.as_str().into_aad_piece().is_empty()
+                && !n.into_aad_piece().is_empty()
+                && o.is_empty() == o.clone().into_aad_piece().is_empty()
+                && (s.as_str(), n).is_empty() == (s.as_str(), n).into_aad_piece().is_empty()
+                && (o.clone(), s.as_str()).is_empty() == (o, s.as_str()).into_aad_piece().is_empty()
+        }
 
-    #[quickcheck]
-    fn unsigned_integers_agree(a: u8, b: u16, c: u32, d: u64, e: u128) -> bool {
-        agrees(a) && agrees(b) && agrees(c) && agrees(d) && agrees(e)
-    }
-
-    #[quickcheck]
-    fn signed_integers_agree(a: i8, b: i16, c: i32, d: i64, e: i128) -> bool {
-        agrees(a) && agrees(b) && agrees(c) && agrees(d) && agrees(e)
-    }
-
-    #[quickcheck]
-    fn composites_agree(s: String, n: u64, o: Option<String>, b: Vec<u8>) -> bool {
-        agrees((s.as_str(), n))
-            && agrees(o.clone())
-            && agrees(((s.as_str(), n), b.as_slice()))
-            && agrees(Some((o, n)))
-            && agrees((s, ()))
-    }
-
-    #[test]
-    fn fixed_shapes_agree() {
-        assert!(agrees(()));
-        assert!(agrees([1u8, 2, 3]));
-        assert!(agrees(&[4u8, 5, 6]));
-        assert!(agrees(Aad::from_slice(b"raw")));
-        assert!(agrees(Option::<&str>::None));
-        assert!(agrees(NonEmpty::new("users/email").unwrap()));
-        assert!(agrees(NonEmpty::new(("users/email", 7u64)).unwrap()));
+        #[test]
+        fn fixed_shapes_follow_the_static_rule() {
+            assert!(AadPiece::List(vec![]).is_empty(), "the empty list is empty");
+            assert!(
+                AadPiece::List(vec![text("")]).is_empty(),
+                "a list of empty parts is empty"
+            );
+            assert!(
+                !AadPiece::List(vec![text(""), AadPiece::U64(0)]).is_empty(),
+                "an integer part makes a list non-empty, even zero"
+            );
+            assert!(
+                !AadPiece::List(vec![AadPiece::List(vec![AadPiece::Bytes(Cow::Borrowed(
+                    b"x"
+                ))])])
+                .is_empty(),
+                "emptiness looks through nested lists"
+            );
+            assert!(
+                NonEmpty::new(AadPiece::List(vec![AadPiece::U8(0)])).is_ok(),
+                "a tree with an integer is provable non-empty"
+            );
+            assert!(
+                NonEmpty::new(text("")).is_err(),
+                "an empty text leaf is not provable non-empty"
+            );
+        }
     }
 
     #[test]

--- a/packages/prf/src/context.rs
+++ b/packages/prf/src/context.rs
@@ -183,15 +183,24 @@ integer_context!(
     i128 => PrfEncoding::I128,
 );
 
+/// An `Option` context follows its parts view: `Some(x)` is the one-element
+/// list `PAE([x])` and `None` the empty list `PAE([])`, exactly as
+/// `IntoAad` encodes them. A context built at runtime from parts (an
+/// `AadPiece` list of one) is therefore the same PRF context as the static
+/// `Some(x)`, on this side as on the AEAD side.
+///
+/// This is deliberately *not* the `PrfValue` `Option` encoding, which tags
+/// `Some` with a domain of its own: that tag keeps an optional *value*'s
+/// derivation apart from its inner value's, and a value is never compared
+/// with a context. Sharing the tag here bought nothing and cost the parts
+/// identity.
 impl<'a, T> IntoPrfContext<'a> for Option<T>
 where
     T: IntoPrfContext<'a>,
 {
     fn into_prf_context(self) -> PrfContext<'a> {
         match self {
-            // Tagged with the same domain as the `PrfValue` Option path so the
-            // crate has exactly one `Some` encoding.
-            Some(value) => value.into_prf_context().for_option_some(),
+            Some(value) => PrfContext::pae(&[value.into_prf_context().as_bytes()]),
             None => PrfContext::pae(&[]),
         }
     }
@@ -291,23 +300,26 @@ mod tests {
         );
     }
 
+    #[quickcheck]
+    fn option_context_is_the_one_element_list(bytes: Vec<u8>) -> bool {
+        // `Some(x)` is the single-piece PAE of `x`'s encoding — the same
+        // shape `IntoAad` gives it, so a runtime list of one part is the
+        // static `Some`. It is framed, so it is not `x` itself.
+        let inner = bytes.clone().into_prf_context();
+        let some = Some(bytes).into_prf_context();
+        some == PrfContext::pae(&[inner.as_bytes()]) && some != inner
+    }
+
     #[test]
-    fn option_context_shares_the_value_path_some_domain() {
-        // Both Option paths must tag `Some` through `for_option_some`. If this
-        // fails, the crate has grown a second, divergent Option encoding.
-        assert_eq!(
+    fn option_context_does_not_share_the_value_path_some_domain() {
+        // The `PrfValue` Option path tags `Some` with its own domain; a
+        // context does not. If this fails, the context encoding has grown a
+        // tag again and runtime parts can no longer spell `Some`.
+        assert_ne!(
             Some("value").into_prf_context(),
             "value".into_prf_context().for_option_some()
         );
-    }
-
-    #[quickcheck]
-    fn option_context_some_cannot_collide_with_a_bare_pae(bytes: Vec<u8>) -> bool {
-        // Guards the invariant that no other construction produces the
-        // `Some` framing: a plain single-piece PAE of the inner encoding
-        // must never equal the Option encoding.
-        let inner = bytes.clone().into_prf_context();
-        Some(bytes).into_prf_context() != PrfContext::pae(&[inner.as_bytes()])
+        assert_eq!(None::<&str>.into_prf_context(), PrfContext::pae(&[]));
     }
 
     #[test]
@@ -374,10 +386,7 @@ mod tests {
 
         let some = Some("value").into_prf_context();
         let typed_value = PrfContext::typed(PrfEncoding::UTF8, b"value");
-        assert_eq!(
-            some,
-            PrfContext::pae(&[OPTION_SOME_DOMAIN, typed_value.as_bytes()])
-        );
+        assert_eq!(some, PrfContext::pae(&[typed_value.as_bytes()]));
         assert_eq!(None::<&str>.into_prf_context(), PrfContext::pae(&[]));
 
         let left = PrfContext::typed(PrfEncoding::UTF8, b"left");

--- a/packages/prf/src/context.rs
+++ b/packages/prf/src/context.rs
@@ -57,8 +57,8 @@ impl<'a> PrfContext<'a> {
     ///
     /// The leading domain tag keeps caller-refined contexts disjoint from the
     /// contexts this crate assigns automatically. Without it, a context built
-    /// as `PrfContext::from_slice(OPTION_SOME_DOMAIN).refine(x)` would encode
-    /// identically to the one derived for `Some(x)`.
+    /// as `PrfContext::from_slice(MAP_ENTRY_DOMAIN).refine(key)` would encode
+    /// identically to the one `for_map_entry` derives for `key`.
     pub fn refine<'b, C>(&self, component: C) -> PrfContext<'static>
     where
         C: IntoPrfContext<'b>,
@@ -300,26 +300,39 @@ mod tests {
         );
     }
 
-    #[quickcheck]
-    fn option_context_is_the_one_element_list(bytes: Vec<u8>) -> bool {
-        // `Some(x)` is the single-piece PAE of `x`'s encoding — the same
-        // shape `IntoAad` gives it, so a runtime list of one part is the
-        // static `Some`. It is framed, so it is not `x` itself.
-        let inner = bytes.clone().into_prf_context();
-        let some = Some(bytes).into_prf_context();
-        some == PrfContext::pae(&[inner.as_bytes()]) && some != inner
-    }
+    mod given_an_option_context {
+        use super::*;
 
-    #[test]
-    fn option_context_does_not_share_the_value_path_some_domain() {
-        // The `PrfValue` Option path tags `Some` with its own domain; a
-        // context does not. If this fails, the context encoding has grown a
-        // tag again and runtime parts can no longer spell `Some`.
-        assert_ne!(
-            Some("value").into_prf_context(),
-            "value".into_prf_context().for_option_some()
-        );
-        assert_eq!(None::<&str>.into_prf_context(), PrfContext::pae(&[]));
+        #[quickcheck]
+        fn some_is_the_one_element_list(bytes: Vec<u8>) -> bool {
+            // `Some(x)` is the single-piece PAE of `x`'s encoding — the same
+            // shape `IntoAad` gives it, so a runtime list of one part is the
+            // static `Some`. It is framed, so it is not `x` itself.
+            let inner = bytes.clone().into_prf_context();
+            let some = Some(bytes).into_prf_context();
+            some == PrfContext::pae(&[inner.as_bytes()]) && some != inner
+        }
+
+        #[test]
+        fn some_does_not_carry_the_value_path_domain() {
+            // The `PrfValue` Option path tags `Some` with its own domain; a
+            // context does not. If this fails, the context encoding has grown
+            // a tag again and runtime parts can no longer spell `Some`.
+            assert_ne!(
+                Some("value").into_prf_context(),
+                "value".into_prf_context().for_option_some(),
+                "a `Some` context must not share the `PrfValue` option-some domain"
+            );
+        }
+
+        #[test]
+        fn none_is_the_empty_list() {
+            assert_eq!(
+                None::<&str>.into_prf_context(),
+                PrfContext::pae(&[]),
+                "`None` is the PAE of zero pieces"
+            );
+        }
     }
 
     #[test]
@@ -386,8 +399,16 @@ mod tests {
 
         let some = Some("value").into_prf_context();
         let typed_value = PrfContext::typed(PrfEncoding::UTF8, b"value");
-        assert_eq!(some, PrfContext::pae(&[typed_value.as_bytes()]));
-        assert_eq!(None::<&str>.into_prf_context(), PrfContext::pae(&[]));
+        assert_eq!(
+            some,
+            PrfContext::pae(&[typed_value.as_bytes()]),
+            "`Some` frames the typed inner context as one piece"
+        );
+        assert_eq!(
+            None::<&str>.into_prf_context(),
+            PrfContext::pae(&[]),
+            "`None` is the PAE of zero pieces"
+        );
 
         let left = PrfContext::typed(PrfEncoding::UTF8, b"left");
         let right = PrfContext::typed(PrfEncoding::U16, &7_u16.to_le_bytes());

--- a/packages/prf/src/context.rs
+++ b/packages/prf/src/context.rs
@@ -327,6 +327,16 @@ mod tests {
         }
 
         #[test]
+        fn some_frames_the_typed_inner_context() {
+            let typed_value = PrfContext::typed(PrfEncoding::UTF8, b"value");
+            assert_eq!(
+                Some("value").into_prf_context(),
+                PrfContext::pae(&[typed_value.as_bytes()]),
+                "`Some` frames the typed inner context as one piece"
+            );
+        }
+
+        #[test]
         fn none_is_the_empty_list() {
             assert_eq!(
                 None::<&str>.into_prf_context(),
@@ -389,33 +399,52 @@ mod tests {
         );
     }
 
-    #[test]
-    fn every_context_conversion_preserves_structure() {
-        let expected_bytes = PrfContext::typed(PrfEncoding::BYTES, b"abc");
-        let slice: &[u8] = b"abc";
-        assert_eq!(slice.into_prf_context(), expected_bytes);
-        assert_eq!((*b"abc").into_prf_context(), expected_bytes);
-        assert_eq!(b"abc".to_vec().into_prf_context(), expected_bytes);
-        assert_eq!(().into_prf_context(), PrfContext::default());
+    mod given_a_bytes_context {
+        use super::*;
 
-        let some = Some("value").into_prf_context();
-        let typed_value = PrfContext::typed(PrfEncoding::UTF8, b"value");
-        assert_eq!(
-            some,
-            PrfContext::pae(&[typed_value.as_bytes()]),
-            "`Some` frames the typed inner context as one piece"
-        );
-        assert_eq!(
-            None::<&str>.into_prf_context(),
-            PrfContext::pae(&[]),
-            "`None` is the PAE of zero pieces"
-        );
+        #[test]
+        fn every_byte_shape_encodes_as_typed_bytes() {
+            let expected = PrfContext::typed(PrfEncoding::BYTES, b"abc");
+            let slice: &[u8] = b"abc";
+            assert_eq!(slice.into_prf_context(), expected, "a slice is typed bytes");
+            assert_eq!(
+                (*b"abc").into_prf_context(),
+                expected,
+                "an array is typed bytes"
+            );
+            assert_eq!(
+                b"abc".to_vec().into_prf_context(),
+                expected,
+                "a vector is typed bytes"
+            );
+        }
+    }
 
-        let left = PrfContext::typed(PrfEncoding::UTF8, b"left");
-        let right = PrfContext::typed(PrfEncoding::U16, &7_u16.to_le_bytes());
-        assert_eq!(
-            ("left", 7_u16).into_prf_context(),
-            PrfContext::pae(&[left.as_bytes(), right.as_bytes()])
-        );
+    mod given_the_unit_context {
+        use super::*;
+
+        #[test]
+        fn is_the_empty_context() {
+            assert_eq!(
+                ().into_prf_context(),
+                PrfContext::default(),
+                "`()` is the empty context by definition, with no framing"
+            );
+        }
+    }
+
+    mod given_a_pair_context {
+        use super::*;
+
+        #[test]
+        fn frames_both_typed_parts() {
+            let left = PrfContext::typed(PrfEncoding::UTF8, b"left");
+            let right = PrfContext::typed(PrfEncoding::U16, &7_u16.to_le_bytes());
+            assert_eq!(
+                ("left", 7_u16).into_prf_context(),
+                PrfContext::pae(&[left.as_bytes(), right.as_bytes()]),
+                "a pair is the PAE of its two typed parts"
+            );
+        }
     }
 }

--- a/packages/prf/src/context.rs
+++ b/packages/prf/src/context.rs
@@ -55,11 +55,11 @@ impl<'a> PrfContext<'a> {
 
     /// Add a domain component without allowing concatenation ambiguities.
     ///
-    /// The leading domain tag keeps caller-refined contexts disjoint from the
-    /// contexts this crate assigns automatically. Without it, a context built
-    /// as `PrfContext::from_slice(OPTION_SOME_DOMAIN).refine(x)` would encode
-    /// identically to the one `for_option_some` assigns to the `Some` arm of
-    /// an optional *value* derived under `x`.
+    /// The leading domain tag keeps caller-refined contexts apart from the
+    /// contexts this crate assigns on its own. Without it, a caller could
+    /// build `PrfContext::from_slice(OPTION_SOME_DOMAIN).refine(x)` and get
+    /// the same bytes as the context `for_option_some` assigns when an
+    /// optional *value* is derived under `x`.
     pub fn refine<'b, C>(&self, component: C) -> PrfContext<'static>
     where
         C: IntoPrfContext<'b>,
@@ -184,17 +184,17 @@ integer_context!(
     i128 => PrfEncoding::I128,
 );
 
-/// An `Option` context follows its parts view: `Some(x)` is the one-element
-/// list `PAE([x])` and `None` the empty list `PAE([])`, exactly as
-/// `IntoAad` encodes them. A context built at runtime from parts (an
-/// `AadPiece` list of one) is therefore the same PRF context as the static
-/// `Some(x)`, on this side as on the AEAD side.
+/// `Some(x)` is the one-element list `PAE([x])` and `None` is the empty
+/// list `PAE([])`, the same shapes `IntoAad` gives them. A context built at
+/// runtime as a list of one part (an `AadPiece` list) is therefore the same
+/// PRF context as the static `Some(x)`, just as it is the same AAD.
 ///
-/// This is deliberately *not* the `PrfValue` `Option` encoding, which tags
-/// `Some` with a domain of its own: that tag keeps an optional *value*'s
-/// derivation apart from its inner value's, and a value is never compared
-/// with a context. Sharing the tag here bought nothing and cost the parts
-/// identity.
+/// This is deliberately different from how a `PrfValue` encodes an optional
+/// *value*, which tags `Some` with its own domain. That tag keeps the
+/// derivation of an optional value apart from the derivation of its inner
+/// value. A value is never compared with a context, so sharing the tag here
+/// gained nothing, and it broke the rule that a parts tree is the same
+/// context as the value it came from.
 impl<'a, T> IntoPrfContext<'a> for Option<T>
 where
     T: IntoPrfContext<'a>,
@@ -306,7 +306,7 @@ mod tests {
 
         #[quickcheck]
         fn some_is_the_one_element_list(bytes: Vec<u8>) -> bool {
-            // `Some(x)` is the single-piece PAE of `x`'s encoding — the same
+            // `Some(x)` is the single-piece PAE of `x`'s encoding, the same
             // shape `IntoAad` gives it, so a runtime list of one part is the
             // static `Some`. It is framed, so it is not `x` itself.
             let inner = bytes.clone().into_prf_context();
@@ -316,9 +316,10 @@ mod tests {
 
         #[test]
         fn some_does_not_carry_the_value_path_domain() {
-            // The `PrfValue` Option path tags `Some` with its own domain; a
-            // context does not. If this fails, the context encoding has grown
-            // a tag again and runtime parts can no longer spell `Some`.
+            // A `PrfValue` tags an optional value's `Some` with its own
+            // domain; an `Option` context does not. If this fails, the
+            // context encoding has grown a tag again and a runtime list of
+            // one part no longer matches `Some`.
             assert_ne!(
                 Some("value").into_prf_context(),
                 "value".into_prf_context().for_option_some(),

--- a/packages/prf/src/context.rs
+++ b/packages/prf/src/context.rs
@@ -57,8 +57,9 @@ impl<'a> PrfContext<'a> {
     ///
     /// The leading domain tag keeps caller-refined contexts disjoint from the
     /// contexts this crate assigns automatically. Without it, a context built
-    /// as `PrfContext::from_slice(MAP_ENTRY_DOMAIN).refine(key)` would encode
-    /// identically to the one `for_map_entry` derives for `key`.
+    /// as `PrfContext::from_slice(OPTION_SOME_DOMAIN).refine(x)` would encode
+    /// identically to the one `for_option_some` assigns to the `Some` arm of
+    /// an optional *value* derived under `x`.
     pub fn refine<'b, C>(&self, component: C) -> PrfContext<'static>
     where
         C: IntoPrfContext<'b>,


### PR DESCRIPTION
## Summary

A *context* is the extra data a caller binds to an encrypted value, such as `("users/email", 7u64)`. It is used in two places. The AEAD authenticates it as associated data, so decryption fails under the wrong context. The PRF mixes it into key derivation for searchable index terms, so a probe under the wrong context matches nothing. Today the two encodings are computed separately, and for `Option` they disagreed: a row sealed under `Some(7u64)` and the same context arriving at runtime as the list `[7u64]` decrypted fine and then matched no index term.

This PR makes the parts tree of a context, `AadPiece`, the single source of truth for both. A context assembled at runtime from parts (for example one that crossed the Go or Python FFI boundary as plain data) now produces exactly the same AEAD bytes and the same PRF context as the static Rust value with those parts. The rule is stated in the docs and checked by quickcheck for every built-in context type.

## Changes

**`vitaminc-prf`** (breaking)
- `IntoPrfContext for Option<T>`: `Some(x)` is now `pae([x])`, matching what `IntoAad` already produced. The `OPTION_SOME_DOMAIN` tag is no longer used for contexts. How a `PrfValue` encodes an optional value is untouched.
- `refine` docs now say which collision its domain tag prevents.

**`vitaminc-aead`**
- `impl IntoPrfContext for AadPiece`: leaves use the standard type's own impl, `List` is `PrfContext::pae` of its parts.
- `impl MaybeEmpty for AadPiece`: same rule as the static types, so `NonEmpty<AadPiece>` can be built.
- New `AadPiece::Unit` variant for `()`. It encodes as no bytes for the AEAD and the empty context for the PRF, so `()` follows the rule too, including inside pairs, `Some`, and `.with()` chains. Previously `()` was an empty `Bytes` leaf, which the PRF side frames, so `("x", ())` derived different PRF bytes from its tree than from the value. The variant is additive (the enum is `non_exhaustive`) and changes no existing bytes.
- `Display`: `Unit` prints as `()`. The empty list now prints as `None` so the two stay distinguishable in a log. Existing byte encodings are unchanged.
- New dependency on `vitaminc-prf` (no cycle: prf depends only on protected).
- Docs: the rule is a runnable doctest on `AadPiece`. The type, trait, impl and README docs are rewritten in plainer language.

**Tests**
- Rule tests live in `given_<context>` modules, one expectation per test, with a message on every assert. AAD and PRF sides are checked together by one `is_identity` helper.
- The tree oracle for a list's PRF context frames bytes by hand so it does not share `PrfContext::pae` with the code under test.
- `()` is covered on its own, inside a pair on either side, inside `Some`, and appended with `with`. `[u8; N]` and `&[u8; N]` are covered on the PRF side.

## Breaking change

Any index term derived under an `Option` PRF context changes bytes. Re-derive stored terms whose context was an `Option`. Non-`Option` contexts and `PrfValue` derivations are unaffected. The `feat(prf)!` commit carries the `BREAKING CHANGE:` footer. cipherstash-suite has no frozen fixture under an `Option` context.

`Display` output for the empty list changed from `()` to `None`. This is log output only, not a wire format.

## Verification

Run on the first three commits by the original author, mirroring `.github/workflows/test.yml`: clippy (all features, aws-lc-rs, wasm32), `cargo fmt --check`, `cargo doc` with `-D warnings`, `cargo test` with `vitaminc-kms` against LocalStack, the RustCrypto and `hlist` variants, wasm32 check, `wasm-pack test --node`. All green.

Run after the review-fix commits (`ae22e79` through `210feda`):
- `cargo test --workspace --exclude vitaminc-kms`: all green. `vitaminc-aead` 135 unit tests and 14 doctests (9 ignored, pre-existing), `vitaminc-prf` 56 unit tests. The new `AadPiece` doctest runs and passes.
- `cargo test -p vitaminc-aead --features hlist`: green.
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`: clean.
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`: clean.
- `cargo fmt --all --check`: clean.
- `cargo check -p vitaminc-aead --target wasm32-unknown-unknown`: clean.
- Not re-run after the fix commits: `wasm-pack test`, LocalStack KMS tests. CI covers them.

## Related

- Closes #335.
- Refs #339: one canonical context encoding shared by both derivations, superseding #223 and #315.
- Refs cipherstash/cipherstash-suite#2210: the WASI guest's `ContextPart` mirror collapses to `FfiValue -> AadPiece`.
- Refs #333: the C and Python bindings inherit the same three derivations from the same type.

## Review notes

- Start at `packages/aead/src/aad/piece.rs`: the type docs state the rule, the impls sit directly under it, and the `given_*` test modules check it per type.
- `AadPiece::Unit` came from the P2 review comment on the `()` exception. The alternative, changing what `().into_prf_context()` encodes, would change the default context everywhere.
- The `given_*` test layout is new to this repo and intended as the direction for touched tests, not a wholesale rewrite.

https://claude.ai/code/session_01T5TcvQ8sPnpWQ9ptCfVjj6
